### PR TITLE
Refactor parameter registration and reduce API surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Moreover, the parameters are set via CLI using the flag syntax.
 - Rename `Taskflow.MustRegister` method to `Register` and remove previous `Taskflow.Register` implemention.
 - Remove `Taskflow.Params` field and `TF.Params` method, add `Taskflow.Register*Param` methods and `Task.Params` field instead.
 - Remove `TF.Verbose`, add `Taskflow.VerboseParam` instead.
-- Remove `New` function, create instance using `&Taskflow` instead.
+- Remove `New` function, create instance using `&Taskflow{}` instead.
 - Unexport `Runner` type, use `Taskflow` in tests instead.
 - Drop official support for Go 1.10.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,8 @@ Moreover, the parameters are set via CLI using the flag syntax.
 - Rename `Taskflow.MustRegister` method to `Register` and remove previous `Taskflow.Register` implemention.
 - Remove `Taskflow.Params` field and `TF.Params` method, add `Taskflow.Register*Param` methods and `Task.Params` field instead.
 - Remove `TF.Verbose`, add `Taskflow.VerboseParam` instead.
-- Unexport `Runner` type.
+- Remove `New` function, create instance using `&Taskflow` instead.
+- Unexport `Runner` type, use `Taskflow` in tests instead.
 - Drop official support for Go 1.10.
 
 ## [0.2.0](https://github.com/goyek/goyek/compare/v0.1.1...v0.2.0) - 2021-03-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ Moreover, the parameters are set via CLI using the flag syntax.
 - Remove `TF.Verbose`, add `Taskflow.VerboseParam` instead.
 - Remove `New` function, create instance using `&Taskflow{}` instead.
 - Unexport `Runner` type, use `Taskflow` in tests instead.
-- Enforce patterns for task names (`goyek.TaskNamePattern`) and parameter names (`goyek.ParamNamePattern`).
+- Enforce patterns for task names (`TaskNamePattern`) and parameter names (`ParamNamePattern`).
 - Drop official support for Go 1.10.
 
 ## [0.2.0](https://github.com/goyek/goyek/compare/v0.1.1...v0.2.0) - 2021-03-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Moreover, the parameters are set via CLI using the flag syntax.
 - Use the flag syntax for setting parameters via CLI.
 - Rename `Task.Description` field to `Usage`.
 - Rename `Task.Dependencies` field to `Deps`.
+- Rename `CodeFailure` constant to `CodeFail`.
 - Rename `Taskflow.MustRegister` method to `Register` and remove previous `Taskflow.Register` implemention.
 - Remove `Taskflow.Params` field and `TF.Params` method, add `Taskflow.Register*Param` methods and `Task.Params` field instead.
 - Remove `TF.Verbose`, add `Taskflow.VerboseParam` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Moreover, the parameters are set via CLI using the flag syntax.
 - Help is printed when `-h`, `--help` or `help` is passed.
 - Help contains parameters' information.
 - The tasks and parameters can be passed via CLI in any order.
+- `Taskflow.Run` handles `nil` passed as `context.Context` argument.
 - `Taskflow.Run` panics when a registered parameter is not assigned to any task.
 
 ### Changed
@@ -32,6 +33,7 @@ Moreover, the parameters are set via CLI using the flag syntax.
 - Rename `Taskflow.MustRegister` method to `Register` and remove previous `Taskflow.Register` implemention.
 - Remove `Taskflow.Params` field and `TF.Params` method, add `Taskflow.Register*Param` methods and `Task.Params` field instead.
 - Remove `TF.Verbose`, add `Taskflow.VerboseParam` instead.
