### PR TITLE
Rename Taskflow type to Flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,11 @@ This release contains multiple **breaking changes** in the Go API. It is suppose
 ### Added
 
 - `Tf.Cmd` also sets `Stdin` to `os.Stdin`.
-- Add `Taskflow.Tasks` and `Taskflow.Params` to allow introspection of the registered tasks and parameters.
+- Add `Flow.Tasks` and `Flow.Params` to allow introspection of the registered tasks and parameters.
 
 ### Changed
 
+- Rename `Taskflow` type to `Flow` to simplify the naming.
 - Rename `Task.Command` field to `Action` to avoid confusion with [`exec.Command`](https://golang.org/pkg/os/exec/#Command) and `TF.Cmd`.
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Please ⭐ `Star` this repository if you find it valuable and worth maintaining.
 **Be aware that `goyek` is still in `v0` phase, and the API is still in flux.** As per [Go module version numbering](https://golang.org/doc/modules/version-numbers), you can use released versions for your projects, yet there is the potential for breaking changes in later releases. We anticipate a `v1` release for a stable API. It is not yet clear when this will happen.
 
 > :warning: The `main` branch contains **breaking changes** compared to the previous release.
-> Here is the [**README for the latest release**](https://github.com/pellared/taskflow/blob/v0.5.0/README.md).
+> Here is the [**README for the latest release**](https://github.com/goyek/goyek/blob/v0.5.0/README.md).
 
 Table of Contents:
 
@@ -83,7 +83,7 @@ import (
 )
 
 func main() {
-	flow := &goyek.Taskflow{}
+	flow := &goyek.Flow{}
 
 	flow.Register(goyek.Task{
 		Name:  "hello",
@@ -183,13 +183,13 @@ A task without description is not listed in CLI usage.
 ### Task action
 
 Task action is a function which is executed when a task is executed.
-It is not required to to set a action.
-Not having a action is very handy when registering "pipelines".
+
+It is not required to set a action. Not having a action is very handy when registering "pipelines".
 
 ### Task dependencies
 
 During task registration it is possible to add a dependency to an already registered task.
-When taskflow is processed, it makes sure that the dependency is executed before the current task is run.
+When the flow is processed, it makes sure that the dependency is executed before the current task is run.
 Take note that each task will be executed at most once.
 
 ### Helpers for running programs
@@ -237,12 +237,12 @@ Enable verbose output using the `-v` CLI flag.
 It works similar to `go test -v`. Verbose mode streams all logs to the output.
 If it is disabled, only logs from failed task are send to the output.
 
-Use [`func (f *Taskflow) VerboseParam() BoolParam`](https://pkg.go.dev/github.com/goyek/goyek#Taskflow.VerboseParam)
+Use [`func (f *Flow) VerboseParam() BoolParam`](https://pkg.go.dev/github.com/goyek/goyek#Flow.VerboseParam)
 if you need to check if verbose mode was set within a task's action.
 
 ### Default task
 
-Default task can be assigned via the [`Taskflow.DefaultTask`](https://pkg.go.dev/github.com/goyek/goyek#Taskflow.DefaultTask) field.
+Default task can be assigned via the [`Flow.DefaultTask`](https://pkg.go.dev/github.com/goyek/goyek#Flow.DefaultTask) field.
 
 When the default task is set, then it is run if no task is provided via CLI.
 
@@ -261,7 +261,7 @@ For example, `./goyek.sh test -v -pkg ./...` would run the `test` task
 with `v` bool parameter (verbose mode) set to `true`,
 and `pkg` string parameter set to `"./..."`.
 
-Parameters must first be registered via [`func (f *Taskflow) RegisterValueParam(newValue func() ParamValue, info ParamInfo) ValueParam`](https://pkg.go.dev/github.com/goyek/goyek#Taskflow.RegisterValueParam), or one of the provided methods like [`RegisterStringParam`](https://pkg.go.dev/github.com/goyek/goyek#Taskflow.RegisterStringParam).
+Parameters must first be registered via [`func (f *Flow) RegisterValueParam(newValue func() ParamValue, info ParamInfo) ValueParam`](https://pkg.go.dev/github.com/goyek/goyek#Flow.RegisterValueParam), or one of the provided methods like [`RegisterStringParam`](https://pkg.go.dev/github.com/goyek/goyek#Flow.RegisterStringParam).
 
 The registered parameters are required to have a non-empty name, matching
 the regular expression `^[a-zA-Z0-9][a-zA-Z0-9_-]*$`, available as
@@ -281,7 +281,7 @@ When registration is done, the task's action can retrieve the parameter value us
 
 See [examples/parameters/main.go](examples/parameters/main.go) for a detailed example.
 
-`Taskflow` will fail execution if there are unused parameters.
+`Flow` will fail execution if there are unused parameters.
 
 ### Supported Go versions
 

--- a/build/build.go
+++ b/build/build.go
@@ -13,8 +13,8 @@ func main() {
 	flow().Main()
 }
 
-func flow() *goyek.Taskflow {
-	flow := &goyek.Taskflow{}
+func flow() *goyek.Flow {
+	flow := &goyek.Flow{}
 
 	// parameters
 	ci := flow.RegisterBoolParam(goyek.BoolParam{

--- a/cli.go
+++ b/cli.go
@@ -8,7 +8,7 @@ import (
 
 // Main parses the command-line arguments and runs the provided tasks.
 // The usage is printed when invalid arguments are passed.
-func (f *Taskflow) Main() {
+func (f *Flow) Main() {
 	// trap Ctrl+C and call cancel on the context
 	ctx, cancel := context.WithCancel(context.Background())
 	c := make(chan os.Signal, 1)
@@ -21,7 +21,7 @@ func (f *Taskflow) Main() {
 		}
 	}()
 
-	// run taskflow
+	// run flow
 	exitCode := f.Run(ctx, os.Args[1:]...)
 	os.Exit(exitCode)
 }

--- a/cli_example_test.go
+++ b/cli_example_test.go
@@ -3,7 +3,7 @@ package goyek_test
 import "github.com/goyek/goyek"
 
 func Example() {
-	flow := &goyek.Taskflow{}
+	flow := &goyek.Flow{}
 
 	task1 := flow.Register(goyek.Task{
 		Name:  "task-1",

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -11,7 +11,7 @@ import (
 func TestCmd_success(t *testing.T) {
 	taskName := "exec"
 	sb := &strings.Builder{}
-	flow := &goyek.Taskflow{
+	flow := &goyek.Flow{
 		Output: sb,
 	}
 	flow.Register(goyek.Task{
@@ -31,7 +31,7 @@ func TestCmd_success(t *testing.T) {
 
 func TestCmd_error(t *testing.T) {
 	taskName := "exec"
-	flow := &goyek.Taskflow{}
+	flow := &goyek.Flow{}
 	flow.Register(goyek.Task{
 		Name: taskName,
 		Action: func(tf *goyek.TF) {

--- a/doc.go
+++ b/doc.go
@@ -1,17 +1,4 @@
 /*
 Package goyek helps implementing build automation.
-It is intended to be used in concert with the "go run" command,
-to run a program which implements the build pipeline (called taskflow).
-A taskflow consists of a set of registered tasks.
-A task has a name, can have a defined command, which is a function with signature
-	func (*goyek.TF)
-and can have dependencies (already defined tasks).
-
-When the taskflow is executed for given tasks,
-then the tasks' actions are run in the order defined by their dependencies.
-The task's dependencies are run in a recursive manner, however each is going to be run at most once.
-
-The taskflow is interrupted in case a action fails.
-Within these functions, use the Error, Fail or related methods to signal failure.
 */
 package goyek

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -5,7 +5,7 @@ import (
 )
 
 func main() {
-	flow := &goyek.Taskflow{}
+	flow := &goyek.Flow{}
 
 	flow.Register(goyek.Task{
 		Name:  "hello",

--- a/examples/parameters/main.go
+++ b/examples/parameters/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 func main() {
-	flow := &goyek.Taskflow{}
+	flow := &goyek.Flow{}
 
 	sharedParam := flow.RegisterStringParam(goyek.StringParam{
 		Name:    "shared",
@@ -44,7 +44,7 @@ func taskFirst(sharedParam goyek.RegisteredStringParam) goyek.Task {
 	}
 }
 
-func taskSecond(flow *goyek.Taskflow, sharedParam goyek.RegisteredStringParam) goyek.Task {
+func taskSecond(flow *goyek.Flow, sharedParam goyek.RegisteredStringParam) goyek.Task {
 	// The following is a "private" parameter, only available to this task.
 	privateParam := flow.RegisterStringParam(goyek.StringParam{
 		Name:    "private",
@@ -97,7 +97,7 @@ func (value *complexParamValue) IsBool() bool {
 // taskComplexParam showcases complex parameters, JSON encoded.
 //
 // Execute `go run . -v complex -json "{\"stringValue\":\"abc\"}"` as an example.
-func taskComplexParam(flow *goyek.Taskflow) goyek.Task {
+func taskComplexParam(flow *goyek.Flow) goyek.Task {
 	privateParam := flow.RegisterValueParam(goyek.ValueParam{
 		Name:  "json",
 		Usage: "A complex parameter",
@@ -145,7 +145,7 @@ func (value *listParamValue) IsBool() bool {
 // taskListParam showcases repeatable parameters.
 //
 // Execute `go run . -v list -port 1 -port 2 -port 3` as an example.
-func taskListParam(flow *goyek.Taskflow) goyek.Task {
+func taskListParam(flow *goyek.Flow) goyek.Task {
 	privateParam := flow.RegisterValueParam(goyek.ValueParam{
 		Name:  "port",
 		Usage: "Integer parameter, can be repeated",

--- a/parameter.go
+++ b/parameter.go
@@ -50,7 +50,7 @@ type ParamValue interface {
 	Set(string) error
 }
 
-// RegisteredParam represents a parameter that has been registered to a Taskflow.
+// RegisteredParam represents a parameter that has been registered to a Flow.
 // It can be used as a parameter for a Task.
 type RegisteredParam interface {
 	Name() string

--- a/parameter_test.go
+++ b/parameter_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/goyek/goyek"
 )
 
-func runTaskflowWith(flow *goyek.Taskflow, param goyek.RegisteredParam, cmd func(*goyek.TF), args []string) int {
+func runFlowWith(flow *goyek.Flow, param goyek.RegisteredParam, cmd func(*goyek.TF), args []string) int {
 	flow.Register(goyek.Task{
 		Name:   "task",
 		Params: goyek.Params{param},
@@ -39,13 +39,13 @@ func Test_bool_param(t *testing.T) {
 	for index, tc := range tt {
 		tc := tc
 		t.Run("case "+strconv.Itoa(index), func(t *testing.T) {
-			flow := &goyek.Taskflow{}
+			flow := &goyek.Flow{}
 			param := flow.RegisterBoolParam(goyek.BoolParam{
 				Name:    "b",
 				Default: tc.defaultValue,
 			})
 			var got bool
-			exitCode := runTaskflowWith(flow, param, func(tf *goyek.TF) { got = param.Get(tf) }, tc.args)
+			exitCode := runFlowWith(flow, param, func(tf *goyek.TF) { got = param.Get(tf) }, tc.args)
 
 			assertEqual(t, exitCode, tc.exitCode, "exit code should match")
 			assertEqual(t, got, tc.value, "value should match")
@@ -54,12 +54,12 @@ func Test_bool_param(t *testing.T) {
 }
 
 func Test_bool_param_help(t *testing.T) {
-	flow := &goyek.Taskflow{}
+	flow := &goyek.Flow{}
 	param := flow.RegisterBoolParam(goyek.BoolParam{
 		Name:    "bool",
 		Default: true,
 	})
-	exitCode := runTaskflowWith(flow, param, func(tf *goyek.TF) {}, []string{"-h"})
+	exitCode := runFlowWith(flow, param, func(tf *goyek.TF) {}, []string{"-h"})
 
 	assertEqual(t, exitCode, 0, "exit code should be OK")
 }
@@ -84,13 +84,13 @@ func Test_int_param(t *testing.T) {
 	for index, tc := range tt {
 		tc := tc
 		t.Run("case "+strconv.Itoa(index), func(t *testing.T) {
-			flow := &goyek.Taskflow{}
+			flow := &goyek.Flow{}
 			param := flow.RegisterIntParam(goyek.IntParam{
 				Name:    "i",
 				Default: tc.defaultValue,
 			})
 			var got int
-			exitCode := runTaskflowWith(flow, param, func(tf *goyek.TF) { got = param.Get(tf) }, tc.args)
+			exitCode := runFlowWith(flow, param, func(tf *goyek.TF) { got = param.Get(tf) }, tc.args)
 
 			assertEqual(t, exitCode, tc.exitCode, "exit code should match")
 			assertEqual(t, got, tc.value, "value should match")
@@ -99,12 +99,12 @@ func Test_int_param(t *testing.T) {
 }
 
 func Test_int_param_help(t *testing.T) {
-	flow := &goyek.Taskflow{}
+	flow := &goyek.Flow{}
 	param := flow.RegisterIntParam(goyek.IntParam{
 		Name:    "int",
 		Default: 123,
 	})
-	exitCode := runTaskflowWith(flow, param, func(tf *goyek.TF) {}, []string{"-h"})
+	exitCode := runFlowWith(flow, param, func(tf *goyek.TF) {}, []string{"-h"})
 
 	assertEqual(t, exitCode, 0, "exit code should be OK")
 }
@@ -126,13 +126,13 @@ func Test_string_param(t *testing.T) {
 	for index, tc := range tt {
 		tc := tc
 		t.Run("case "+strconv.Itoa(index), func(t *testing.T) {
-			flow := &goyek.Taskflow{}
+			flow := &goyek.Flow{}
 			param := flow.RegisterStringParam(goyek.StringParam{
 				Name:    "s",
 				Default: tc.defaultValue,
 			})
 			var got string
-			exitCode := runTaskflowWith(flow, param, func(tf *goyek.TF) { got = param.Get(tf) }, tc.args)
+			exitCode := runFlowWith(flow, param, func(tf *goyek.TF) { got = param.Get(tf) }, tc.args)
 
 			assertEqual(t, exitCode, goyek.CodePass, "exit code should match")
 			assertEqual(t, got, tc.value, "value should match")
@@ -141,12 +141,12 @@ func Test_string_param(t *testing.T) {
 }
 
 func Test_string_param_help(t *testing.T) {
-	flow := &goyek.Taskflow{}
+	flow := &goyek.Flow{}
 	param := flow.RegisterStringParam(goyek.StringParam{
 		Name:    "string",
 		Default: "abc",
 	})
-	exitCode := runTaskflowWith(flow, param, func(tf *goyek.TF) {}, []string{"-h"})
+	exitCode := runFlowWith(flow, param, func(tf *goyek.TF) {}, []string{"-h"})
 
 	assertEqual(t, exitCode, 0, "exit code should be OK")
 }

--- a/task.go
+++ b/task.go
@@ -13,7 +13,7 @@ type Task struct {
 	// If it is empty, this task will not be listed in the usage output.
 	Usage string
 
-	// Action executes the task in the given taskflow context.
+	// Action executes the task in the given flow context.
 	// A task can be registered without a action and can act as a "collector" task
 	// for a list of dependencies.
 	Action func(tf *TF)
@@ -27,7 +27,7 @@ type Task struct {
 	Params Params
 }
 
-// RegisteredTask represents a task that has been registered to a Taskflow.
+// RegisteredTask represents a task that has been registered to a Flow.
 // It can be used as a dependency for another Task.
 type RegisteredTask struct {
 	task Task

--- a/taskflow.go
+++ b/taskflow.go
@@ -9,18 +9,18 @@ import (
 )
 
 const (
-	// CodePass indicates that taskflow passed.
+	// CodePass indicates that flow passed.
 	CodePass = 0
-	// CodeFail indicates that taskflow failed.
+	// CodeFail indicates that flow failed.
 	CodeFail = 1
-	// CodeInvalidArgs indicates that taskflow got invalid input.
+	// CodeInvalidArgs indicates that flow got invalid input.
 	CodeInvalidArgs = 2
 )
 
-// Taskflow is the root type of the package.
+// Flow is the root type of the package.
 // Use Register methods to register all tasks
 // and Run or Main method to execute provided tasks.
-type Taskflow struct {
+type Flow struct {
 	Output io.Writer // output where text is printed; os.Stdout by default
 
 	DefaultTask RegisteredTask // task which is run when non is explicitly provided
@@ -32,7 +32,7 @@ type Taskflow struct {
 }
 
 // Tasks returns all registered tasks.
-func (f *Taskflow) Tasks() []RegisteredTask {
+func (f *Flow) Tasks() []RegisteredTask {
 	var tasks []RegisteredTask
 	for _, task := range f.tasks {
 		tasks = append(tasks, RegisteredTask{
@@ -43,7 +43,7 @@ func (f *Taskflow) Tasks() []RegisteredTask {
 }
 
 // Params returns all registered parameters.
-func (f *Taskflow) Params() []RegisteredParam {
+func (f *Flow) Params() []RegisteredParam {
 	// make sure OOTB parameters are registered
 	f.VerboseParam()
 	f.WorkDirParam()
@@ -56,7 +56,7 @@ func (f *Taskflow) Params() []RegisteredParam {
 }
 
 // VerboseParam returns the out-of-the-box verbose parameter which controls the output behavior.
-func (f *Taskflow) VerboseParam() RegisteredBoolParam {
+func (f *Flow) VerboseParam() RegisteredBoolParam {
 	if f.verbose == nil {
 		param := f.RegisterBoolParam(BoolParam{
 			Name:  "v",
@@ -69,7 +69,7 @@ func (f *Taskflow) VerboseParam() RegisteredBoolParam {
 }
 
 // WorkDirParam returns the out-of-the-box working directory parameter which controls the working directory.
-func (f *Taskflow) WorkDirParam() RegisteredStringParam {
+func (f *Flow) WorkDirParam() RegisteredStringParam {
 	if f.workDir == nil {
 		param := f.RegisterStringParam(StringParam{
 			Name:    "wd",
@@ -85,9 +85,9 @@ func (f *Taskflow) WorkDirParam() RegisteredStringParam {
 // RegisterValueParam registers a generic parameter that is defined by the calling code.
 // Use this variant in case the primitive-specific implementations cannot cover the parameter.
 //
-// The value is provided via a factory function since Taskflow could be executed multiple times,
+// The value is provided via a factory function since flow could be executed multiple times,
 // requiring a new Value instance each time.
-func (f *Taskflow) RegisterValueParam(p ValueParam) RegisteredValueParam {
+func (f *Flow) RegisterValueParam(p ValueParam) RegisteredValueParam {
 	regParam := registeredParam{
 		name:     p.Name,
 		usage:    p.Usage,
@@ -98,7 +98,7 @@ func (f *Taskflow) RegisterValueParam(p ValueParam) RegisteredValueParam {
 }
 
 // RegisterBoolParam registers a boolean parameter.
-func (f *Taskflow) RegisterBoolParam(p BoolParam) RegisteredBoolParam {
+func (f *Flow) RegisterBoolParam(p BoolParam) RegisteredBoolParam {
 	valGetter := func() ParamValue {
 		value := boolValue(p.Default)
 		return &value
@@ -112,7 +112,7 @@ func (f *Taskflow) RegisterBoolParam(p BoolParam) RegisteredBoolParam {
 }
 
 // RegisterIntParam registers an integer parameter.
-func (f *Taskflow) RegisterIntParam(p IntParam) RegisteredIntParam {
+func (f *Flow) RegisterIntParam(p IntParam) RegisteredIntParam {
 	valGetter := func() ParamValue {
 		value := intValue(p.Default)
 		return &value
@@ -127,7 +127,7 @@ func (f *Taskflow) RegisterIntParam(p IntParam) RegisteredIntParam {
 }
 
 // RegisterStringParam registers a string parameter.
-func (f *Taskflow) RegisterStringParam(p StringParam) RegisteredStringParam {
+func (f *Flow) RegisterStringParam(p StringParam) RegisteredStringParam {
 	valGetter := func() ParamValue {
 		value := stringValue(p.Default)
 		return &value
@@ -146,7 +146,7 @@ const ParamNamePattern = "^[a-zA-Z0-9][a-zA-Z0-9_-]*$"
 
 var paramNameRegex = regexp.MustCompile(ParamNamePattern)
 
-func (f *Taskflow) registerParam(p registeredParam) {
+func (f *Flow) registerParam(p registeredParam) {
 	if !paramNameRegex.MatchString(p.name) {
 		panic("parameter name must match ParamNamePattern")
 	}
@@ -168,7 +168,7 @@ const TaskNamePattern = "^[a-zA-Z0-9_][a-zA-Z0-9_-]*$"
 var taskNameRegex = regexp.MustCompile(TaskNamePattern)
 
 // Register registers the task. It panics in case of any error.
-func (f *Taskflow) Register(task Task) RegisteredTask {
+func (f *Flow) Register(task Task) RegisteredTask {
 	// validate
 	if !taskNameRegex.MatchString(task.Name) {
 		panic("task name must match TaskNamePattern")
@@ -188,7 +188,7 @@ func (f *Taskflow) Register(task Task) RegisteredTask {
 
 // Run runs provided tasks and all their dependencies.
 // Each task is executed at most once.
-func (f *Taskflow) Run(ctx context.Context, args ...string) int {
+func (f *Flow) Run(ctx context.Context, args ...string) int {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -209,7 +209,7 @@ func (f *Taskflow) Run(ctx context.Context, args ...string) int {
 	return flow.Run(ctx, args)
 }
 
-func (f *Taskflow) isRegistered(name string) bool {
+func (f *Flow) isRegistered(name string) bool {
 	if f.tasks == nil {
 		f.tasks = map[string]Task{}
 	}

--- a/taskflow_test.go
+++ b/taskflow_test.go
@@ -35,7 +35,7 @@ func Test_Register_errors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			flow := &goyek.Taskflow{}
+			flow := &goyek.Flow{}
 
 			act := func() { flow.Register(tc.task) }
 
@@ -45,7 +45,7 @@ func Test_Register_errors(t *testing.T) {
 }
 
 func Test_Register_same_name(t *testing.T) {
-	flow := &goyek.Taskflow{}
+	flow := &goyek.Flow{}
 	task := goyek.Task{Name: "task"}
 	flow.Register(task)
 
@@ -56,7 +56,7 @@ func Test_Register_same_name(t *testing.T) {
 
 func Test_successful(t *testing.T) {
 	ctx := context.Background()
-	flow := &goyek.Taskflow{}
+	flow := &goyek.Flow{}
 	var executed1 int
 	task1 := flow.Register(goyek.Task{
 		Name: "task-1",
@@ -98,7 +98,7 @@ func Test_successful(t *testing.T) {
 }
 
 func Test_dependency_failure(t *testing.T) {
-	flow := &goyek.Taskflow{}
+	flow := &goyek.Flow{}
 	var executed1 int
 	task1 := flow.Register(goyek.Task{
 		Name: "task-1",
@@ -137,7 +137,7 @@ func Test_dependency_failure(t *testing.T) {
 }
 
 func Test_fail(t *testing.T) {
-	flow := &goyek.Taskflow{}
+	flow := &goyek.Flow{}
 	failed := false
 	flow.Register(goyek.Task{
 		Name: "task",
@@ -156,7 +156,7 @@ func Test_fail(t *testing.T) {
 }
 
 func Test_skip(t *testing.T) {
-	flow := &goyek.Taskflow{}
+	flow := &goyek.Flow{}
 	skipped := false
 	flow.Register(goyek.Task{
 		Name: "task",
@@ -175,7 +175,7 @@ func Test_skip(t *testing.T) {
 }
 
 func Test_task_panics(t *testing.T) {
-	flow := &goyek.Taskflow{}
+	flow := &goyek.Flow{}
 	flow.Register(goyek.Task{
 		Name: "task",
 		Action: func(tf *goyek.TF) {
@@ -191,7 +191,7 @@ func Test_task_panics(t *testing.T) {
 func Test_cancelation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	flow := &goyek.Taskflow{}
+	flow := &goyek.Flow{}
 	flow.Register(goyek.Task{
 		Name: "task",
 	})
@@ -204,7 +204,7 @@ func Test_cancelation(t *testing.T) {
 func Test_cancelation_during_last_task(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	flow := &goyek.Taskflow{}
+	flow := &goyek.Flow{}
 	flow.Register(goyek.Task{
 		Name: "task",
 		Action: func(tf *goyek.TF) {
@@ -218,7 +218,7 @@ func Test_cancelation_during_last_task(t *testing.T) {
 }
 
 func Test_empty_action(t *testing.T) {
-	flow := &goyek.Taskflow{}
+	flow := &goyek.Flow{}
 	flow.Register(goyek.Task{
 		Name: "task",
 	})
@@ -229,7 +229,7 @@ func Test_empty_action(t *testing.T) {
 }
 
 func Test_invalid_args(t *testing.T) {
-	flow := &goyek.Taskflow{}
+	flow := &goyek.Flow{}
 	flow.Register(goyek.Task{
 		Name: "task",
 	})
@@ -260,7 +260,7 @@ func Test_invalid_args(t *testing.T) {
 }
 
 func Test_help(t *testing.T) {
-	flow := &goyek.Taskflow{}
+	flow := &goyek.Flow{}
 	fastParam := flow.RegisterBoolParam(goyek.BoolParam{
 		Name:  "fast",
 		Usage: "simulates fast-lane processing",
@@ -279,7 +279,7 @@ func Test_help(t *testing.T) {
 
 func Test_printing(t *testing.T) {
 	sb := &strings.Builder{}
-	flow := &goyek.Taskflow{
+	flow := &goyek.Flow{
 		Output: sb,
 	}
 	skipped := flow.Register(goyek.Task{
@@ -321,7 +321,7 @@ func Test_concurrent_printing(t *testing.T) {
 		testName := fmt.Sprintf("Verbose:%v", tc.verbose)
 		t.Run(testName, func(t *testing.T) {
 			sb := &strings.Builder{}
-			flow := goyek.Taskflow{
+			flow := goyek.Flow{
 				Output: sb,
 			}
 			flow.Register(goyek.Task{
@@ -352,7 +352,7 @@ func Test_concurrent_printing(t *testing.T) {
 }
 
 func Test_name(t *testing.T) {
-	flow := &goyek.Taskflow{}
+	flow := &goyek.Flow{}
 	taskName := "my-named-task"
 	var got string
 	flow.Register(goyek.Task{
@@ -384,7 +384,7 @@ func (value *arrayValue) String() string {
 func (value *arrayValue) IsBool() bool { return false }
 
 func Test_params(t *testing.T) {
-	flow := &goyek.Taskflow{}
+	flow := &goyek.Flow{}
 	boolParam := flow.RegisterBoolParam(goyek.BoolParam{
 		Name:    "b",
 		Default: true,
@@ -431,7 +431,7 @@ func Test_params(t *testing.T) {
 }
 
 func Test_invalid_params(t *testing.T) {
-	flow := &goyek.Taskflow{}
+	flow := &goyek.Flow{}
 	flow.Register(goyek.Task{
 		Name:   "task",
 		Action: func(tf *goyek.TF) {},
@@ -443,7 +443,7 @@ func Test_invalid_params(t *testing.T) {
 }
 
 func Test_unused_params(t *testing.T) {
-	flow := &goyek.Taskflow{}
+	flow := &goyek.Flow{}
 	flow.DefaultTask = flow.Register(goyek.Task{Name: "task", Action: func(tf *goyek.TF) {}})
 	flow.RegisterBoolParam(goyek.BoolParam{Name: "unused"})
 
@@ -451,30 +451,30 @@ func Test_unused_params(t *testing.T) {
 }
 
 func Test_param_registration_error_empty_name(t *testing.T) {
-	flow := &goyek.Taskflow{}
+	flow := &goyek.Flow{}
 	assertPanics(t, func() { flow.RegisterBoolParam(goyek.BoolParam{Name: ""}) }, "empty name")
 }
 
 func Test_param_registration_error_underscore_name_start(t *testing.T) {
-	flow := &goyek.Taskflow{}
+	flow := &goyek.Flow{}
 	assertPanics(t, func() { flow.RegisterBoolParam(goyek.BoolParam{Name: "_reserved"}) }, "should not start with underscore")
 }
 
 func Test_param_registration_error_no_default(t *testing.T) {
-	flow := &goyek.Taskflow{}
+	flow := &goyek.Flow{}
 	assertPanics(t, func() { flow.RegisterValueParam(goyek.ValueParam{Name: "custom"}) }, "custom parameter must have default value factory")
 }
 
 func Test_param_registration_error_double_name(t *testing.T) {
-	flow := &goyek.Taskflow{}
+	flow := &goyek.Flow{}
 	name := "double"
 	flow.RegisterStringParam(goyek.StringParam{Name: name})
 	assertPanics(t, func() { flow.RegisterBoolParam(goyek.BoolParam{Name: name}) }, "double name")
 }
 
 func Test_unregistered_params(t *testing.T) {
-	foreignParam := (&goyek.Taskflow{}).RegisterBoolParam(goyek.BoolParam{Name: "foreign"})
-	flow := &goyek.Taskflow{}
+	foreignParam := (&goyek.Flow{}).RegisterBoolParam(goyek.BoolParam{Name: "foreign"})
+	flow := &goyek.Flow{}
 	flow.Register(goyek.Task{
 		Name: "task",
 		Action: func(tf *goyek.TF) {
@@ -488,7 +488,7 @@ func Test_unregistered_params(t *testing.T) {
 }
 
 func Test_defaultTask(t *testing.T) {
-	flow := &goyek.Taskflow{}
+	flow := &goyek.Flow{}
 	taskRan := false
 	task := flow.Register(goyek.Task{
 		Name: "task",
@@ -505,9 +505,9 @@ func Test_defaultTask(t *testing.T) {
 }
 
 func Test_wd_param(t *testing.T) {
-	flow := &goyek.Taskflow{}
+	flow := &goyek.Flow{}
 	beforeDir, err := os.Getwd()
-	requireEqual(t, err, nil, "should get work dir before the taskflow")
+	requireEqual(t, err, nil, "should get work dir before the flow")
 	dir, cleanup := tempDir(t)
 	defer cleanup()
 	var got string
@@ -522,17 +522,17 @@ func Test_wd_param(t *testing.T) {
 
 	exitCode := flow.Run(context.Background(), "task", "-wd", dir)
 	afterDir, err := os.Getwd()
-	requireEqual(t, err, nil, "should get work dir after the taskflow")
+	requireEqual(t, err, nil, "should get work dir after the flow")
 
 	assertEqual(t, exitCode, 0, "should pass")
-	assertEqual(t, got, dir, "should have changed the working directory in taskflow")
-	assertEqual(t, afterDir, beforeDir, "should change back the working directory after taskflow")
+	assertEqual(t, got, dir, "should have changed the working directory in flow")
+	assertEqual(t, afterDir, beforeDir, "should change back the working directory after flow")
 }
 
 func Test_wd_param_invalid(t *testing.T) {
-	flow := &goyek.Taskflow{}
+	flow := &goyek.Flow{}
 	beforeDir, err := os.Getwd()
-	requireEqual(t, err, nil, "should get work dir before the taskflow")
+	requireEqual(t, err, nil, "should get work dir before the flow")
 	taskRan := false
 	flow.Register(goyek.Task{
 		Name: "task",
@@ -543,15 +543,15 @@ func Test_wd_param_invalid(t *testing.T) {
 
 	exitCode := flow.Run(context.Background(), "task", "-wd=strange-dir")
 	afterDir, err := os.Getwd()
-	requireEqual(t, err, nil, "should get work dir after the taskflow")
+	requireEqual(t, err, nil, "should get work dir after the flow")
 
 	assertEqual(t, exitCode, goyek.CodeInvalidArgs, "should not proceed")
 	assertEqual(t, taskRan, false, "should not run the task")
-	assertEqual(t, afterDir, beforeDir, "should change back the working directory after taskflow")
+	assertEqual(t, afterDir, beforeDir, "should change back the working directory after flow")
 }
 
 func Test_introspection_API(t *testing.T) {
-	flow := &goyek.Taskflow{}
+	flow := &goyek.Flow{}
 	p := flow.RegisterStringParam(goyek.StringParam{Name: "string", Usage: "text param", Default: "dft"})
 	t1 := flow.Register(goyek.Task{Name: "one", Params: goyek.Params{p}})
 	flow.Register(goyek.Task{Name: "two", Usage: "action", Deps: goyek.Deps{t1}})

--- a/tf.go
+++ b/tf.go
@@ -23,7 +23,7 @@ type TF struct {
 	skipped     bool
 }
 
-// Context returns the taskflows' run context.
+// Context returns the flows' run context.
 func (tf *TF) Context() context.Context {
 	return tf.ctx
 }
@@ -40,14 +40,14 @@ func (tf *TF) Output() io.Writer {
 
 // Log formats its arguments using default formatting, analogous to Println,
 // and prints the text to Output. A final newline is added.
-// The text will be printed only if the task fails or taskflow is run in Verbose mode.
+// The text will be printed only if the task fails or flow is run in Verbose mode.
 func (tf *TF) Log(args ...interface{}) {
 	fmt.Fprintln(tf.writer, args...)
 }
 
 // Logf formats its arguments according to the format, analogous to Printf,
 // and prints the text to Output. A final newline is added.
-// The text will be printed only if the task fails or taskflow is run in Verbose mode.
+// The text will be printed only if the task fails or flow is run in Verbose mode.
 func (tf *TF) Logf(format string, args ...interface{}) {
 	fmt.Fprintf(tf.writer, format+"\n", args...)
 }
@@ -89,7 +89,7 @@ func (tf *TF) Fatalf(format string, args ...interface{}) {
 // FailNow marks the function as having failed
 // and stops its execution by calling runtime.Goexit
 // (which then runs all deferred calls in the current goroutine).
-// It finishes the whole taskflow.
+// It finishes the whole flow.
 func (tf *TF) FailNow() {
 	tf.Fail()
 	runtime.Goexit()
@@ -117,7 +117,7 @@ func (tf *TF) Skipf(format string, args ...interface{}) {
 // (which then runs all deferred calls in the current goroutine).
 // If a test fails (see Error, Errorf, Fail) and is then skipped,
 // it is still considered to have failed.
-// Taskflow will continue at the next task.
+// Flow will continue at the next task.
 func (tf *TF) SkipNow() {
 	tf.skipped = true
 	runtime.Goexit()


### PR DESCRIPTION
## Why

Partially addresses https://github.com/goyek/goyek/issues/62

## What

- Rename `Taskflow` type to `Flow` to simplify naming.

## Checklist

- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated.
- [x] The code changes follow [Effective Go](https://golang.org/doc/effective_go).