### PR TITLE
TF.Cmd sets Stdin to os.Stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 This release contains multiple **breaking changes** in the Go API. It is supposed to make it cleaner.
 
+### Added
+
+- `Tf.Cmd` also sets `Stdin` to `os.Stdin`.
+
 ### Changed
 
 - Rename `Task.Command` field to `Action` to avoid confusion with [`exec.Command`](https://golang.org/pkg/os/exec/#Command) and `TF.Cmd`.

--- a/cmd.go
+++ b/cmd.go
@@ -7,7 +7,8 @@ import (
 )
 
 // Cmd is like exec.Command, but it assigns tf's context
-// and assigns Stdout and Stderr to tf's output.
+// and assigns Stdout and Stderr to tf's output,
+// and Stdin to os.Stdin.
 func (tf *TF) Cmd(name string, args ...string) *exec.Cmd {
 	cmdStr := strings.Join(append([]string{name}, args...), " ")
 	tf.Logf("Cmd: %s", cmdStr)

--- a/cmd.go
+++ b/cmd.go
@@ -1,6 +1,7 @@
 package goyek
 
 import (
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -12,6 +13,7 @@ func (tf *TF) Cmd(name string, args ...string) *exec.Cmd {
 	tf.Logf("Cmd: %s", cmdStr)
 
 	cmd := exec.CommandContext(tf.Context(), name, args...) //nolint:gosec // yes, this runs a subprocess
+	cmd.Stdin = os.Stdin
 	cmd.Stderr = tf.Output()
 	cmd.Stdout = tf.Output()
 	return cmd


### PR DESCRIPTION
## Why

It may be useful the redirect's the process started by `exec.Cmd` use the same stdin.

Discussion: https://github.com/goyek/goyek/discussions/109

## What

`TF.Cmd` sets the `Stdin` to `os.Stdin`.

## Checklist

<!-- All items should be verified and marked as done.
     If an item doesn't apply to the introduced changes - check it as done too. -->

- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated.
- [x] The code changes follow [Effective Go](https://golang.org/doc/effective_go).
