### PR TITLE
Remove Slack channel in favor of GitHub discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@
 [![codecov](https://codecov.io/gh/goyek/goyek/branch/main/graph/badge.svg)](https://codecov.io/gh/goyek/goyek)
 [![Mentioned in Awesome Go](https://awesome.re/mentioned-badge.svg)](https://github.com/avelino/awesome-go)
 
-[![Slack](https://img.shields.io/badge/slack-@gophers/goyek-brightgreen.svg?logo=slack)](https://gophers.slack.com/archives/C020UNUK7LL)
-
 Please ⭐ `Star` this repository if you find it valuable and worth maintaining.
 
 **Be aware that `goyek` is still in `v0` phase, and the API is still in flux.** As per [Go module version numbering](https://golang.org/doc/modules/version-numbers), you can use released versions for your projects, yet there is the potential for breaking changes in later releases. We anticipate a `v1` release for a stable API. It is not yet clear when this will happen.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -7,8 +7,6 @@ Feel free to start or join a [discussion](https://github.com/goyek/goyek/discuss
 create an [issue](https://github.com/goyek/goyek/issues),
 or propose a [pull request](https://github.com/goyek/goyek/pulls).
 
-You can also find us on [Gophers Slack](https://invite.slack.golangbridge.org/) in [`#goyek` channel](https://gophers.slack.com/archives/C020UNUK7LL).
-
 ## Developing
 
 Go and Docker is required.


### PR DESCRIPTION
GitHub discussions seem to be favored 