### PR TITLE
Support + and : in task and parameter names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/goyek/goyek/compare/v0.6.2...HEAD)
 
+### Added
+
+- `TaskNamePattern` and `ParamNamePattern` has been changes so that
+  the plus (`+`) and colon (`:`) characters can used
+  as in the task and parameter name (but not as the first character).
+  
 ## [0.6.2](https://github.com/goyek/goyek/compare/v0.6.1...v0.6.2) - 2022-01-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -180,14 +180,15 @@ exit $global:LASTEXITCODE
 ### Task registration
 
 The registered tasks are required to have a non-empty name, matching
-the regular expression `^[a-zA-Z0-9_][a-zA-Z0-9_-]*$`, available as
-[`TaskNamePattern`](https://pkg.go.dev/github.com/goyek/goyek#TaskNamePattern).
+the regular expression [`TaskNamePattern`](https://pkg.go.dev/github.com/goyek/goyek#TaskNamePattern).
 This means the following are acceptable:
 
 - letters (`a-z` and `A-Z`)
 - digits (`0-9`)
 - underscore (`_`)
-- hyphens (`-`) - except at the beginning
+- hyphen (`-`) - except at the beginning
+- plus (`+`) - except at the beginning
+- colon (`:`) - except at the beginning
 
 A task with a given name can be only registered once.
 
@@ -287,14 +288,15 @@ Parameters must first be registered via
 or one of the provided methods like [`RegisterStringParam`](https://pkg.go.dev/github.com/goyek/goyek#Flow.RegisterStringParam).
 
 The registered parameters are required to have a non-empty name, matching
-the regular expression `^[a-zA-Z0-9][a-zA-Z0-9_-]*$`, available as
-[`ParamNamePattern`](https://pkg.go.dev/github.com/goyek/goyek#ParamNamePattern).
+the regular expression [`ParamNamePattern`](https://pkg.go.dev/github.com/goyek/goyek#ParamNamePattern).
 This means the following are acceptable:
 
 - letters (`a-z` and `A-Z`)
 - digits (`0-9`)
 - underscore (`_`) - except at the beginning
-- hyphens (`-`) - except at the beginning
+- hyphen (`-`) - except at the beginning
+- plus (`+`) - except at the beginning
+- colon (`:`) - except at the beginning
 
 After registration, tasks need to specify which parameters they will read.
 Do this by assigning the [`RegisteredParam`](https://pkg.go.dev/github.com/goyek/goyek#RegisteredParam)

--- a/taskflow.go
+++ b/taskflow.go
@@ -17,6 +17,19 @@ const (
 	CodeInvalidArgs = 2
 )
 
+const (
+	// TaskNamePattern describes the regular expression a task name must match.
+	TaskNamePattern = "^[a-zA-Z0-9_]([a-zA-Z0-9_+-]|:)*$"
+
+	// ParamNamePattern describes the regular expression a parameter name must match.
+	ParamNamePattern = "^[a-zA-Z0-9]([a-zA-Z0-9_+-]|:)*$"
+)
+
+var (
+	taskNameRegex  = regexp.MustCompile(TaskNamePattern)
+	paramNameRegex = regexp.MustCompile(ParamNamePattern)
+)
+
 // Flow is the root type of the package.
 // Use Register methods to register all tasks
 // and Run or Main method to execute provided tasks.
@@ -158,11 +171,6 @@ func (f *Flow) RegisterStringParam(p StringParam) RegisteredStringParam {
 	return RegisteredStringParam{regParam}
 }
 
-// ParamNamePattern describes the regular expression a parameter name must match.
-const ParamNamePattern = "^[a-zA-Z0-9][a-zA-Z0-9_-]*$"
-
-var paramNameRegex = regexp.MustCompile(ParamNamePattern)
-
 func (f *Flow) registerParam(p registeredParam) {
 	if !paramNameRegex.MatchString(p.name) {
 		panic("parameter name must match ParamNamePattern")
@@ -178,11 +186,6 @@ func (f *Flow) registerParam(p registeredParam) {
 	}
 	f.params[p.name] = p
 }
-
-// TaskNamePattern describes the regular expression a task name must match.
-const TaskNamePattern = "^[a-zA-Z0-9_][a-zA-Z0-9_-]*$"
-
-var taskNameRegex = regexp.MustCompile(TaskNamePattern)
 
 // Register registers the task. It panics in case of any error.
 func (f *Flow) Register(task Task) RegisteredTask {


### PR DESCRIPTION
## Why

Addresses #153

## What

Add support for using `+` and `:` characters in task and parameter names.

## Checklist

<!-- All items should be verified and marked as done.
     If an item doesn't apply to the introduced changes - check it as done too. -->

- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated.
- [x] The code changes follow [Effective Go](https://golang.org/doc/effective_go).
- [ ] The code changes are covered by tests.

<!-- markdownlint-disable-file MD041 -->
