### PR TITLE
Change Register to Define

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 
 - `Flow.Usage` (or `Flow.Print` if it is `nil`)
   is called when `Flow.Run` returns `CodeInvalidArgs`.
+- Rename `Flow.Register` to `Flow.Define`.
+- Change `Flow.RegisteredTask` to selead interface `Flow.DefinedTask`.
 
 ## [2.0.0-rc.1](https://github.com/goyek/goyek/compare/v1.1.0...v2.0.0-rc.1) - 2022-10-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 - `Flow.Usage` (or `Flow.Print` if it is `nil`)
   is called when `Flow.Run` returns `CodeInvalidArgs`.
 - Rename `Flow.Register` to `Flow.Define`.
-- Change `Flow.RegisteredTask` to selead interface `Flow.DefinedTask`.
+- Change `Flow.RegisteredTask` to sealed interface `Flow.DefinedTask`.
 
 ## [2.0.0-rc.1](https://github.com/goyek/goyek/compare/v1.1.0...v2.0.0-rc.1) - 2022-10-14
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ import (
 func main() {
 	flow := &goyek.Flow{Verbose: true}
 
-	flow.Register(goyek.Task{
+	flow.Define(goyek.Task{
 		Name:  "hello",
 		Usage: "demonstration",
 		Action: func(tf *goyek.TF) {

--- a/build/build.go
+++ b/build/build.go
@@ -16,23 +16,23 @@ func configure() {
 	ci := flag.Bool("ci", false, "whether CI is calling")
 
 	// tasks
-	clean := flow.Register(taskClean())
-	modTidy := flow.Register(taskModTidy())
-	install := flow.Register(taskInstall())
-	build := flow.Register(taskBuild())
-	markdownlint := flow.Register(taskMarkdownLint())
-	misspell := flow.Register(taskMisspell())
-	golangciLint := flow.Register(taskGolangciLint())
-	test := flow.Register(taskTest())
-	diff := flow.Register(taskDiff(ci))
+	clean := flow.Define(taskClean())
+	modTidy := flow.Define(taskModTidy())
+	install := flow.Define(taskInstall())
+	build := flow.Define(taskBuild())
+	markdownlint := flow.Define(taskMarkdownLint())
+	misspell := flow.Define(taskMisspell())
+	golangciLint := flow.Define(taskGolangciLint())
+	test := flow.Define(taskTest())
+	diff := flow.Define(taskDiff(ci))
 
 	// pipelines
-	lint := flow.Register(taskLint(goyek.Deps{
+	lint := flow.Define(taskLint(goyek.Deps{
 		misspell,
 		markdownlint,
 		golangciLint,
 	}))
-	all := flow.Register(taskAll(goyek.Deps{
+	all := flow.Define(taskAll(goyek.Deps{
 		clean,
 		modTidy,
 		install,

--- a/example_test.go
+++ b/example_test.go
@@ -13,14 +13,14 @@ func Example() {
 	flow := &goyek.Flow{Output: os.Stdout}
 	flag.CommandLine.SetOutput(os.Stdout)
 
-	// register a flag to configure flow verbosity
+	// define a flag to configure flow verbosity
 	flag.BoolVar(&flow.Verbose, "v", true, "print all tasks as they are run")
 
-	// register a flag used by a task
+	// define a flag used by a task
 	msg := flag.String("msg", "hello world", `message to display by "hi" task`)
 
-	// register a task printing the message (configurable via flag)
-	hi := flow.Register(goyek.Task{
+	// define a task printing the message (configurable via flag)
+	hi := flow.Define(goyek.Task{
 		Name:  "hi",
 		Usage: "Greetings",
 		Action: func(tf *goyek.TF) {
@@ -28,8 +28,8 @@ func Example() {
 		},
 	})
 
-	// register a task running a command
-	goVer := flow.Register(goyek.Task{
+	// define a task running a command
+	goVer := flow.Define(goyek.Task{
 		Name:  "go-ver",
 		Usage: `Run "go version"`,
 		Action: func(tf *goyek.TF) {
@@ -39,8 +39,8 @@ func Example() {
 		},
 	})
 
-	// register a pipeline
-	all := flow.Register(goyek.Task{
+	// define a pipeline
+	all := flow.Define(goyek.Task{
 		Name: "all",
 		Deps: goyek.Deps{hi, goVer},
 	})

--- a/flow_test.go
+++ b/flow_test.go
@@ -13,7 +13,7 @@ import (
 func Test_Register_empty_name(t *testing.T) {
 	flow := &goyek.Flow{Output: &strings.Builder{}}
 
-	act := func() { flow.Register(goyek.Task{}) }
+	act := func() { flow.Define(goyek.Task{}) }
 
 	assertPanics(t, act, "should panic")
 }
@@ -21,9 +21,9 @@ func Test_Register_empty_name(t *testing.T) {
 func Test_Register_same_name(t *testing.T) {
 	flow := &goyek.Flow{Output: &strings.Builder{}}
 	task := goyek.Task{Name: "task"}
-	flow.Register(task)
+	flow.Define(task)
 
-	act := func() { flow.Register(task) }
+	act := func() { flow.Define(task) }
 
 	assertPanics(t, act, "should not be possible to register tasks with same name twice")
 }
@@ -32,14 +32,14 @@ func Test_successful(t *testing.T) {
 	ctx := context.Background()
 	flow := &goyek.Flow{Output: &strings.Builder{}}
 	var executed1 int
-	task1 := flow.Register(goyek.Task{
+	task1 := flow.Define(goyek.Task{
 		Name: "task-1",
 		Action: func(*goyek.TF) {
 			executed1++
 		},
 	})
 	var executed2 int
-	flow.Register(goyek.Task{
+	flow.Define(goyek.Task{
 		Name: "task-2",
 		Action: func(*goyek.TF) {
 			executed2++
@@ -47,7 +47,7 @@ func Test_successful(t *testing.T) {
 		Deps: goyek.Deps{task1},
 	})
 	var executed3 int
-	flow.Register(goyek.Task{
+	flow.Define(goyek.Task{
 		Name: "task-3",
 		Action: func(*goyek.TF) {
 			executed3++
@@ -74,7 +74,7 @@ func Test_successful(t *testing.T) {
 func Test_dependency_failure(t *testing.T) {
 	flow := &goyek.Flow{Output: &strings.Builder{}}
 	var executed1 int
-	task1 := flow.Register(goyek.Task{
+	task1 := flow.Define(goyek.Task{
 		Name: "task-1",
 		Action: func(tf *goyek.TF) {
 			executed1++
@@ -85,7 +85,7 @@ func Test_dependency_failure(t *testing.T) {
 		},
 	})
 	var executed2 int
-	flow.Register(goyek.Task{
+	flow.Define(goyek.Task{
 		Name: "task-2",
 		Action: func(*goyek.TF) {
 			executed2++
@@ -93,7 +93,7 @@ func Test_dependency_failure(t *testing.T) {
 		Deps: goyek.Deps{task1},
 	})
 	var executed3 int
-	flow.Register(goyek.Task{
+	flow.Define(goyek.Task{
 		Name: "task-3",
 		Action: func(*goyek.TF) {
 			executed3++
@@ -113,7 +113,7 @@ func Test_dependency_failure(t *testing.T) {
 func Test_fail(t *testing.T) {
 	flow := &goyek.Flow{Output: &strings.Builder{}}
 	failed := false
-	flow.Register(goyek.Task{
+	flow.Define(goyek.Task{
 		Name: "task",
 		Action: func(tf *goyek.TF) {
 			defer func() {
@@ -132,7 +132,7 @@ func Test_fail(t *testing.T) {
 func Test_skip(t *testing.T) {
 	flow := &goyek.Flow{Output: &strings.Builder{}}
 	skipped := false
-	flow.Register(goyek.Task{
+	flow.Define(goyek.Task{
 		Name: "task",
 		Action: func(tf *goyek.TF) {
 			defer func() {
@@ -150,7 +150,7 @@ func Test_skip(t *testing.T) {
 
 func Test_task_panics(t *testing.T) {
 	flow := &goyek.Flow{Output: &strings.Builder{}}
-	flow.Register(goyek.Task{
+	flow.Define(goyek.Task{
 		Name: "task",
 		Action: func(tf *goyek.TF) {
 			panic("panicked!")
@@ -166,7 +166,7 @@ func Test_cancelation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	flow := &goyek.Flow{Output: &strings.Builder{}}
-	flow.Register(goyek.Task{
+	flow.Define(goyek.Task{
 		Name: "task",
 	})
 
@@ -179,7 +179,7 @@ func Test_cancelation_during_last_task(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	flow := &goyek.Flow{Output: &strings.Builder{}}
-	flow.Register(goyek.Task{
+	flow.Define(goyek.Task{
 		Name: "task",
 		Action: func(tf *goyek.TF) {
 			cancel()
@@ -193,7 +193,7 @@ func Test_cancelation_during_last_task(t *testing.T) {
 
 func Test_empty_action(t *testing.T) {
 	flow := &goyek.Flow{Output: &strings.Builder{}}
-	flow.Register(goyek.Task{
+	flow.Define(goyek.Task{
 		Name: "task",
 	})
 
@@ -235,13 +235,13 @@ func Test_printing(t *testing.T) {
 		Output:  out,
 		Verbose: true,
 	}
-	skipped := flow.Register(goyek.Task{
+	skipped := flow.Define(goyek.Task{
 		Name: "skipped",
 		Action: func(tf *goyek.TF) {
 			tf.Skipf("Skipf %d", 0)
 		},
 	})
-	flow.Register(goyek.Task{
+	flow.Define(goyek.Task{
 		Name: "failing",
 		Deps: goyek.Deps{skipped},
 		Action: func(tf *goyek.TF) {
@@ -274,7 +274,7 @@ func Test_concurrent_printing(t *testing.T) {
 				Output:  out,
 				Verbose: tc.verbose,
 			}
-			flow.Register(goyek.Task{
+			flow.Define(goyek.Task{
 				Name: "task",
 				Action: func(tf *goyek.TF) {
 					ch := make(chan struct{})
@@ -300,7 +300,7 @@ func Test_name(t *testing.T) {
 	flow := &goyek.Flow{Output: &strings.Builder{}}
 	taskName := "my-named-task"
 	var got string
-	flow.Register(goyek.Task{
+	flow.Define(goyek.Task{
 		Name: taskName,
 		Action: func(tf *goyek.TF) {
 			got = tf.Name()
@@ -316,7 +316,7 @@ func Test_name(t *testing.T) {
 func Test_defaultTask(t *testing.T) {
 	flow := &goyek.Flow{Output: &strings.Builder{}}
 	taskRan := false
-	task := flow.Register(goyek.Task{
+	task := flow.Define(goyek.Task{
 		Name: "task",
 		Action: func(tf *goyek.TF) {
 			taskRan = true
@@ -337,7 +337,7 @@ func TestCmd_success(t *testing.T) {
 		Output:  out,
 		Verbose: true,
 	}
-	flow.Register(goyek.Task{
+	flow.Define(goyek.Task{
 		Name: taskName,
 		Action: func(tf *goyek.TF) {
 			if err := tf.Cmd("go", "version").Run(); err != nil {
@@ -355,7 +355,7 @@ func TestCmd_success(t *testing.T) {
 func TestCmd_error(t *testing.T) {
 	taskName := "exec"
 	flow := &goyek.Flow{Output: &strings.Builder{}}
-	flow.Register(goyek.Task{
+	flow.Define(goyek.Task{
 		Name: taskName,
 		Action: func(tf *goyek.TF) {
 			if err := tf.Cmd("go", "wrong").Run(); err != nil {
@@ -371,9 +371,9 @@ func TestCmd_error(t *testing.T) {
 
 func TestFlow_Tasks(t *testing.T) {
 	flow := &goyek.Flow{Output: &strings.Builder{}}
-	t1 := flow.Register(goyek.Task{Name: "one"})
-	flow.Register(goyek.Task{Name: "two", Usage: "action", Deps: goyek.Deps{t1}})
-	flow.Register(goyek.Task{Name: "three"})
+	t1 := flow.Define(goyek.Task{Name: "one"})
+	flow.Define(goyek.Task{Name: "two", Usage: "action", Deps: goyek.Deps{t1}})
+	flow.Define(goyek.Task{Name: "three"})
 
 	got := flow.Tasks()
 
@@ -388,7 +388,7 @@ func TestFlow_Tasks(t *testing.T) {
 func TestFlow_Usage_default(t *testing.T) {
 	out := &strings.Builder{}
 	flow := &goyek.Flow{Output: out}
-	task := flow.Register(goyek.Task{Name: "task"})
+	task := flow.Define(goyek.Task{Name: "task"})
 	flow.DefaultTask = task
 
 	exitCode := flow.Run(context.Background(), "bad")

--- a/runner.go
+++ b/runner.go
@@ -10,19 +10,12 @@ import (
 	"time"
 )
 
-type (
-	runner struct {
-		output      io.Writer
-		tasks       map[string]taskInfo
-		verbose     bool
-		defaultTask string
-	}
-	taskInfo struct {
-		name   string
-		deps   []string
-		action func(tf *TF)
-	}
-)
+type runner struct {
+	output      io.Writer
+	tasks       map[string]taskSnapshot
+	verbose     bool
+	defaultTask string
+}
 
 // Run runs provided tasks and all their dependencies.
 // Each task is executed at most once.
@@ -95,7 +88,7 @@ func (r *runner) run(ctx context.Context, name string, executed map[string]bool)
 	return nil
 }
 
-func (r *runner) runTask(ctx context.Context, task taskInfo) bool {
+func (r *runner) runTask(ctx context.Context, task taskSnapshot) bool {
 	if task.action == nil {
 		return true
 	}

--- a/task.go
+++ b/task.go
@@ -21,24 +21,35 @@ type Task struct {
 	Deps Deps
 }
 
-// RegisteredTask represents a task that has been registered.
+// DefinedTask represents a task that has been registered.
 // It can be used as a dependency for another task.
-type RegisteredTask struct {
+type DefinedTask interface {
+	Name() string
+	Usage() string
+	Deps() []string
+	sealed()
+}
+
+// Deps represents a collection of dependencies.
+type Deps []DefinedTask
+
+// registeredTask implements (and encapsulates) DefinedTask.
+type registeredTask struct {
 	taskSnapshot
 }
 
 // Name returns the name of the task.
-func (r RegisteredTask) Name() string {
+func (r registeredTask) Name() string {
 	return r.name
 }
 
 // Usage returns the description of the task.
-func (r RegisteredTask) Usage() string {
+func (r registeredTask) Usage() string {
 	return r.usage
 }
 
 // Deps returns the names of all task's dependencies.
-func (r RegisteredTask) Deps() []string {
+func (r registeredTask) Deps() []string {
 	count := len(r.deps)
 	if count == 0 {
 		return nil
@@ -48,5 +59,4 @@ func (r RegisteredTask) Deps() []string {
 	return deps
 }
 
-// Deps represents a collection of dependencies.
-type Deps []RegisteredTask
+func (r registeredTask) sealed() {}

--- a/task.go
+++ b/task.go
@@ -6,44 +6,45 @@ package goyek
 // parameters (which can be used within the action).
 type Task struct {
 	// Name uniquely identifies the task.
-	// Names may not be empty and should be easily representable on the CLI.
+	// Names cannot  be empty and should be easily representable on the CLI.
 	Name string
 
 	// Usage provides information what the task does.
-	// If it is empty, this task will not be listed in the usage output.
 	Usage string
 
 	// Action executes the task in the given flow context.
 	// A task can be registered without a action and can act as a "collector" task
-	// for a list of dependencies.
+	// for a list of dependencies (also called "pipeline").
 	Action func(tf *TF)
 
 	// Deps is a collection of registered tasks that need to be run before this task is executed.
 	Deps Deps
 }
 
-// RegisteredTask represents a task that has been registered to a Flow.
-// It can be used as a dependency for another Task.
+// RegisteredTask represents a task that has been registered.
+// It can be used as a dependency for another task.
 type RegisteredTask struct {
-	task Task
+	taskSnapshot
 }
 
 // Name returns the name of the task.
 func (r RegisteredTask) Name() string {
-	return r.task.Name
+	return r.name
 }
 
 // Usage returns the description of the task.
 func (r RegisteredTask) Usage() string {
-	return r.task.Usage
+	return r.usage
 }
 
 // Deps returns the names of all task's dependencies.
 func (r RegisteredTask) Deps() []string {
-	var deps []string
-	for _, task := range r.task.Deps {
-		deps = append(deps, task.Name())
+	count := len(r.deps)
+	if count == 0 {
+		return nil
 	}
+	deps := make([]string, count)
+	copy(deps, r.deps)
 	return deps
 }
 


### PR DESCRIPTION
## Why

Shorter and same terminology is used in `flag` package.

## What

- Rename `Flow.Register` to `Flow.Define`.
- Change `Flow.RegisteredTask` to sealed interface `Flow.DefinedTask`.

## Checklist

<!-- All items should be verified and marked as done.
     If an item doesn't apply to the introduced changes - check it as done too. -->

- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated.
- [x] The code changes follow [Effective Go](https://golang.org/doc/effective_go).
- [x] The code changes follow [CodeReviewComments](https://github.com/golang/go/wiki/CodeReviewComments).
- [x] The code changes are covered by tests.

<!-- markdownlint-disable-file MD041 -->
