### PR TITLE
Remove TF.Cmd undocumented behavior and fix panic printing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 - The `TF` methods `Log[f]`, `Error[f]`, `Fatal[f]`, `Skip[f]`, `Cmd`
   prints indented text with a prefix containing file and line information.
 
+### Fixed
+
+- `TF.Cmd` undocumented behavior (printing command name and arguments)
+  is removed.
+
 ## [1.0.0](https://github.com/goyek/goyek/compare/v0.6.3...v1.0.0) - 2022-09-08
 
 This is the first stable release.
@@ -49,7 +54,7 @@ It is supposed to make it cleaner.
 
 ### Added
 
-- `Tf.Cmd` also sets `Stdin` to `os.Stdin`.
+- `TF.Cmd` also sets `Stdin` to `os.Stdin`.
 - Add `Flow.Tasks` and `Flow.Params` to allow introspection
   of the registered tasks and parameters.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 
 ### Fixed
 
-- `TF.Cmd` undocumented behavior is removed
+- Remove `TF.Cmd` undocumented behavior 
   (printing command name and arguments).
 
 ## [1.0.0](https://github.com/goyek/goyek/compare/v0.6.3...v1.0.0) - 2022-09-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 
 ### Fixed
 
-- Remove `TF.Cmd` undocumented behavior 
+- Remove `TF.Cmd` undocumented behavior
   (printing command name and arguments).
 
 ## [1.0.0](https://github.com/goyek/goyek/compare/v0.6.3...v1.0.0) - 2022-09-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 
 ### Fixed
 
-- `TF.Cmd` undocumented behavior (printing command name and arguments)
-  is removed.
+- `TF.Cmd` undocumented behavior is removed
+  (printing command name and arguments).
 
 ## [1.0.0](https://github.com/goyek/goyek/compare/v0.6.3...v1.0.0) - 2022-09-08
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Here are some good parts:
   - [`github.com/rjeczalik/notify`](https://pkg.go.dev/github.com/rjeczalik/notify)
   - [`github.com/magefile/mage/target`](https://pkg.go.dev/github.com/magefile/mage/target)
   - [`github.com/mattn/go-shellwords`](https://pkg.go.dev/github.com/mattn/go-shellwords)
-- Tasks and helpers can be unit tested.
+- Tasks and helpers can be unit tested. For example, see [cmd_test.go](cmd_test.go).
 - [`github.com/goyek/goyek` package](go.mod) does not use any third-party dependency
   other than the Go standard library.
 

--- a/README.md
+++ b/README.md
@@ -213,22 +213,15 @@ import (
 	"github.com/mattn/go-shellwords"
 )
 
-func Cmd(tf *goyek.TF, cmdLine string) *exec.Cmd {
-	args, err := shellwords.Parse(cmdLine)
-	if err != nil {
-		tf.Fatalf("parse command line: %v", err)
-	}
-	return tf.Cmd(args[0], args[1:]...)
-}
-
 func Exec(cmdLine string) func(tf *goyek.TF) {
 	args, err := shellwords.Parse(cmdLine)
 	if err != nil {
 		panic(fmt.Sprintf("parse command line: %v", err))
 	}
 	return func(tf *goyek.TF) {
+    tf.Logf("Run '%s'", cmdLine)
 		if err := tf.Cmd(args[0], args[1:]...).Run(); err != nil {
-			tf.Fatal(err)
+			tf.Error(err)
 		}
 	}
 }

--- a/build/exec.go
+++ b/build/exec.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/goyek/goyek"
+)
+
+// Exec runs the command in given directory.
+func Exec(tf *goyek.TF, workDir, cmdLine string) error {
+	tf.Logf("Run '%s' in %s", cmdLine, workDir)
+	args := strings.Split(cmdLine, " ")
+	cmd := tf.Cmd(args[0], args[1:]...)
+	cmd.Dir = workDir
+	return cmd.Run()
+}

--- a/cmd.go
+++ b/cmd.go
@@ -3,16 +3,12 @@ package goyek
 import (
 	"os"
 	"os/exec"
-	"strings"
 )
 
 // Cmd is like exec.Command, but it assigns tf's context
 // and assigns Stdout and Stderr to tf's output,
 // and Stdin to os.Stdin.
 func (tf *TF) Cmd(name string, args ...string) *exec.Cmd {
-	cmdStr := strings.Join(append([]string{name}, args...), " ")
-	tf.logf("Cmd: %s", cmdStr)
-
 	cmd := exec.CommandContext(tf.Context(), name, args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = tf.Output()

--- a/task_runner.go
+++ b/task_runner.go
@@ -1,7 +1,8 @@
 package goyek
 
 import (
-	"runtime/debug"
+	"fmt"
+	"io"
 	"time"
 )
 
@@ -22,8 +23,11 @@ func (r taskRunner) Run(tf *TF, action func(tf *TF)) runResult {
 		from := time.Now()
 		defer func() {
 			if r := recover(); r != nil {
-				tf.Errorf("panic: %v", r)
-				tf.Log(string(debug.Stack()))
+				txt := fmt.Sprintf("panic: %v", r)
+				const skipUntilPanic = 3
+				txt = tf.decorate(txt, skipUntilPanic)
+				io.WriteString(tf.writer, txt) //nolint // not checking errors when writing to output
+				tf.failed = true
 			}
 			result := runResult{
 				Failed:   tf.failed,


### PR DESCRIPTION
## Why

Fix flaws in printing output.

## What

- TF.Cmd no longer prints.
- Fix printing for panic.
- Refactor the build pipeline.