### PR TITLE
Fix proper use of ParamNamePattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/goyek/goyek/compare/v0.4.0...HEAD)
 
+### Changed
+
+- Names of parameters now have to follow `goyek.ParamNamePattern`;
+  They were allowed to start with an underscore (`_`), and now no longer are.
+
 ## [0.4.0](https://github.com/goyek/goyek/compare/v0.3.0...v0.4.0) - 2021-05-26
 
 ### Added

--- a/taskflow.go
+++ b/taskflow.go
@@ -129,7 +129,7 @@ func (f *Taskflow) RegisterStringParam(p StringParam) RegisteredStringParam {
 // ParamNamePattern describes the regular expression a parameter name must match.
 const ParamNamePattern = "^[a-zA-Z0-9][a-zA-Z0-9_-]*$"
 
-var paramNameRegex = regexp.MustCompile(TaskNamePattern)
+var paramNameRegex = regexp.MustCompile(ParamNamePattern)
 
 func (f *Taskflow) registerParam(p registeredParam) {
 	if !paramNameRegex.MatchString(p.name) {

--- a/taskflow_test.go
+++ b/taskflow_test.go
@@ -460,6 +460,11 @@ func Test_param_registration_error_empty_name(t *testing.T) {
 	assertPanics(t, func() { flow.RegisterBoolParam(goyek.BoolParam{Name: ""}) }, "empty name")
 }
 
+func Test_param_registration_error_underscore_name_start(t *testing.T) {
+	flow := &goyek.Taskflow{}
+	assertPanics(t, func() { flow.RegisterBoolParam(goyek.BoolParam{Name: "_reserved"}) }, "should not start with underscore")
+}
+
 func Test_param_registration_error_no_default(t *testing.T) {
 	flow := &goyek.Taskflow{}
 	assertPanics(t, func() { flow.RegisterValueParam(goyek.ValueParam{Name: "custom"}) }, "custom parameter must have default value factory")


### PR DESCRIPTION
Signed-off-by: Christian Haas <christian.haas@sevensuns.at>

## Why

I just stumbled over an unused constant - although it should be used.

## What

Constant `ParamNamePattern` was not used and did thus allow parameters to start with an underscore.
> I was under the impression to have had this double checked when I initially wrote this. Apparently an explicit test was necessary to nail this down.

## Checklist

- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated. (n/a)
- [x] The code changes follow [Effective Go](https://golang.org/doc/effective_go).
