### PR TITLE
Refactor flowRunner.Run()

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,6 @@
 linters-settings:
   goimports:
     local-prefixes: github.com/goyek/goyek
-  golint:
-    min-confidence: 0.8
   gocyclo:
     min-complexity: 15
   govet:
@@ -43,7 +41,7 @@ linters:
     - gocyclo
     - godot
     - gofumpt
-    - golint
+    - revive
     - gomnd
     - goprintffuncname
     - gosec

--- a/flow_runner.go
+++ b/flow_runner.go
@@ -138,7 +138,7 @@ func (f *flowRunner) pushWorkingDir() (func(), error) {
 		panic(err)
 	}
 
-	wd := wdParamVal.Get().(string) // nolint // it is always a string
+	wd := wdParamVal.Get().(string) //nolint // it is always a string
 	if err := os.Chdir(wd); err != nil {
 		return func() {}, err
 	}

--- a/flow_runner.go
+++ b/flow_runner.go
@@ -121,7 +121,7 @@ func (f *flowRunner) parseArguments(args []string) ([]string, bool, error) {
 }
 
 func (f *flowRunner) defaultTasks(tasks []string) []string {
-	if len(tasks) > 0 || len(f.defaultTask.name) == 0 {
+	if len(tasks) > 0 || (f.defaultTask.name == "") {
 		return tasks
 	}
 	return []string{f.defaultTask.name}

--- a/flow_runner.go
+++ b/flow_runner.go
@@ -38,7 +38,7 @@ func (f *flowRunner) Run(ctx context.Context, args []string) int {
 		return CodePass
 	}
 
-	tasks = f.defaultTasks(tasks)
+	tasks = f.tasksToRun(tasks)
 
 	if len(tasks) == 0 {
 		fmt.Fprintln(f.output, "no task provided")
@@ -120,7 +120,7 @@ func (f *flowRunner) parseArguments(args []string) ([]string, bool, error) {
 	return tasks, usageRequested, nil
 }
 
-func (f *flowRunner) defaultTasks(tasks []string) []string {
+func (f *flowRunner) tasksToRun(tasks []string) []string {
 	if len(tasks) > 0 || (f.defaultTask.name == "") {
 		return tasks
 	}


### PR DESCRIPTION
## Why

Handle linter warnings

## What

This PR refactors `flowRunner.Run()` to handle the (disabled) linter warning. Main strategy was to extract methods.
Also included is an update of linters, as `golangci-lint` reported a warning about a deprecated linter.

Fixes #55 

## Checklist

- [x] `CHANGELOG.md` is updated. - N/A
- [x] `README.md` is updated. - N/A
- [x] The code changes follow [Effective Go](https://golang.org/doc/effective_go).
