### PR TITLE
Regular expressions for names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,10 @@ Moreover, the parameters are set via CLI using the flag syntax.
 - Use the flag syntax for setting parameters via CLI.
 - Rename `Task.Description` field to `Usage`.
 - Rename `Task.Dependencies` field to `Deps`.
-- Rename `Taskflow.MustRegister` method to `Register` and remove previous `Taskflow.Register` implemention.
+- Rename `Taskflow.MustRegister` method to `Register` and remove previous `Taskflow.Register` implementation.
 - Remove `Taskflow.Params` field and `TF.Params` method, add `Taskflow.Register*Param` methods and `Task.Params` field instead.
 - Remove `TF.Verbose`, add `Taskflow.VerboseParam` instead.
-- Enforce pattern for task and parameter names.
+- Enforce patterns for task names (`goyek.TaskNamePattern`) and parameter names (`goyek.ParamNamePattern`).
 - Drop official support for Go 1.10.
 
 ## [0.2.0](https://github.com/goyek/goyek/compare/v0.1.1...v0.2.0) - 2021-03-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Moreover, the parameters are set via CLI using the flag syntax.
 - Rename `Taskflow.MustRegister` method to `Register` and remove previous `Taskflow.Register` implemention.
 - Remove `Taskflow.Params` field and `TF.Params` method, add `Taskflow.Register*Param` methods and `Task.Params` field instead.
 - Remove `TF.Verbose`, add `Taskflow.VerboseParam` instead.
+- Enforce pattern for task and parameter names.
 - Drop official support for Go 1.10.
 
 ## [0.2.0](https://github.com/goyek/goyek/compare/v0.1.1...v0.2.0) - 2021-03-14

--- a/README.md
+++ b/README.md
@@ -218,6 +218,16 @@ and `pkg` string parameter set to `"./..."`.
 
 Parameters must first be registered via [`func (f *Taskflow) RegisterValueParam(newValue func() ParamValue, info ParamInfo) ValueParam`](https://pkg.go.dev/github.com/goyek/goyek#Taskflow.RegisterValueParam), or one of the provided methods like [`RegisterStringParam`](https://pkg.go.dev/github.com/goyek/goyek#Taskflow.RegisterStringParam).
 
+The registered parameters are required to have a non-empty name, matching
+the regular expression `^[a-zA-Z0-9][a-zA-Z0-9_-]*$`, available as
+[`ParamNamePattern`](https://pkg.go.dev/github.com/goyek/goyek#ParamNamePattern).
+This means the following are acceptable:
+
+- letters (`a-z` and `A-Z`)
+- digits (`0-9`)
+- underscore (`_`) - except at the beginning
+- hyphens (`-`) - except at the beginning
+
 After registration, tasks need to specify which parameters they will read.
 Do this by assigning the [`RegisteredParam`](https://pkg.go.dev/github.com/goyek/goyek#RegisteredParam) instance from the registration result to the [`Task.Params`](https://pkg.go.dev/github.com/goyek/goyek#Task.Params) field.
 If a task tries to retrieve the value from an unregistered parameter, the task will fail.

--- a/README.md
+++ b/README.md
@@ -152,15 +152,15 @@ alias goyek='go run ./build'
 
 ### Task registration
 
-The registered tasks are required to have a non-empty name.
-For future compatibility, it is strongly suggested to use only the following characters:
+The registered tasks are required to have a non-empty name, matching
+the regular expression `^[a-zA-Z0-9_][a-zA-Z0-9_-]*$`, available as
+[`TaskNamePattern`](https://pkg.go.dev/github.com/goyek/goyek#TaskNamePattern).
+This means the following are acceptable:
 
 - letters (`a-z` and `A-Z`)
 - digits (`0-9`)
 - underscore (`_`)
-- hyphens (`-`)
-
-Do not begin the task name with `-` sign as it is used for assigning parameters.
+- hyphens (`-`) - except at the beginning
 
 A task with a given name can be only registered once.
 

--- a/taskflow.go
+++ b/taskflow.go
@@ -96,9 +96,14 @@ func (f *Taskflow) RegisterStringParam(defaultValue string, info ParamInfo) Stri
 	return StringParam{param{name: info.Name}}
 }
 
+// ParamNamePattern describes the regular expression a parameter name must match.
+const ParamNamePattern = "^[a-zA-Z0-9][a-zA-Z0-9_-]*$"
+
+var paramNameRegex = regexp.MustCompile(TaskNamePattern)
+
 func (f *Taskflow) registerParam(newValue func() ParamValue, info ParamInfo) {
-	if info.Name == "" {
-		panic("parameter name cannot be empty")
+	if !paramNameRegex.MatchString(info.Name) {
+		panic("parameter name must match ParamNamePattern")
 	}
 	if _, exists := f.params[info.Name]; exists {
 		panic(fmt.Sprintf("%s parameter was already registered", info.Name))
@@ -112,7 +117,7 @@ func (f *Taskflow) registerParam(newValue func() ParamValue, info ParamInfo) {
 	}
 }
 
-// TaskNamePattern describes the regular expression a task name must have.
+// TaskNamePattern describes the regular expression a task name must match.
 const TaskNamePattern = "^[a-zA-Z0-9_][a-zA-Z0-9_-]*$"
 
 var taskNameRegex = regexp.MustCompile(TaskNamePattern)

--- a/taskflow.go
+++ b/taskflow.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 )
 
 const (
@@ -111,14 +112,16 @@ func (f *Taskflow) registerParam(newValue func() ParamValue, info ParamInfo) {
 	}
 }
 
+// TaskNamePattern describes the regular expression a task name must have.
+const TaskNamePattern = "^[a-zA-Z0-9_][a-zA-Z0-9_-]*$"
+
+var taskNameRegex = regexp.MustCompile(TaskNamePattern)
+
 // Register registers the task. It panics in case of any error.
 func (f *Taskflow) Register(task Task) RegisteredTask {
 	// validate
-	if task.Name == "" {
-		panic("task name cannot be empty")
-	}
-	if task.Name[0] == '-' {
-		panic("task name cannot start with '-' sign")
+	if !taskNameRegex.MatchString(task.Name) {
+		panic("task name must match TaskNamePattern")
 	}
 	if f.isRegistered(task.Name) {
 		panic(fmt.Sprintf("%s task was already registered", task.Name))


### PR DESCRIPTION
## Why

Documentation specified that names "should" follow a pattern, yet it was unclear what the actual limits were.
Based on that, a more strict approach is now implemented, checking names against regular expressions.

## What

Both task and parameter names are checked against regular expressions. The expressions are similar, while I figured a task named `_` is feasible, having a parameter entered as `-_` is rather not. So, task names may start with an underscore, parameters not. Otherwise it's alphanumeric, plus dashes (in the middle).

## Checklist

- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated.
- [x] The code changes follow [Effective Go](https://golang.org/doc/effective_go).
