### PR TITLE
Release v0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/goyek/goyek/compare/v0.6.2...HEAD)
+## [Unreleased](https://github.com/goyek/goyek/compare/v0.6.3...HEAD)
+
+## [0.6.3](https://github.com/goyek/goyek/compare/v0.6.2...v0.6.3) - 2022-02-23
 
 ### Added
 
-- `TaskNamePattern` and `ParamNamePattern` has been changes so that
-  the plus (`+`) and colon (`:`) characters can used
-  as in the task and parameter name (but not as the first character).
+- `TaskNamePattern` and `ParamNamePattern` has been changed so that
+  the plus (`+`) and colon (`:`) characters can be used
+  in the task and parameter name (but not as the first character).
   
 ## [0.6.2](https://github.com/goyek/goyek/compare/v0.6.1...v0.6.2) - 2022-01-25
 

--- a/build/go.mod
+++ b/build/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/client9/misspell v0.3.4
 	github.com/golangci/golangci-lint v1.44.2
-	github.com/goyek/goyek v0.6.2
+	github.com/goyek/goyek v0.6.3
 	golang.org/x/tools v0.1.9
 	mvdan.cc/gofumpt v0.2.1
 )


### PR DESCRIPTION
### Added

- `TaskNamePattern` and `ParamNamePattern` has been changed so that
  the plus (`+`) and colon (`:`) characters can be used
  in the task and parameter name (but not as the first character).