### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Names of parameters now have to follow `goyek.ParamNamePattern`;
+- Names of parameters now have to follow `goyek.ParamNamePattern`.
   They were allowed to start with an underscore (`_`), and now no longer are.
 - The PowerShell wrapper scripts `goyek.ps1` better handles `stderr` redirection.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/goyek/goyek/compare/v0.4.0...HEAD)
+## [Unreleased](https://github.com/goyek/goyek/compare/v0.5.0...HEAD)
+
+## [0.5.0](https://github.com/goyek/goyek/compare/v0.4.0...v0.5.0) - 2021-06-21
 
 ### Added
 

--- a/build/go.mod
+++ b/build/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/client9/misspell v0.3.4
 	github.com/golangci/golangci-lint v1.41.1
-	github.com/goyek/goyek v0.4.0
+	github.com/goyek/goyek v0.5.0
 	mvdan.cc/gofumpt v0.1.1
 )
 


### PR DESCRIPTION
## Changelog

### Added

- Add the stack trace when a task panics.

### Changed

- Names of parameters now have to follow `goyek.ParamNamePattern`.
  They were allowed to start with an underscore (`_`), and now no longer are.
- The PowerShell wrapper scripts `goyek.ps1` better handles `stderr` redirection.

## Checklist

https://github.com/goyek/goyek/blob/main/docs/releasing.md