+- Unexport `Runner` type.
 - Drop official support for Go 1.10.
 
 ## [0.2.0](https://github.com/goyek/goyek/compare/v0.1.1...v0.2.0) - 2021-03-14

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ package main
 import "github.com/goyek/goyek"
 
 func main() {
-	flow := goyek.New()
+	flow := &goyek.Taskflow{}
 
 	hello := flow.Register(taskHello())
 	fmt := flow.Register(taskFmt())

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Table of Contents:
     - [Verbose mode](#verbose-mode)
     - [Default task](#default-task)
     - [Parameters](#parameters)
-    - [Task runner](#task-runner)
     - [Supported Go versions](#supported-go-versions)
   - [Alternatives](#alternatives)
     - [Make](#make)
@@ -227,12 +226,6 @@ When registration is done, the task's command can retrieve the parameter value u
 See [examples/parameters/main.go](examples/parameters/main.go) for a detailed example.
 
 `Taskflow` will fail execution if there are unused parameters.
-
-### Task runner
-
-You can use [`type Runner`](https://pkg.go.dev/github.com/goyek/goyek#Runner) to execute a single command.
-
-It may be handy during development of a new task, when debugging some issue or if you want to have a test suite for reusable commands.
 
 ### Supported Go versions
 

--- a/build/build.go
+++ b/build/build.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	flow := goyek.New()
+	flow := &goyek.Taskflow{}
 
 	ci := flow.RegisterBoolParam(goyek.BoolParam{
 		Name:  "ci",

--- a/build/build.go
+++ b/build/build.go
@@ -120,7 +120,7 @@ func taskModTidy() goyek.Task {
 	}
 }
 
-func taskDiff(ci goyek.BoolParam) goyek.Task {
+func taskDiff(ci goyek.RegisteredBoolParam) goyek.Task {
 	return goyek.Task{
 		Name:   "diff",
 		Usage:  "git diff",

--- a/build/build.go
+++ b/build/build.go
@@ -10,7 +10,7 @@ import (
 func main() {
 	flow := goyek.New()
 
-	ci := flow.RegisterBoolParam(false, goyek.ParamInfo{
+	ci := flow.RegisterBoolParam(goyek.BoolParam{
 		Name:  "ci",
 		Usage: "Whether CI is calling the build script",
 	})

--- a/cli_example_test.go
+++ b/cli_example_test.go
@@ -3,7 +3,7 @@ package goyek_test
 import "github.com/goyek/goyek"
 
 func Example() {
-	flow := goyek.New()
+	flow := &goyek.Taskflow{}
 
 	task1 := flow.Register(goyek.Task{
 		Name:    "task-1",

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -3,7 +3,7 @@ package main
 import "github.com/goyek/goyek"
 
 func main() {
-	flow := goyek.New()
+	flow := &goyek.Taskflow{}
 
 	hello := flow.Register(taskHello())
 	fmt := flow.Register(taskFmt())

--- a/examples/parameters/main.go
+++ b/examples/parameters/main.go
@@ -30,7 +30,7 @@ func main() {
 	flow.Main()
 }
 
-func taskFirst(sharedParam goyek.StringParam) goyek.Task {
+func taskFirst(sharedParam goyek.RegisteredStringParam) goyek.Task {
 	return goyek.Task{
 		Name:   "first",
 		Usage:  "Showcases a simple parameter",
@@ -41,7 +41,7 @@ func taskFirst(sharedParam goyek.StringParam) goyek.Task {
 	}
 }
 
-func taskSecond(flow *goyek.Taskflow, sharedParam goyek.StringParam) goyek.Task {
+func taskSecond(flow *goyek.Taskflow, sharedParam goyek.RegisteredStringParam) goyek.Task {
 	// The following is a "private" parameter, only available to this task.
 	privateParam := flow.RegisterStringParam("special-default", goyek.ParamInfo{
 		Name:  "private",

--- a/examples/parameters/main.go
+++ b/examples/parameters/main.go
@@ -99,7 +99,7 @@ func taskComplexParam(flow *goyek.Taskflow) goyek.Task {
 	privateParam := flow.RegisterValueParam(goyek.ValueParam{
 		Name:  "json",
 		Usage: "A complex parameter",
-		Default: func() goyek.ParamValue {
+		NewValue: func() goyek.ParamValue {
 			return &complexParamValue{
 				StringValue: "default",
 				IntValue:    123,

--- a/examples/parameters/main.go
+++ b/examples/parameters/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 func main() {
-	flow := goyek.New()
+	flow := &goyek.Taskflow{}
 
 	sharedParam := flow.RegisterStringParam(goyek.StringParam{
 		Name:    "shared",

--- a/examples/parameters/main.go
+++ b/examples/parameters/main.go
@@ -17,9 +17,10 @@ import (
 func main() {
 	flow := goyek.New()
 
-	sharedParam := flow.RegisterStringParam("default-value", goyek.ParamInfo{
-		Name:  "shared",
-		Usage: "An example parameter shared between tasks",
+	sharedParam := flow.RegisterStringParam(goyek.StringParam{
+		Name:    "shared",
+		Usage:   "An example parameter shared between tasks",
+		Default: "default-value",
 	})
 
 	first := flow.Register(taskFirst(sharedParam))
@@ -43,9 +44,10 @@ func taskFirst(sharedParam goyek.RegisteredStringParam) goyek.Task {
 
 func taskSecond(flow *goyek.Taskflow, sharedParam goyek.RegisteredStringParam) goyek.Task {
 	// The following is a "private" parameter, only available to this task.
-	privateParam := flow.RegisterStringParam("special-default", goyek.ParamInfo{
-		Name:  "private",
-		Usage: "A task-specific parameter",
+	privateParam := flow.RegisterStringParam(goyek.StringParam{
+		Name:    "private",
+		Usage:   "A task-specific parameter",
+		Default: "special-default",
 	})
 	return goyek.Task{
 		Name:   "second",
@@ -94,15 +96,15 @@ func (value *complexParamValue) IsBool() bool {
 //
 // Execute `go run ./main.go -v complex -json "{\"stringValue\":\"abc\"}"` as an example.
 func taskComplexParam(flow *goyek.Taskflow) goyek.Task {
-	privateParam := flow.RegisterValueParam(func() goyek.ParamValue {
-		param := complexParamValue{
-			StringValue: "default",
-			IntValue:    123,
-		}
-		return &param
-	}, goyek.ParamInfo{
+	privateParam := flow.RegisterValueParam(goyek.ValueParam{
 		Name:  "json",
 		Usage: "A complex parameter",
+		Default: func() goyek.ParamValue {
+			return &complexParamValue{
+				StringValue: "default",
+				IntValue:    123,
+			}
+		},
 	})
 	return goyek.Task{
 		Name:   "complex",

--- a/exec_test.go
+++ b/exec_test.go
@@ -1,6 +1,8 @@
 package goyek_test
 
 import (
+	"context"
+	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -8,21 +10,33 @@ import (
 )
 
 func TestExec_success(t *testing.T) {
+	taskName := "exec"
 	sb := &strings.Builder{}
-	r := goyek.Runner{
+	flow := &goyek.Taskflow{
 		Output: sb,
 	}
+	flow.Register(goyek.Task{
+		Name:    taskName,
+		Command: goyek.Exec("go", "version"),
+	})
 
-	got := r.Run(goyek.Exec("go", "version"))
+	exitCode := flow.Run(context.Background(), "-v", taskName)
 
 	assertContains(t, sb.String(), "go version go", "output should contain prefix of version report")
-	assertTrue(t, got.Passed(), "task should pass")
+	assertEqual(t, exitCode, goyek.CodePass, "task should pass")
 }
 
 func TestExec_error(t *testing.T) {
-	r := goyek.Runner{}
+	taskName := "exec"
+	flow := &goyek.Taskflow{
+		Output: ioutil.Discard,
+	}
+	flow.Register(goyek.Task{
+		Name:    taskName,
+		Command: goyek.Exec("go", "wrong"),
+	})
 
-	got := r.Run(goyek.Exec("go", "wrong"))
+	exitCode := flow.Run(context.Background(), taskName)
 
-	assertTrue(t, got.Failed(), "task should fail")
+	assertEqual(t, exitCode, goyek.CodeFailure, "task should pass")
 }

--- a/exec_test.go
+++ b/exec_test.go
@@ -36,7 +36,7 @@ func TestExec_error(t *testing.T) {
 		Command: goyek.Exec("go", "wrong"),
 	})
 
-	exitCode := flow.Run(context.Background(), taskName)
+	exitCode := flow.Run(nil, taskName) //nolint:staticcheck // present that nil context is handled
 
 	assertEqual(t, exitCode, goyek.CodeFailure, "task should pass")
 }

--- a/exec_test.go
+++ b/exec_test.go
@@ -38,5 +38,5 @@ func TestExec_error(t *testing.T) {
 
 	exitCode := flow.Run(nil, taskName) //nolint:staticcheck // present that nil context is handled
 
-	assertEqual(t, exitCode, goyek.CodeFailure, "task should pass")
+	assertEqual(t, exitCode, goyek.CodeFail, "task should pass")
 }

--- a/flow_runner.go
+++ b/flow_runner.go
@@ -164,13 +164,13 @@ func (f *flowRunner) runTask(ctx context.Context, task Task) bool {
 		fmt.Fprintf(w, "===== TASK  %s\n", tf.Name())
 
 		// run task
-		runner := Runner{
+		r := runner{
 			Ctx:         tf.Context(),
 			TaskName:    tf.Name(),
 			ParamValues: tf.paramValues,
 			Output:      w,
 		}
-		result := runner.Run(task.Command)
+		result := r.Run(task.Command)
 
 		// report task end
 		status := "PASS"
@@ -188,7 +188,7 @@ func (f *flowRunner) runTask(ctx context.Context, task Task) bool {
 		}
 	}
 
-	measuredRunner := Runner{
+	measuredRunner := runner{
 		Ctx:         ctx,
 		TaskName:    task.Name,
 		ParamValues: paramValues,

--- a/flow_runner.go
+++ b/flow_runner.go
@@ -16,7 +16,7 @@ type flowRunner struct {
 	params      map[string]paramValueFactory
 	paramValues map[string]ParamValue
 	tasks       map[string]Task
-	verbose     BoolParam
+	verbose     RegisteredBoolParam
 	defaultTask RegisteredTask
 }
 

--- a/flow_runner.go
+++ b/flow_runner.go
@@ -108,7 +108,7 @@ func (f *flowRunner) runTasks(ctx context.Context, tasks []string) int {
 	for _, name := range tasks {
 		if err := f.run(ctx, name, executedTasks); err != nil {
 			fmt.Fprintf(f.output, "%v\t%.3fs\n", err, time.Since(from).Seconds())
-			return CodeFailure
+			return CodeFail
 		}
 	}
 	fmt.Fprintf(f.output, "ok\t%.3fs\n", time.Since(from).Seconds())

--- a/flow_runner.go
+++ b/flow_runner.go
@@ -30,7 +30,7 @@ func (f *flowRunner) Run(ctx context.Context, args []string) int { //nolint // T
 	f.paramValues = make(map[string]ParamValue)
 	for _, param := range f.params {
 		value := param.newValue()
-		f.paramValues[param.info.Name] = value
+		f.paramValues[param.name] = value
 	}
 	usageRequested := false
 
@@ -232,7 +232,7 @@ func printUsage(f *flowRunner) {
 	sort.Strings(keys)
 	for _, key := range keys {
 		param := f.params[key]
-		fmt.Fprintf(w, "  %s\tDefault: %s\t%s\n", flagName(param.info.Name), param.newValue().String(), param.info.Usage)
+		fmt.Fprintf(w, "  %s\tDefault: %s\t%s\n", flagName(param.name), param.newValue().String(), param.usage)
 	}
 	w.Flush() //nolint // not checking errors when writing to output
 

--- a/parameter.go
+++ b/parameter.go
@@ -57,13 +57,13 @@ func (p param) value(tf *TF) ParamValue {
 	return value
 }
 
-// ValueParam represents a registered parameter based on a generic implementation.
-type ValueParam struct {
+// RegisteredValueParam represents a registered parameter based on a generic implementation.
+type RegisteredValueParam struct {
 	param
 }
 
 // Get returns the concrete instance of the generic value in the given flow.
-func (p ValueParam) Get(tf *TF) interface{} {
+func (p RegisteredValueParam) Get(tf *TF) interface{} {
 	return p.value(tf).Get()
 }
 
@@ -88,13 +88,13 @@ func (value *boolValue) String() string { return strconv.FormatBool(bool(*value)
 
 func (value *boolValue) IsBool() bool { return true }
 
-// BoolParam represents a registered boolean parameter.
-type BoolParam struct {
+// RegisteredBoolParam represents a registered boolean parameter.
+type RegisteredBoolParam struct {
 	param
 }
 
 // Get returns the boolean value of the parameter in the given flow.
-func (p BoolParam) Get(tf *TF) bool {
+func (p RegisteredBoolParam) Get(tf *TF) bool {
 	value := p.value(tf)
 	return value.Get().(bool)
 }
@@ -116,13 +116,13 @@ func (value *intValue) String() string { return strconv.Itoa(int(*value)) }
 
 func (value *intValue) IsBool() bool { return false }
 
-// IntParam represents a registered integer parameter.
-type IntParam struct {
+// RegisteredIntParam represents a registered integer parameter.
+type RegisteredIntParam struct {
 	param
 }
 
 // Get returns the integer value of the parameter in the given flow.
-func (p IntParam) Get(tf *TF) int {
+func (p RegisteredIntParam) Get(tf *TF) int {
 	value := p.value(tf)
 	return value.Get().(int)
 }
@@ -140,13 +140,13 @@ func (value *stringValue) String() string { return string(*value) }
 
 func (value *stringValue) IsBool() bool { return false }
 
-// StringParam represents a registered string parameter.
-type StringParam struct {
+// RegisteredStringParam represents a registered string parameter.
+type RegisteredStringParam struct {
 	param
 }
 
 // Get returns the string value of the parameter in the given flow.
-func (p StringParam) Get(tf *TF) string {
+func (p RegisteredStringParam) Get(tf *TF) string {
 	value := p.value(tf)
 	return value.Get().(string)
 }

--- a/parameter.go
+++ b/parameter.go
@@ -33,11 +33,11 @@ type StringParam struct {
 }
 
 // ValueParam represents a named parameter for a custom type that can be registered.
-// Default field must be set with a default value factory.
+// NewValue field must be set with a default value factory.
 type ValueParam struct {
-	Name    string
-	Usage   string
-	Default func() ParamValue
+	Name     string
+	Usage    string
+	NewValue func() ParamValue
 }
 
 // ParamValue represents an instance of a generic parameter.

--- a/parameter.go
+++ b/parameter.go
@@ -6,14 +6,38 @@ import (
 )
 
 type paramValueFactory struct {
-	info     ParamInfo
+	name     string
+	usage    string
 	newValue func() ParamValue
 }
 
-// ParamInfo represents the general information of a parameter for one or more tasks.
-type ParamInfo struct {
-	Name  string
-	Usage string
+// BoolParam represents a named boolean parameter that can be registered.
+type BoolParam struct {
+	Name    string
+	Usage   string
+	Default bool
+}
+
+// IntParam represents a named integer parameter that can be registered.
+type IntParam struct {
+	Name    string
+	Usage   string
+	Default int
+}
+
+// StringParam represents a named string parameter that can be registered.
+type StringParam struct {
+	Name    string
+	Usage   string
+	Default string
+}
+
+// ValueParam represents a named parameter for a custom type that can be registered.
+// Default field must be set with a default value factory.
+type ValueParam struct {
+	Name    string
+	Usage   string
+	Default func() ParamValue
 }
 
 // ParamValue represents an instance of a generic parameter.

--- a/parameter_test.go
+++ b/parameter_test.go
@@ -39,7 +39,7 @@ func Test_bool_param(t *testing.T) {
 	for index, tc := range tt {
 		tc := tc
 		t.Run("case "+strconv.Itoa(index), func(t *testing.T) {
-			flow := goyek.New()
+			flow := &goyek.Taskflow{}
 			param := flow.RegisterBoolParam(goyek.BoolParam{
 				Name:    "b",
 				Default: tc.defaultValue,
@@ -54,7 +54,7 @@ func Test_bool_param(t *testing.T) {
 }
 
 func Test_bool_param_help(t *testing.T) {
-	flow := goyek.New()
+	flow := &goyek.Taskflow{}
 	param := flow.RegisterBoolParam(goyek.BoolParam{
 		Name:    "bool",
 		Default: true,
@@ -84,7 +84,7 @@ func Test_int_param(t *testing.T) {
 	for index, tc := range tt {
 		tc := tc
 		t.Run("case "+strconv.Itoa(index), func(t *testing.T) {
-			flow := goyek.New()
+			flow := &goyek.Taskflow{}
 			param := flow.RegisterIntParam(goyek.IntParam{
 				Name:    "i",
 				Default: tc.defaultValue,
@@ -99,7 +99,7 @@ func Test_int_param(t *testing.T) {
 }
 
 func Test_int_param_help(t *testing.T) {
-	flow := goyek.New()
+	flow := &goyek.Taskflow{}
 	param := flow.RegisterIntParam(goyek.IntParam{
 		Name:    "int",
 		Default: 123,
@@ -126,7 +126,7 @@ func Test_string_param(t *testing.T) {
 	for index, tc := range tt {
 		tc := tc
 		t.Run("case "+strconv.Itoa(index), func(t *testing.T) {
-			flow := goyek.New()
+			flow := &goyek.Taskflow{}
 			param := flow.RegisterStringParam(goyek.StringParam{
 				Name:    "s",
 				Default: tc.defaultValue,
@@ -141,7 +141,7 @@ func Test_string_param(t *testing.T) {
 }
 
 func Test_string_param_help(t *testing.T) {
-	flow := goyek.New()
+	flow := &goyek.Taskflow{}
 	param := flow.RegisterStringParam(goyek.StringParam{
 		Name:    "string",
 		Default: "abc",

--- a/parameter_test.go
+++ b/parameter_test.go
@@ -40,8 +40,9 @@ func Test_bool_param(t *testing.T) {
 		tc := tc
 		t.Run("case "+strconv.Itoa(index), func(t *testing.T) {
 			flow := goyek.New()
-			param := flow.RegisterBoolParam(tc.defaultValue, goyek.ParamInfo{
-				Name: "b",
+			param := flow.RegisterBoolParam(goyek.BoolParam{
+				Name:    "b",
+				Default: tc.defaultValue,
 			})
 			var got bool
 			exitCode := runTaskflowWith(flow, param, func(tf *goyek.TF) { got = param.Get(tf) }, tc.args)
@@ -54,8 +55,9 @@ func Test_bool_param(t *testing.T) {
 
 func Test_bool_param_help(t *testing.T) {
 	flow := goyek.New()
-	param := flow.RegisterBoolParam(true, goyek.ParamInfo{
-		Name: "bool",
+	param := flow.RegisterBoolParam(goyek.BoolParam{
+		Name:    "bool",
+		Default: true,
 	})
 	exitCode := runTaskflowWith(flow, param, func(tf *goyek.TF) {}, []string{"-h"})
 
@@ -83,8 +85,9 @@ func Test_int_param(t *testing.T) {
 		tc := tc
 		t.Run("case "+strconv.Itoa(index), func(t *testing.T) {
 			flow := goyek.New()
-			param := flow.RegisterIntParam(tc.defaultValue, goyek.ParamInfo{
-				Name: "i",
+			param := flow.RegisterIntParam(goyek.IntParam{
+				Name:    "i",
+				Default: tc.defaultValue,
 			})
 			var got int
 			exitCode := runTaskflowWith(flow, param, func(tf *goyek.TF) { got = param.Get(tf) }, tc.args)
@@ -97,8 +100,9 @@ func Test_int_param(t *testing.T) {
 
 func Test_int_param_help(t *testing.T) {
 	flow := goyek.New()
-	param := flow.RegisterIntParam(123, goyek.ParamInfo{
-		Name: "int",
+	param := flow.RegisterIntParam(goyek.IntParam{
+		Name:    "int",
+		Default: 123,
 	})
 	exitCode := runTaskflowWith(flow, param, func(tf *goyek.TF) {}, []string{"-h"})
 
@@ -123,8 +127,9 @@ func Test_string_param(t *testing.T) {
 		tc := tc
 		t.Run("case "+strconv.Itoa(index), func(t *testing.T) {
 			flow := goyek.New()
-			param := flow.RegisterStringParam(tc.defaultValue, goyek.ParamInfo{
-				Name: "s",
+			param := flow.RegisterStringParam(goyek.StringParam{
+				Name:    "s",
+				Default: tc.defaultValue,
 			})
 			var got string
 			exitCode := runTaskflowWith(flow, param, func(tf *goyek.TF) { got = param.Get(tf) }, tc.args)
@@ -137,8 +142,9 @@ func Test_string_param(t *testing.T) {
 
 func Test_string_param_help(t *testing.T) {
 	flow := goyek.New()
-	param := flow.RegisterStringParam("abc", goyek.ParamInfo{
-		Name: "string",
+	param := flow.RegisterStringParam(goyek.StringParam{
+		Name:    "string",
+		Default: "abc",
 	})
 	exitCode := runTaskflowWith(flow, param, func(tf *goyek.TF) {}, []string{"-h"})
 

--- a/taskflow.go
+++ b/taskflow.go
@@ -114,7 +114,7 @@ const ParamNamePattern = "^[a-zA-Z0-9][a-zA-Z0-9_-]*$"
 var paramNameRegex = regexp.MustCompile(TaskNamePattern)
 
 func (f *Taskflow) registerParam(p paramValueFactory) {
-	if !paramNameRegex.MatchString(p.Name) {
+	if !paramNameRegex.MatchString(p.name) {
 		panic("parameter name must match ParamNamePattern")
 	}
 	if p.newValue == nil {

--- a/taskflow.go
+++ b/taskflow.go
@@ -114,7 +114,7 @@ const ParamNamePattern = "^[a-zA-Z0-9][a-zA-Z0-9_-]*$"
 var paramNameRegex = regexp.MustCompile(TaskNamePattern)
 
 func (f *Taskflow) registerParam(p paramValueFactory) {
-	if !paramNameRegex.MatchString(info.Name) {
+	if !paramNameRegex.MatchString(p.Name) {
 		panic("parameter name must match ParamNamePattern")
 	}
 	if p.newValue == nil {

--- a/taskflow.go
+++ b/taskflow.go
@@ -27,7 +27,7 @@ type Taskflow struct {
 
 	DefaultTask RegisteredTask // task which is run when non is explicitly provided
 
-	verbose *BoolParam // when enabled, then the whole output will be always streamed
+	verbose *RegisteredBoolParam // when enabled, then the whole output will be always streamed
 	params  map[string]paramValueFactory
 	tasks   map[string]Task
 }
@@ -46,7 +46,7 @@ func New() *Taskflow {
 }
 
 // VerboseParam returns the out-of-the-box verbose parameter which controls the output behavior.
-func (f *Taskflow) VerboseParam() BoolParam {
+func (f *Taskflow) VerboseParam() RegisteredBoolParam {
 	if f.verbose == nil {
 		param := f.RegisterBoolParam(false, ParamInfo{
 			Name:  "v",
@@ -63,36 +63,36 @@ func (f *Taskflow) VerboseParam() BoolParam {
 //
 // The value is provided via a factory function since Taskflow could be executed multiple times,
 // requiring a new Value instance each time.
-func (f *Taskflow) RegisterValueParam(newValue func() ParamValue, info ParamInfo) ValueParam {
+func (f *Taskflow) RegisterValueParam(newValue func() ParamValue, info ParamInfo) RegisteredValueParam {
 	f.registerParam(newValue, info)
-	return ValueParam{param{name: info.Name}}
+	return RegisteredValueParam{param{name: info.Name}}
 }
 
 // RegisterBoolParam registers a boolean parameter.
-func (f *Taskflow) RegisterBoolParam(defaultValue bool, info ParamInfo) BoolParam {
+func (f *Taskflow) RegisterBoolParam(defaultValue bool, info ParamInfo) RegisteredBoolParam {
 	f.registerParam(func() ParamValue {
 		value := boolValue(defaultValue)
 		return &value
 	}, info)
-	return BoolParam{param{name: info.Name}}
+	return RegisteredBoolParam{param{name: info.Name}}
 }
 
 // RegisterIntParam registers an integer parameter.
-func (f *Taskflow) RegisterIntParam(defaultValue int, info ParamInfo) IntParam {
+func (f *Taskflow) RegisterIntParam(defaultValue int, info ParamInfo) RegisteredIntParam {
 	f.registerParam(func() ParamValue {
 		value := intValue(defaultValue)
 		return &value
 	}, info)
-	return IntParam{param{name: info.Name}}
+	return RegisteredIntParam{param{name: info.Name}}
 }
 
 // RegisterStringParam registers a string parameter.
-func (f *Taskflow) RegisterStringParam(defaultValue string, info ParamInfo) StringParam {
+func (f *Taskflow) RegisterStringParam(defaultValue string, info ParamInfo) RegisteredStringParam {
 	f.registerParam(func() ParamValue {
 		value := stringValue(defaultValue)
 		return &value
 	}, info)
-	return StringParam{param{name: info.Name}}
+	return RegisteredStringParam{param{name: info.Name}}
 }
 
 func (f *Taskflow) registerParam(newValue func() ParamValue, info ParamInfo) {

--- a/taskflow.go
+++ b/taskflow.go
@@ -155,6 +155,10 @@ func (f *Taskflow) Register(task Task) RegisteredTask {
 // Run runs provided tasks and all their dependencies.
 // Each task is executed at most once.
 func (f *Taskflow) Run(ctx context.Context, args ...string) int {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	flow := &flowRunner{
 		output:      f.Output,
 		params:      f.params,

--- a/taskflow.go
+++ b/taskflow.go
@@ -38,13 +38,6 @@ type RegisteredTask struct {
 	name string
 }
 
-// New return an instance of Taskflow with initialized fields.
-func New() *Taskflow {
-	return &Taskflow{
-		Output: DefaultOutput,
-	}
-}
-
 // VerboseParam returns the out-of-the-box verbose parameter which controls the output behavior.
 func (f *Taskflow) VerboseParam() RegisteredBoolParam {
 	if f.verbose == nil {

--- a/taskflow.go
+++ b/taskflow.go
@@ -60,7 +60,7 @@ func (f *Taskflow) RegisterValueParam(p ValueParam) RegisteredValueParam {
 	f.registerParam(paramValueFactory{
 		name:     p.Name,
 		usage:    p.Usage,
-		newValue: p.Default,
+		newValue: p.NewValue,
 	})
 	return RegisteredValueParam{param{name: p.Name}}
 }

--- a/taskflow.go
+++ b/taskflow.go
@@ -10,8 +10,8 @@ import (
 const (
 	// CodePass indicates that taskflow passed.
 	CodePass = 0
-	// CodeFailure indicates that taskflow failed.
-	CodeFailure = 1
+	// CodeFail indicates that taskflow failed.
+	CodeFail = 1
 	// CodeInvalidArgs indicates that taskflow got invalid input.
 	CodeInvalidArgs = 2
 )

--- a/taskflow.go
+++ b/taskflow.go
@@ -48,7 +48,7 @@ func New() *Taskflow {
 // VerboseParam returns the out-of-the-box verbose parameter which controls the output behavior.
 func (f *Taskflow) VerboseParam() RegisteredBoolParam {
 	if f.verbose == nil {
-		param := f.RegisterBoolParam(false, ParamInfo{
+		param := f.RegisterBoolParam(BoolParam{
 			Name:  "v",
 			Usage: "Verbose output: log all tasks as they are run. Also print all text from Log and Logf calls even if the task succeeds.",
 		})
@@ -63,52 +63,71 @@ func (f *Taskflow) VerboseParam() RegisteredBoolParam {
 //
 // The value is provided via a factory function since Taskflow could be executed multiple times,
 // requiring a new Value instance each time.
-func (f *Taskflow) RegisterValueParam(newValue func() ParamValue, info ParamInfo) RegisteredValueParam {
-	f.registerParam(newValue, info)
-	return RegisteredValueParam{param{name: info.Name}}
+func (f *Taskflow) RegisterValueParam(p ValueParam) RegisteredValueParam {
+	f.registerParam(paramValueFactory{
+		name:     p.Name,
+		usage:    p.Usage,
+		newValue: p.Default,
+	})
+	return RegisteredValueParam{param{name: p.Name}}
 }
 
 // RegisterBoolParam registers a boolean parameter.
-func (f *Taskflow) RegisterBoolParam(defaultValue bool, info ParamInfo) RegisteredBoolParam {
-	f.registerParam(func() ParamValue {
-		value := boolValue(defaultValue)
+func (f *Taskflow) RegisterBoolParam(p BoolParam) RegisteredBoolParam {
+	valGetter := func() ParamValue {
+		value := boolValue(p.Default)
 		return &value
-	}, info)
-	return RegisteredBoolParam{param{name: info.Name}}
+	}
+	f.registerParam(paramValueFactory{
+		name:     p.Name,
+		usage:    p.Usage,
+		newValue: valGetter,
+	})
+	return RegisteredBoolParam{param{name: p.Name}}
 }
 
 // RegisterIntParam registers an integer parameter.
-func (f *Taskflow) RegisterIntParam(defaultValue int, info ParamInfo) RegisteredIntParam {
-	f.registerParam(func() ParamValue {
-		value := intValue(defaultValue)
+func (f *Taskflow) RegisterIntParam(p IntParam) RegisteredIntParam {
+	valGetter := func() ParamValue {
+		value := intValue(p.Default)
 		return &value
-	}, info)
-	return RegisteredIntParam{param{name: info.Name}}
+	}
+	f.registerParam(paramValueFactory{
+		name:     p.Name,
+		usage:    p.Usage,
+		newValue: valGetter,
+	})
+	return RegisteredIntParam{param{name: p.Name}}
 }
 
 // RegisterStringParam registers a string parameter.
-func (f *Taskflow) RegisterStringParam(defaultValue string, info ParamInfo) RegisteredStringParam {
-	f.registerParam(func() ParamValue {
-		value := stringValue(defaultValue)
+func (f *Taskflow) RegisterStringParam(p StringParam) RegisteredStringParam {
+	valGetter := func() ParamValue {
+		value := stringValue(p.Default)
 		return &value
-	}, info)
-	return RegisteredStringParam{param{name: info.Name}}
+	}
+	f.registerParam(paramValueFactory{
+		name:     p.Name,
+		usage:    p.Usage,
+		newValue: valGetter,
+	})
+	return RegisteredStringParam{param{name: p.Name}}
 }
 
-func (f *Taskflow) registerParam(newValue func() ParamValue, info ParamInfo) {
-	if info.Name == "" {
+func (f *Taskflow) registerParam(p paramValueFactory) {
+	if p.name == "" {
 		panic("parameter name cannot be empty")
 	}
-	if _, exists := f.params[info.Name]; exists {
-		panic(fmt.Sprintf("%s parameter was already registered", info.Name))
+	if p.newValue == nil {
+		panic("parameter is missing default value factory")
+	}
+	if _, exists := f.params[p.name]; exists {
+		panic(fmt.Sprintf("%s parameter was already registered", p.name))
 	}
 	if f.params == nil {
 		f.params = make(map[string]paramValueFactory)
 	}
-	f.params[info.Name] = paramValueFactory{
-		info:     info,
-		newValue: newValue,
-	}
+	f.params[p.name] = p
 }
 
 // Register registers the task. It panics in case of any error.

--- a/taskflow_test.go
+++ b/taskflow_test.go
@@ -399,8 +399,8 @@ func Test_params(t *testing.T) {
 		Default: "abc",
 	})
 	arrayParam := flow.RegisterValueParam(goyek.ValueParam{
-		Name:    "array",
-		Default: func() goyek.ParamValue { return &arrayValue{} },
+		Name:     "array",
+		NewValue: func() goyek.ParamValue { return &arrayValue{} },
 	})
 	var gotBool bool
 	var gotInt int

--- a/taskflow_test.go
+++ b/taskflow_test.go
@@ -35,7 +35,7 @@ func Test_Register_errors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			flow := goyek.New()
+			flow := &goyek.Taskflow{}
 
 			act := func() { flow.Register(tc.task) }
 
@@ -229,7 +229,7 @@ func Test_empty_command(t *testing.T) {
 }
 
 func Test_invalid_args(t *testing.T) {
-	flow := goyek.New()
+	flow := &goyek.Taskflow{}
 	flow.Register(goyek.Task{
 		Name: "task",
 	})
@@ -260,7 +260,7 @@ func Test_invalid_args(t *testing.T) {
 }
 
 func Test_help(t *testing.T) {
-	flow := goyek.New()
+	flow := &goyek.Taskflow{}
 	fastParam := flow.RegisterBoolParam(goyek.BoolParam{
 		Name:  "fast",
 		Usage: "simulates fast-lane processing",
@@ -385,7 +385,7 @@ func (value *arrayValue) String() string {
 func (value *arrayValue) IsBool() bool { return false }
 
 func Test_params(t *testing.T) {
-	flow := goyek.New()
+	flow := &goyek.Taskflow{}
 	boolParam := flow.RegisterBoolParam(goyek.BoolParam{
 		Name:    "b",
 		Default: true,
@@ -432,7 +432,7 @@ func Test_params(t *testing.T) {
 }
 
 func Test_invalid_params(t *testing.T) {
-	flow := goyek.New()
+	flow := &goyek.Taskflow{}
 	flow.Register(goyek.Task{
 		Name:    "task",
 		Command: func(tf *goyek.TF) {},
@@ -444,7 +444,7 @@ func Test_invalid_params(t *testing.T) {
 }
 
 func Test_unused_params(t *testing.T) {
-	flow := goyek.New()
+	flow := &goyek.Taskflow{}
 	flow.DefaultTask = flow.Register(goyek.Task{Name: "task", Command: func(tf *goyek.TF) {}})
 	flow.RegisterBoolParam(goyek.BoolParam{Name: "unused"})
 
@@ -452,25 +452,25 @@ func Test_unused_params(t *testing.T) {
 }
 
 func Test_param_registration_error_empty_name(t *testing.T) {
-	flow := goyek.New()
+	flow := &goyek.Taskflow{}
 	assertPanics(t, func() { flow.RegisterBoolParam(goyek.BoolParam{Name: ""}) }, "empty name")
 }
 
 func Test_param_registration_error_no_default(t *testing.T) {
-	flow := goyek.New()
+	flow := &goyek.Taskflow{}
 	assertPanics(t, func() { flow.RegisterValueParam(goyek.ValueParam{Name: "custom"}) }, "custom parameter must have default value factory")
 }
 
 func Test_param_registration_error_double_name(t *testing.T) {
-	flow := goyek.New()
+	flow := &goyek.Taskflow{}
 	name := "double"
 	flow.RegisterStringParam(goyek.StringParam{Name: name})
 	assertPanics(t, func() { flow.RegisterBoolParam(goyek.BoolParam{Name: name}) }, "double name")
 }
 
 func Test_unregistered_params(t *testing.T) {
-	foreignParam := goyek.New().RegisterBoolParam(goyek.BoolParam{Name: "foreign"})
-	flow := goyek.New()
+	foreignParam := (&goyek.Taskflow{}).RegisterBoolParam(goyek.BoolParam{Name: "foreign"})
+	flow := &goyek.Taskflow{}
 	flow.Register(goyek.Task{
 		Name: "task",
 		Command: func(tf *goyek.TF) {
@@ -484,7 +484,7 @@ func Test_unregistered_params(t *testing.T) {
 }
 
 func Test_defaultTask(t *testing.T) {
-	flow := goyek.New()
+	flow := &goyek.Taskflow{}
 	taskRan := false
 	task := flow.Register(goyek.Task{
 		Name: "task",

--- a/taskflow_test.go
+++ b/taskflow_test.go
@@ -345,7 +345,7 @@ func Test_concurrent_printing(t *testing.T) {
 			args = append(args, "task")
 			exitCode := flow.Run(context.Background(), args...)
 
-			assertEqual(t, exitCode, goyek.CodeFailure, "should fail")
+			assertEqual(t, exitCode, goyek.CodeFail, "should fail")
 			assertContains(t, sb.String(), "from child goroutine", "should contain log from child goroutine")
 			assertContains(t, sb.String(), "from main goroutine", "should contain log from main goroutine")
 		})
@@ -480,7 +480,7 @@ func Test_unregistered_params(t *testing.T) {
 
 	exitCode := flow.Run(context.Background(), "task")
 
-	assertEqual(t, goyek.CodeFailure, exitCode, "should fail because of unregistered parameter")
+	assertEqual(t, goyek.CodeFail, exitCode, "should fail because of unregistered parameter")
 }
 
 func Test_defaultTask(t *testing.T) {


### PR DESCRIPTION
## Why

> Why this pull request was created? Explain the problem that this pull request is trying to solve.

1. The default parameter value often can be a zero-value for simple types.
2. Reduce the API surface when possible (especially when it makes trouble when introducing new functionalities).
3. Support `nil` as `context.Context`.

## What

> What does this pull request contain? Explain what is this pull request changing.

Each `Register*Param` accepts a struct as a single parameter. The `Default` value does not have to be provided (except `RegisterValueParam` where it is strictly required). Some types have been renamed.

Before the change:

```go
ci := flow.RegisterBoolParam(false, goyek.ParamInfo{
	Name:  "ci",
	Usage: "Whether CI is calling the build script",
})
```

After the change:

```go
ci := flow.RegisterBoolParam(goyek.BoolParam{
	Name:  "ci",
	Usage: "Whether CI is calling the build script",
})
```
Moreover, the `Runner` type is now unexported because:
1. It was almost impossible to use with parameters
2. It was really redundant. Better to use `Taskflow`
3. It would only cripple the development

Additionally, the `New` function was also removed as it was redundant and often less useful than simply using `&goyek.Taskflow{}`. One could even use `new(goyek.Taskflow)`.

Rename `CodeFailure` constant to `CodeFail`, because even in output there is `FAIL`. I find it also consistent with `CodePass` (we do not have `CodePassed` or `CodeSuccess`.

These changes should also help in maintaining backward compatibility. More: 
https://blog.golang.org/module-compatibility

To make also the API more "easy-to-use" and working with zero-values I added support for `nil` as `context.Context` in `Taskflow.Run` method.

## Checklist

- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated.
- [x] The code changes follow [Effective Go](https://golang.org/doc/effective_go).
