### PR TITLE
Add possibility to change the OOTB parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This release contains multiple **breaking changes** in the Go API. It is suppose
 
 - `Tf.Cmd` also sets `Stdin` to `os.Stdin`.
 - Add `Flow.Tasks` and `Flow.Params` to allow introspection of the registered tasks and parameters.
+- Add `NewFlow` to create a new flow with custom defaults for default parameters.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/goyek/goyek/compare/v0.6.0...HEAD)
 
+### Added
+
+- Add `RegisterVerboseParam` and `RegisterWorkDirParam` to overwrite default values for verbose and work dir parameters.
+
 ## [0.6.0](https://github.com/goyek/goyek/compare/v0.5.0...v0.6.0) - 2021-08-02
 
 This release contains multiple **breaking changes** in the Go API. It is supposed to make it cleaner.
@@ -15,7 +19,6 @@ This release contains multiple **breaking changes** in the Go API. It is suppose
 
 - `Tf.Cmd` also sets `Stdin` to `os.Stdin`.
 - Add `Flow.Tasks` and `Flow.Params` to allow introspection of the registered tasks and parameters.
-- Add `NewFlow` to create a new flow with custom defaults for default parameters.
 
 ### Changed
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Christian Haas, Robert Pająk
+Copyright (c) 2021 Christian Haas, Robert Pająk, Arno van Liere
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ If it is disabled, only logs from failed task are send to the output.
 Use [`func (f *Flow) VerboseParam() BoolParam`](https://pkg.go.dev/github.com/goyek/goyek#Flow.VerboseParam)
 if you need to check if verbose mode was set within a task's action.
 
-The default value for the verbose parameter can be overwritten with 
+The default value for the verbose parameter can be overwritten with
 [`func (f *Flow) RegisterVerboseParam(p BoolParam) RegisteredBoolParam`](https://pkg.go.dev/github.com/goyek/goyek#Flow.RegisterVerboseParam).
 
 ### Default task

--- a/README.md
+++ b/README.md
@@ -243,7 +243,8 @@ If it is disabled, only logs from failed task are send to the output.
 Use [`func (f *Flow) VerboseParam() BoolParam`](https://pkg.go.dev/github.com/goyek/goyek#Flow.VerboseParam)
 if you need to check if verbose mode was set within a task's action.
 
-When creating the flow with `NewFlow`, the default value for the verbose param can be set in the `Options`-struct.
+The default value for the verbose parameter can be overwritten with 
+[`func (f *Flow) RegisterVerboseParam(p BoolParam) RegisteredBoolParam`](https://pkg.go.dev/github.com/goyek/goyek#Flow.RegisterVerboseParam).
 
 ### Default task
 

--- a/README.md
+++ b/README.md
@@ -243,6 +243,8 @@ If it is disabled, only logs from failed task are send to the output.
 Use [`func (f *Flow) VerboseParam() BoolParam`](https://pkg.go.dev/github.com/goyek/goyek#Flow.VerboseParam)
 if you need to check if verbose mode was set within a task's action.
 
+When creating the flow with `NewFlow`, the default value for the verbose param can be set in the `Options`-struct.
+
 ### Default task
 
 Default task can be assigned via the [`Flow.DefaultTask`](https://pkg.go.dev/github.com/goyek/goyek#Flow.DefaultTask) field.

--- a/parameter.go
+++ b/parameter.go
@@ -76,7 +76,7 @@ func (p registeredParam) Usage() string {
 	return p.usage
 }
 
-// Default returns the parameter's default value formated as string.
+// Default returns the parameter's default value formatted as string.
 func (p registeredParam) Default() string {
 	return p.newValue().String()
 }

--- a/taskflow.go
+++ b/taskflow.go
@@ -27,8 +27,9 @@ var verboseParam = BoolParam{
 // Default work dir parameter, is registered in NewFlow or,
 // if NewFlow is not used, whenever the tasks are started
 var workDirParam = StringParam{
-	Name:  "wd",
-	Usage: "Working directory: set the working directory.",
+	Name:    "wd",
+	Usage:   "Working directory: set the working directory.",
+	Default: ".",
 }
 
 // Flow is the root type of the package.
@@ -70,8 +71,6 @@ func NewFlow(options *Options) *Flow {
 	workDir := workDirParam
 	if options != nil && options.WorkDir != "" {
 		workDir.Default = options.WorkDir
-	} else {
-		workDir.Default = "."
 	}
 
 	return flow
@@ -114,9 +113,7 @@ func (f *Flow) VerboseParam() RegisteredBoolParam {
 // WorkDirParam returns the out-of-the-box working directory parameter which controls the working directory.
 func (f *Flow) WorkDirParam() RegisteredStringParam {
 	if f.workDir == nil {
-		workDir := workDirParam
-		workDir.Default = "."
-		param := f.RegisterStringParam(workDir)
+		param := f.RegisterStringParam(workDirParam)
 		f.workDir = &param
 	}
 

--- a/taskflow.go
+++ b/taskflow.go
@@ -64,14 +64,16 @@ func NewFlow(options *Options) *Flow {
 	// Add verbose param
 	verbose := verboseParam
 	verbose.Default = options != nil && options.Verbose
-	param := flow.RegisterBoolParam(verbose)
-	flow.verbose = &param
+	registeredVerbose := flow.RegisterBoolParam(verbose)
+	flow.verbose = &registeredVerbose
 
 	// Add work dir param
 	workDir := workDirParam
 	if options != nil && options.WorkDir != "" {
 		workDir.Default = options.WorkDir
 	}
+	registeredWorkDir := flow.RegisterStringParam(workDir)
+	flow.workDir = &registeredWorkDir
 
 	return flow
 }

--- a/taskflow.go
+++ b/taskflow.go
@@ -17,25 +17,9 @@ const (
 	CodeInvalidArgs = 2
 )
 
-// Default verbose parameter, is registered in NewFlow or,
-// if NewFlow is not used, whenever the tasks are started
-var verboseParam = BoolParam{
-	Name:  "v",
-	Usage: "Verbose: log all tasks as they are run.",
-}
-
-// Default work dir parameter, is registered in NewFlow or,
-// if NewFlow is not used, whenever the tasks are started
-var workDirParam = StringParam{
-	Name:    "wd",
-	Usage:   "Working directory: set the working directory.",
-	Default: ".",
-}
-
 // Flow is the root type of the package.
-// Use NewFlow to create a flow, the Register
-// methods to register all tasks and Run or Main
-// method to execute provided tasks.
+// Use Register methods to register all tasks
+// and Run or Main method to execute provided tasks.
 type Flow struct {
 	Output io.Writer // output where text is printed; os.Stdout by default
 
@@ -45,37 +29,6 @@ type Flow struct {
 	workDir *RegisteredStringParam // sets the working directory
 	params  map[string]registeredParam
 	tasks   map[string]Task
-}
-
-// Options for a new flow
-type Options struct {
-	// Whether flow should be verbose or not, default false
-	Verbose bool
-	// The working directory of the flow. Default "."
-	WorkDir string
-}
-
-// NewFlow creates a new flow and adds the verbose and work dir
-// parameters. Default values for these parameters can be set
-// with the Options-struct which can optionally be passed.
-func NewFlow(options *Options) *Flow {
-	flow := &Flow{}
-
-	// Add verbose param
-	verbose := verboseParam
-	verbose.Default = options != nil && options.Verbose
-	registeredVerbose := flow.RegisterBoolParam(verbose)
-	flow.verbose = &registeredVerbose
-
-	// Add work dir param
-	workDir := workDirParam
-	if options != nil && options.WorkDir != "" {
-		workDir.Default = options.WorkDir
-	}
-	registeredWorkDir := flow.RegisterStringParam(workDir)
-	flow.workDir = &registeredWorkDir
-
-	return flow
 }
 
 // Tasks returns all registered tasks.
@@ -103,22 +56,46 @@ func (f *Flow) Params() []RegisteredParam {
 }
 
 // VerboseParam returns the out-of-the-box verbose parameter which controls the output behavior.
+// This can be overridden with RegisterVerboseParam.
 func (f *Flow) VerboseParam() RegisteredBoolParam {
 	if f.verbose == nil {
-		param := f.RegisterBoolParam(verboseParam)
+		param := f.RegisterBoolParam(BoolParam{
+			Name:  "v",
+			Usage: "Verbose: log all tasks as they are run.",
+		})
 		f.verbose = &param
 	}
 
 	return *f.verbose
 }
 
+// RegisterVerboseParam overwrites the default name, usage and value for the verbose parameter.
+// If this function is used, the default 'v' parameter will be replaced with this parameter.
+func (f *Flow) RegisterVerboseParam(p BoolParam) RegisteredBoolParam {
+	param := f.RegisterBoolParam(p)
+	f.verbose = &param
+	return *f.verbose
+}
+
 // WorkDirParam returns the out-of-the-box working directory parameter which controls the working directory.
 func (f *Flow) WorkDirParam() RegisteredStringParam {
 	if f.workDir == nil {
-		param := f.RegisterStringParam(workDirParam)
+		param := f.RegisterStringParam(StringParam{
+			Name:    "wd",
+			Usage:   "Working directory: set the working directory.",
+			Default: ".",
+		})
 		f.workDir = &param
 	}
 
+	return *f.workDir
+}
+
+// RegisterWorkDirParam overwrites the default name, usage and value for the work dir parameter.
+// If this function is used, the default 'wd' parameter will be replaced with this parameter.
+func (f *Flow) RegisterWorkDirParam(p StringParam) RegisteredStringParam {
+	param := f.RegisterStringParam(p)
+	f.workDir = &param
 	return *f.workDir
 }
 


### PR DESCRIPTION
## Why
I wanted a method to set the default values for OOTB params which wasn't possible, because if you tried to register a verbose parameter again, goyek would panic because it was already registered.

## What
I added a new method to create a flow (`NewFlow`) which accepts an `Options`-struct in which the defaults can be set.

## Checklist
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated.
- [x] The code changes follow [Effective Go](https://golang.org/doc/effective_go).
