### PR TITLE
Use dependabot to bump docker images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,11 @@ updates:
     schedule:
       interval: "weekly"
 
+  - package-ecosystem: "docker"
+    directory: "/build"
+    schedule:
+      interval: "weekly"
+
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/build/build.go
+++ b/build/build.go
@@ -112,8 +112,13 @@ func taskMarkdownLint() goyek.Task {
 				tf.Fatal(err)
 			}
 
-			if err := tf.Cmd("docker", "run", "--rm", "-v", curDir+":/workdir", "ghcr.io/igorshubovych/markdownlint-cli:"+markdownlintCliVersion, "**/*.md", ".github/**/*.md").Run(); err != nil {
-				tf.Error(err)
+			dockerTag := "markdownlint-cli"
+			if err := tf.Cmd("docker", "build", "-t", dockerTag, "-f", "build/markdownlint-cli.dockerfile", ".").Run(); err != nil {
+				tf.Fatal(err)
+			}
+
+			if err := tf.Cmd("docker", "run", "--rm", "-v", curDir+":/workdir", dockerTag, "**/*.md").Run(); err != nil {
+				tf.Fatal(err)
 			}
 		},
 	}

--- a/build/markdownlint-cli.dockerfile
+++ b/build/markdownlint-cli.dockerfile
@@ -1,0 +1,1 @@
+FROM ghcr.io/igorshubovych/markdownlint-cli:v0.32.0

--- a/build/versions.go
+++ b/build/versions.go
@@ -1,5 +1,0 @@
-package main
-
-const (
-	markdownlintCliVersion = "v0.32.0"
-)


### PR DESCRIPTION
## Why

Use dependabot for bumping markdownlint-cli to avoid manual work as well as decrease the possibility to miss an update.

## What

- Create Dockerfile for markdownlint-cli and use it in build pipeline
- Configure dependabot to bump Dockerfiles inside /build directory.

## Checklist

<!-- All items should be verified and marked as done.
     If an item doesn't apply to the introduced changes - check it as done too. -->

- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated.
- [x] The code changes follow [Effective Go](https://golang.org/doc/effective_go).
- [x] The code changes are covered by tests.

<!-- markdownlint-disable-file MD041 -->
