### PR TITLE
Release 2.0.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 as well as to [Module version numbering](https://go.dev/doc/modules/version-numbers).
 
-## [Unreleased](https://github.com/goyek/goyek/compare/v1.1.0...HEAD)
+## [Unreleased](https://github.com/goyek/goyek/compare/v2.0.0-rc.1...HEAD)
+
+## [2.0.0-rc.1](https://github.com/goyek/goyek/compare/v1.1.0...v2.0.0-rc.1) - 2022-10-14
 
 This release contains **breaking changes** in the Go API.
 It focuses on improving customization mainly by removing the parameters API.
@@ -26,7 +28,7 @@ It gives the user the possibility of parsing the input.
 
 - Remove parameters API and out-of-the-box flags (`-v`, `-wd`).
 
-## [1.1.0](https://github.com/goyek/goyek/compare/v1.0.0...v1.1.0) - 2022-10-13
+## [1.1.0](https://github.com/goyek/goyek/compare/v1.0.0...v1.1.0) - 2022-10-12
 
 This release focuses on improving output printing.
 There are no API changes.

--- a/build/go.mod
+++ b/build/go.mod
@@ -2,6 +2,6 @@ module github.com/goyek/goyek/build
 
 go 1.19
 
-require github.com/goyek/goyek/v2 v2.0.0
+require github.com/goyek/goyek/v2 v2.0.0-rc.1
 
 replace github.com/goyek/goyek/v2 => ../


### PR DESCRIPTION
This release contains **breaking changes** in the Go API.
It focuses on improving customization mainly by removing the parameters API.
It gives the user the possibility of parsing the input.

### Added

- Add `Flow.Verbose` for controlling the verbose mode.
- Add `Flow.Print` for printing the flow usage.
- `Flow.Main` now exits on receiving the second SIGINT.

### Changed

- `RegisteredTask.Deps` returns `[]string` (dependency names) for easier introspection.

### Removed

- Remove parameters API and out-of-the-box flags (`-v`, `-wd`).