### PR TITLE
Draft: Option to mark params as required

### DIFF
--- a/examples/parameters/main.go
+++ b/examples/parameters/main.go
@@ -94,6 +94,10 @@ func (value *complexParamValue) IsBool() bool {
 	return false
 }
 
+func (value *complexParamValue) IsSet() bool {
+	return value.StringValue != ""
+}
+
 // taskComplexParam showcases complex parameters, JSON encoded.
 //
 // Execute `go run . -v complex -json "{\"stringValue\":\"abc\"}"` as an example.
@@ -140,6 +144,10 @@ func (value *listParamValue) String() string {
 
 func (value *listParamValue) IsBool() bool {
 	return false
+}
+
+func (value *listParamValue) IsSet() bool {
+	return value != nil && *value != nil
 }
 
 // taskListParam showcases repeatable parameters.

--- a/flow_runner.go
+++ b/flow_runner.go
@@ -186,11 +186,7 @@ func (f *flowRunner) run(ctx context.Context, name string, executed map[string]b
 	return nil
 }
 
-func (f *flowRunner) runTask(ctx context.Context, task Task) bool {
-	if task.Action == nil {
-		return true
-	}
-
+func (f *flowRunner) getParamValues(task Task) (map[string]ParamValue, bool) {
 	// set all the param values and check if the required params have a value
 	var errStr string
 	paramValues := make(map[string]ParamValue)
@@ -200,8 +196,20 @@ func (f *flowRunner) runTask(ctx context.Context, task Task) bool {
 			errStr += fmt.Sprintf("param %q is required\n", param.Name())
 		}
 	}
-	if errStr != "" {
-		fmt.Print(errStr)
+	if errStr == "" {
+		return paramValues, true
+	}
+	fmt.Print(errStr)
+	return nil, false
+}
+
+func (f *flowRunner) runTask(ctx context.Context, task Task) bool {
+	if task.Action == nil {
+		return true
+	}
+
+	paramValues, ok := f.getParamValues(task)
+	if !ok {
 		return false
 	}
 

--- a/flow_runner.go
+++ b/flow_runner.go
@@ -191,9 +191,18 @@ func (f *flowRunner) runTask(ctx context.Context, task Task) bool {
 		return true
 	}
 
+	// set all the param values and check if the required params have a value
+	var errStr string
 	paramValues := make(map[string]ParamValue)
 	for _, param := range task.Params {
 		paramValues[param.Name()] = f.paramValues[param.Name()]
+		if param.Required() && !f.paramValues[param.Name()].IsSet() {
+			errStr += fmt.Sprintf("param %q is required\n", param.Name())
+		}
+	}
+	if errStr != "" {
+		fmt.Print(errStr)
+		return false
 	}
 
 	// if verbose flag is registered then check its value
@@ -280,7 +289,7 @@ func printUsage(f *flowRunner) {
 	sort.Strings(keys)
 	for _, key := range keys {
 		param := f.params[key]
-		fmt.Fprintf(w, "  %s\tDefault: %s\t%s\n", flagName(param.name), param.newValue().String(), param.usage)
+		fmt.Fprintf(w, "  %s\tDefault: %s\tRequired: %v\t%s\n", flagName(param.name), param.newValue().String(), param.required, param.usage)
 	}
 	w.Flush() //nolint // not checking errors when writing to output
 

--- a/parameter.go
+++ b/parameter.go
@@ -89,7 +89,7 @@ func (p registeredParam) Default() string {
 	return p.newValue().String()
 }
 
-// Required returns whether the parameter is required
+// Required returns whether the parameter is required.
 func (p registeredParam) Required() bool {
 	return p.required
 }

--- a/taskflow.go
+++ b/taskflow.go
@@ -109,6 +109,7 @@ func (f *Flow) RegisterValueParam(p ValueParam) RegisteredValueParam {
 		name:     p.Name,
 		usage:    p.Usage,
 		newValue: p.NewValue,
+		required: p.Required,
 	}
 	f.registerParam(regParam)
 	return RegisteredValueParam{regParam}
@@ -117,13 +118,13 @@ func (f *Flow) RegisterValueParam(p ValueParam) RegisteredValueParam {
 // RegisterBoolParam registers a boolean parameter.
 func (f *Flow) RegisterBoolParam(p BoolParam) RegisteredBoolParam {
 	valGetter := func() ParamValue {
-		value := boolValue(p.Default)
-		return &value
+		return &boolValue{value: p.Default}
 	}
 	f.registerParam(registeredParam{
 		name:     p.Name,
 		usage:    p.Usage,
 		newValue: valGetter,
+		required: p.Required,
 	})
 	return RegisteredBoolParam{registeredParam{name: p.Name}}
 }
@@ -131,13 +132,13 @@ func (f *Flow) RegisterBoolParam(p BoolParam) RegisteredBoolParam {
 // RegisterIntParam registers an integer parameter.
 func (f *Flow) RegisterIntParam(p IntParam) RegisteredIntParam {
 	valGetter := func() ParamValue {
-		value := intValue(p.Default)
-		return &value
+		return &intValue{value: p.Default}
 	}
 	regParam := registeredParam{
 		name:     p.Name,
 		usage:    p.Usage,
 		newValue: valGetter,
+		required: p.Required,
 	}
 	f.registerParam(regParam)
 	return RegisteredIntParam{regParam}
@@ -146,13 +147,13 @@ func (f *Flow) RegisterIntParam(p IntParam) RegisteredIntParam {
 // RegisterStringParam registers a string parameter.
 func (f *Flow) RegisterStringParam(p StringParam) RegisteredStringParam {
 	valGetter := func() ParamValue {
-		value := stringValue(p.Default)
-		return &value
+		return &stringValue{value: p.Default}
 	}
 	regParam := registeredParam{
 		name:     p.Name,
 		usage:    p.Usage,
 		newValue: valGetter,
+		required: p.Required,
 	}
 	f.registerParam(regParam)
 	return RegisteredStringParam{regParam}

--- a/taskflow_test.go
+++ b/taskflow_test.go
@@ -383,6 +383,8 @@ func (value *arrayValue) String() string {
 
 func (value *arrayValue) IsBool() bool { return false }
 
+func (value *arrayValue) IsSet() bool { return value != nil }
+
 func Test_params(t *testing.T) {
 	flow := &goyek.Flow{}
 	boolParam := flow.RegisterBoolParam(goyek.BoolParam{


### PR DESCRIPTION
## Why
Params could not be marked as required, so for every parameter you had to check whether it had a value or not inside the task handler. It seems like basic functionality for a task runner to be able to mark params as required.

## What
It is a draft pull request to get feedback on the way I've set the validation up. I've made it so only the params which are used in the task which is being run, are checked whether they are required. All params which are required, but not set, are printed and the task fails.

If a maintainer or other contributor thinks this is the right direction for such a feature, I will write tests, update the `CHANGELOG` etc, but I wanted to have feedback first.

## Checklist
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated.
- [x] The code changes follow [Effective Go](https://golang.org/doc/effective_go).
- [ ] The code changes are covered by tests.
