### PR TITLE
Bump markdownlintcli to v0.32.0

### DIFF
--- a/build/versions.go
+++ b/build/versions.go
@@ -1,5 +1,5 @@
 package main
 
 const (
-	markdownlintCliVersion = "v0.31.1"
+	markdownlintCliVersion = "v0.32.0"
 )


### PR DESCRIPTION
## Why

https://github.com/igorshubovych/markdownlint-cli/releases/tag/v0.32.0

## What

Bump markdownlintcli to v0.32.0
