### PR TITLE
Add working directory global parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add Bash and PowerShell wrapper scripts.
+- Add `-wd` global parameter allowing to change the working directory.
 
 ## [0.3.0](https://github.com/goyek/goyek/compare/v0.2.0...v0.3.0) - 2021-05-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add Bash and PowerShell wrapper scripts.
 - Add `-wd` global parameter allowing to change the working directory.
+  The new `Taskflow.WorkDirParam` method can be used to get its value in a task's command.
 
 ## [0.3.0](https://github.com/goyek/goyek/compare/v0.2.0...v0.3.0) - 2021-05-03
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@
 [![codecov](https://codecov.io/gh/goyek/goyek/branch/main/graph/badge.svg)](https://codecov.io/gh/goyek/goyek)
 [![Mentioned in Awesome Go](https://awesome.re/mentioned-badge.svg)](https://github.com/avelino/awesome-go)
 
+> :warning: The `main` branch contains **new features**.
+> Here is the [**README for the latest release**](https://github.com/goyek/goyek/blob/v0.3.0/README.md).
+
 Table of Contents:
 
 - [goyek](#goyek)

--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ Sample usage:
 $ go run . -h
 Usage: [flag(s) | task(s)]...
 Flags:
-  -v     Default: false    Verbose output: log all tasks as they are run. Also print all text from Log and Logf calls even if the task succeeds.
-  -wd    Default: .        Working directory: sets the working directory.
+  -v     Default: false    Verbose: log all tasks as they are run.
+  -wd    Default: .        Working directory: set the working directory.
 Tasks:
   hello    demonstration
 ```

--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ Sample usage:
 $ go run . -h
 Usage: [flag(s) | task(s)]...
 Flags:
-  -v    Default: false    Verbose output: log all tasks as they are run. Also print all text from Log and Logf calls even if the task succeeds.
+  -v     Default: false    Verbose output: log all tasks as they are run. Also print all text from Log and Logf calls even if the task succeeds.
+  -wd    Default: .        Working directory: sets the working directory.
 Tasks:
   hello    demonstration
 ```

--- a/build/build.go
+++ b/build/build.go
@@ -1,19 +1,13 @@
 package main
 
 import (
-	"fmt"
 	"io"
-	"os"
 	"strings"
 
 	"github.com/goyek/goyek"
 )
 
 func main() {
-	if err := os.Chdir(".."); err != nil {
-		fmt.Println(err)
-		os.Exit(goyek.CodeInvalidArgs)
-	}
 	flow().Main()
 }
 

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -1,18 +1,10 @@
 package main
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/goyek/goyek"
 )
 
 func main() {
-	if err := os.Chdir(".."); err != nil {
-		fmt.Println(err)
-		os.Exit(goyek.CodeInvalidArgs)
-	}
-
 	flow := &goyek.Taskflow{}
 
 	flow.Register(goyek.Task{

--- a/examples/parameters/main.go
+++ b/examples/parameters/main.go
@@ -10,17 +10,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/goyek/goyek"
 )
 
 func main() {
-	if err := os.Chdir(".."); err != nil {
-		fmt.Println(err)
-		os.Exit(goyek.CodeInvalidArgs)
-	}
-
 	flow := &goyek.Taskflow{}
 
 	sharedParam := flow.RegisterStringParam(goyek.StringParam{

--- a/flow_runner.go
+++ b/flow_runner.go
@@ -101,11 +101,11 @@ func (f *flowRunner) Run(ctx context.Context, args []string) int { //nolint // T
 		return CodeInvalidArgs
 	}
 
+	// set working directory using global parameter
 	oldWd, err := os.Getwd()
 	if err != nil {
 		panic(err)
 	}
-
 	if wdParamVal, ok := f.paramValues[f.workDir.Name()]; ok {
 		wd := wdParamVal.Get().(string) //nolint // it is always a string
 		if err := os.Chdir(wd); err != nil {

--- a/flow_runner.go
+++ b/flow_runner.go
@@ -13,7 +13,7 @@ import (
 
 type flowRunner struct {
 	output      io.Writer
-	params      map[string]paramValueFactory
+	params      map[string]registeredParam
 	paramValues map[string]ParamValue
 	tasks       map[string]Task
 	verbose     RegisteredBoolParam

--- a/goyek.ps1
+++ b/goyek.ps1
@@ -1,6 +1,6 @@
 $ErrorActionPreference = "Stop"
 
 Push-Location "$PSScriptRoot\build"
-& go run . $args
+& go run . -wd=".." $args
 Pop-Location
 exit $global:LASTEXITCODE

--- a/goyek.sh
+++ b/goyek.sh
@@ -3,4 +3,4 @@ set -euo pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 cd "$DIR/build"
-go run . $@
+go run . -wd=".." $@

--- a/parameter.go
+++ b/parameter.go
@@ -5,12 +5,6 @@ import (
 	"strconv"
 )
 
-type paramValueFactory struct {
-	name     string
-	usage    string
-	newValue func() ParamValue
-}
-
 // BoolParam represents a named boolean parameter that can be registered.
 type BoolParam struct {
 	Name    string
@@ -63,17 +57,19 @@ type RegisteredParam interface {
 	value(tf *TF) ParamValue
 }
 
-// param is a helper struct for implementing concrete parameter types.
-type param struct {
-	name string
+// registeredParam is a helper struct encapsulating concrete registered parameter type.
+type registeredParam struct {
+	name     string
+	usage    string
+	newValue func() ParamValue
 }
 
 // Name returns the key of the parameter.
-func (p param) Name() string {
+func (p registeredParam) Name() string {
 	return p.name
 }
 
-func (p param) value(tf *TF) ParamValue {
+func (p registeredParam) value(tf *TF) ParamValue {
 	value, existing := tf.paramValues[p.name]
 	if !existing {
 		tf.Fatal(&ParamError{Key: p.name, Err: errors.New("parameter not registered")})
@@ -83,7 +79,7 @@ func (p param) value(tf *TF) ParamValue {
 
 // RegisteredValueParam represents a registered parameter based on a generic implementation.
 type RegisteredValueParam struct {
-	param
+	registeredParam
 }
 
 // Get returns the concrete instance of the generic value in the given flow.
@@ -114,7 +110,7 @@ func (value *boolValue) IsBool() bool { return true }
 
 // RegisteredBoolParam represents a registered boolean parameter.
 type RegisteredBoolParam struct {
-	param
+	registeredParam
 }
 
 // Get returns the boolean value of the parameter in the given flow.
@@ -142,7 +138,7 @@ func (value *intValue) IsBool() bool { return false }
 
 // RegisteredIntParam represents a registered integer parameter.
 type RegisteredIntParam struct {
-	param
+	registeredParam
 }
 
 // Get returns the integer value of the parameter in the given flow.
@@ -166,7 +162,7 @@ func (value *stringValue) IsBool() bool { return false }
 
 // RegisteredStringParam represents a registered string parameter.
 type RegisteredStringParam struct {
-	param
+	registeredParam
 }
 
 // Get returns the string value of the parameter in the given flow.

--- a/taskflow.go
+++ b/taskflow.go
@@ -45,7 +45,7 @@ func (f *Taskflow) VerboseParam() RegisteredBoolParam {
 	if f.verbose == nil {
 		param := f.RegisterBoolParam(BoolParam{
 			Name:  "v",
-			Usage: "Verbose output: log all tasks as they are run. Also print all text from Log and Logf calls even if the task succeeds.",
+			Usage: "Verbose: log all tasks as they are run.",
 		})
 		f.verbose = &param
 	}
@@ -58,7 +58,7 @@ func (f *Taskflow) WorkDirParam() RegisteredStringParam {
 	if f.workDir == nil {
 		param := f.RegisterStringParam(StringParam{
 			Name:    "wd",
-			Usage:   "Working directory: sets the working directory.",
+			Usage:   "Working directory: set the working directory.",
 			Default: ".",
 		})
 		f.workDir = &param

--- a/taskflow.go
+++ b/taskflow.go
@@ -28,7 +28,8 @@ type Taskflow struct {
 
 	DefaultTask RegisteredTask // task which is run when non is explicitly provided
 
-	verbose *RegisteredBoolParam // when enabled, then the whole output will be always streamed
+	verbose *RegisteredBoolParam   // when enabled, then the whole output will be always streamed
+	workDir *RegisteredStringParam // sets the working directory
 	params  map[string]registeredParam
 	tasks   map[string]Task
 }
@@ -50,6 +51,20 @@ func (f *Taskflow) VerboseParam() RegisteredBoolParam {
 	}
 
 	return *f.verbose
+}
+
+// WorkDirParam returns the out-of-the-box working directory parameter which controls the working directory.
+func (f *Taskflow) WorkDirParam() RegisteredStringParam {
+	if f.workDir == nil {
+		param := f.RegisterStringParam(StringParam{
+			Name:    "wd",
+			Usage:   "Working directory: sets the working directory.",
+			Default: ".",
+		})
+		f.workDir = &param
+	}
+
+	return *f.workDir
 }
 
 // RegisterValueParam registers a generic parameter that is defined by the calling code.
@@ -168,6 +183,7 @@ func (f *Taskflow) Run(ctx context.Context, args ...string) int {
 		params:      f.params,
 		tasks:       f.tasks,
 		verbose:     f.VerboseParam(),
+		workDir:     f.WorkDirParam(),
 		defaultTask: f.DefaultTask,
 	}
 

--- a/taskflow.go
+++ b/taskflow.go
@@ -29,7 +29,7 @@ type Taskflow struct {
 	DefaultTask RegisteredTask // task which is run when non is explicitly provided
 
 	verbose *RegisteredBoolParam // when enabled, then the whole output will be always streamed
-	params  map[string]paramValueFactory
+	params  map[string]registeredParam
 	tasks   map[string]Task
 }
 
@@ -58,12 +58,13 @@ func (f *Taskflow) VerboseParam() RegisteredBoolParam {
 // The value is provided via a factory function since Taskflow could be executed multiple times,
 // requiring a new Value instance each time.
 func (f *Taskflow) RegisterValueParam(p ValueParam) RegisteredValueParam {
-	f.registerParam(paramValueFactory{
+	regParam := registeredParam{
 		name:     p.Name,
 		usage:    p.Usage,
 		newValue: p.NewValue,
-	})
-	return RegisteredValueParam{param{name: p.Name}}
+	}
+	f.registerParam(regParam)
+	return RegisteredValueParam{regParam}
 }
 
 // RegisterBoolParam registers a boolean parameter.
@@ -72,12 +73,12 @@ func (f *Taskflow) RegisterBoolParam(p BoolParam) RegisteredBoolParam {
 		value := boolValue(p.Default)
 		return &value
 	}
-	f.registerParam(paramValueFactory{
+	f.registerParam(registeredParam{
 		name:     p.Name,
 		usage:    p.Usage,
 		newValue: valGetter,
 	})
-	return RegisteredBoolParam{param{name: p.Name}}
+	return RegisteredBoolParam{registeredParam{name: p.Name}}
 }
 
 // RegisterIntParam registers an integer parameter.
@@ -86,12 +87,13 @@ func (f *Taskflow) RegisterIntParam(p IntParam) RegisteredIntParam {
 		value := intValue(p.Default)
 		return &value
 	}
-	f.registerParam(paramValueFactory{
+	regParam := registeredParam{
 		name:     p.Name,
 		usage:    p.Usage,
 		newValue: valGetter,
-	})
-	return RegisteredIntParam{param{name: p.Name}}
+	}
+	f.registerParam(regParam)
+	return RegisteredIntParam{regParam}
 }
 
 // RegisterStringParam registers a string parameter.
@@ -100,12 +102,13 @@ func (f *Taskflow) RegisterStringParam(p StringParam) RegisteredStringParam {
 		value := stringValue(p.Default)
 		return &value
 	}
-	f.registerParam(paramValueFactory{
+	regParam := registeredParam{
 		name:     p.Name,
 		usage:    p.Usage,
 		newValue: valGetter,
-	})
-	return RegisteredStringParam{param{name: p.Name}}
+	}
+	f.registerParam(regParam)
+	return RegisteredStringParam{regParam}
 }
 
 // ParamNamePattern describes the regular expression a parameter name must match.
@@ -113,7 +116,7 @@ const ParamNamePattern = "^[a-zA-Z0-9][a-zA-Z0-9_-]*$"
 
 var paramNameRegex = regexp.MustCompile(TaskNamePattern)
 
-func (f *Taskflow) registerParam(p paramValueFactory) {
+func (f *Taskflow) registerParam(p registeredParam) {
 	if !paramNameRegex.MatchString(p.name) {
 		panic("parameter name must match ParamNamePattern")
 	}
@@ -124,7 +127,7 @@ func (f *Taskflow) registerParam(p paramValueFactory) {
 		panic(fmt.Sprintf("%s parameter was already registered", p.name))
 	}
 	if f.params == nil {
-		f.params = make(map[string]paramValueFactory)
+		f.params = make(map[string]registeredParam)
 	}
 	f.params[p.name] = p
 }

--- a/taskflow_test.go
+++ b/taskflow_test.go
@@ -5,7 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -548,7 +551,8 @@ func Test_wd_param_invalid(t *testing.T) {
 
 func tempDir(t *testing.T) string {
 	t.Helper()
-	dir, err := os.MkdirTemp("", "")
+	dir := filepath.Join(os.TempDir(), t.Name()+strconv.Itoa(rand.Int())) //nolint:gosec // I can use weak random generator in tests
+	err := os.Mkdir(dir, 0700)
 	requireEqual(t, err, nil, "failed to create a temp directory")
 	t.Cleanup(func() {
 		err := os.RemoveAll(dir)

--- a/taskflow_test.go
+++ b/taskflow_test.go
@@ -524,3 +524,24 @@ func Test_wd_param(t *testing.T) {
 	assertEqual(t, got, dir, "should have changed the working directory in taskflow")
 	assertEqual(t, afterDir, beforeDir, "should change back the working directory after taskflow")
 }
+
+func Test_wd_param_invalid(t *testing.T) {
+	flow := &goyek.Taskflow{}
+	beforeDir, err := os.Getwd()
+	requireEqual(t, err, nil, "should get work dir before the taskflow")
+	taskRan := false
+	flow.Register(goyek.Task{
+		Name: "task",
+		Command: func(tf *goyek.TF) {
+			taskRan = true
+		},
+	})
+
+	exitCode := flow.Run(context.Background(), "task", "-wd=strange-dir")
+	afterDir, err := os.Getwd()
+	requireEqual(t, err, nil, "should get work dir after the taskflow")
+
+	assertEqual(t, exitCode, goyek.CodeInvalidArgs, "should not proceed")
+	assertEqual(t, taskRan, false, "should not run the task")
+	assertEqual(t, afterDir, beforeDir, "should change back the working directory after taskflow")
+}

--- a/taskflow_test.go
+++ b/taskflow_test.go
@@ -5,12 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/goyek/goyek"
 )
@@ -552,7 +552,8 @@ func Test_wd_param_invalid(t *testing.T) {
 
 func tempDir(t *testing.T) (string, func()) {
 	t.Helper()
-	dir := filepath.Join(os.TempDir(), t.Name()+strconv.Itoa(rand.Int())) //nolint:gosec // I can use weak random generator in tests
+	dirName := t.Name() + "-" + strconv.FormatInt(time.Now().UnixNano(), 36)
+	dir := filepath.Join(os.TempDir(), dirName)
 	err := os.Mkdir(dir, 0700)
 	requireEqual(t, err, nil, "failed to create a temp directory")
 	cleanup := func() {

--- a/taskflow_test.go
+++ b/taskflow_test.go
@@ -508,7 +508,8 @@ func Test_wd_param(t *testing.T) {
 	flow := &goyek.Taskflow{}
 	beforeDir, err := os.Getwd()
 	requireEqual(t, err, nil, "should get work dir before the taskflow")
-	dir := tempDir(t)
+	dir, cleanup := tempDir(t)
+	defer cleanup()
 	var got string
 	flow.Register(goyek.Task{
 		Name: "task",
@@ -549,14 +550,14 @@ func Test_wd_param_invalid(t *testing.T) {
 	assertEqual(t, afterDir, beforeDir, "should change back the working directory after taskflow")
 }
 
-func tempDir(t *testing.T) string {
+func tempDir(t *testing.T) (string, func()) {
 	t.Helper()
 	dir := filepath.Join(os.TempDir(), t.Name()+strconv.Itoa(rand.Int())) //nolint:gosec // I can use weak random generator in tests
 	err := os.Mkdir(dir, 0700)
 	requireEqual(t, err, nil, "failed to create a temp directory")
-	t.Cleanup(func() {
+	cleanup := func() {
 		err := os.RemoveAll(dir)
 		assertEqual(t, err, nil, "should remove temp dir after test")
-	})
-	return dir
+	}
+	return dir, cleanup
 }

--- a/taskflow_test.go
+++ b/taskflow_test.go
@@ -505,7 +505,7 @@ func Test_wd_param(t *testing.T) {
 	flow := &goyek.Taskflow{}
 	beforeDir, err := os.Getwd()
 	requireEqual(t, err, nil, "should get work dir before the taskflow")
-	dir := t.TempDir()
+	dir := tempDir(t)
 	var got string
 	flow.Register(goyek.Task{
 		Name: "task",
@@ -544,4 +544,15 @@ func Test_wd_param_invalid(t *testing.T) {
 	assertEqual(t, exitCode, goyek.CodeInvalidArgs, "should not proceed")
 	assertEqual(t, taskRan, false, "should not run the task")
 	assertEqual(t, afterDir, beforeDir, "should change back the working directory after taskflow")
+}
+
+func tempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "")
+	requireEqual(t, err, nil, "failed to create a temp directory")
+	t.Cleanup(func() {
+		err := os.RemoveAll(dir)
+		assertEqual(t, err, nil, "should remove temp dir after test")
+	})
+	return dir
 }


### PR DESCRIPTION
## Why

> Why this pull request was created? Explain the problem that this pull request is trying to solve.

Fix https://github.com/goyek/goyek/issues/69

## What

> What does this pull request contain? Explain what is this pull request changing.

- Merge `param` and `paramValueFactory` types into `registeredParam` as they felt redundant
- Add `wd` global parameter allowing to change the working directory.
- Reuse `wd` parameter in wrapper scripts.
- Cleanup examples and build pipeline.

Refactoring proposals are welcome. I was thinking of introducing the "global parameter" abstraction, but could not figure out any obvious implementation in a dozen minutes. I felt that the current code is probably "maintainable" enough.

Test coverage is a little lower, because of panics which are probably almost impossible to test.

## Checklist

- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated.
- [ ] The code changes follow [Effective Go](https://golang.org/doc/effective_go).
