### PR TITLE
Change DefaultTask to SetDefault and Default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
   is called when `Flow.Run` returns `CodeInvalidArgs`.
 - Rename `Flow.Register` to `Flow.Define`.
 - Change `Flow.RegisteredTask` to sealed interface `Flow.DefinedTask`.
+- Change the `Flow.DefaultTask` field to `Flow.SetDefault` and `Flow.Default` methods.
 
 ## [2.0.0-rc.1](https://github.com/goyek/goyek/compare/v1.1.0...v2.0.0-rc.1) - 2022-10-14
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ The registered tasks are required to have a non-empty name.
 
 A task with a given name can be only registered once.
 
-Default task can be assigned using the `DefaultTask` field.
+Default task can be assigned using the `SetDefault` method.
 When the default task is set, then it is run if no task is provided.
 
 ### Task action

--- a/build/build.go
+++ b/build/build.go
@@ -43,7 +43,7 @@ func configure() {
 	}))
 
 	// set default task
-	flow.DefaultTask = all
+	flow.SetDefault(all)
 }
 
 const (

--- a/example_test.go
+++ b/example_test.go
@@ -46,7 +46,7 @@ func Example() {
 	})
 
 	// set the default task
-	flow.DefaultTask = all
+	flow.SetDefault(all)
 
 	// set the help message
 	usage := func() {

--- a/runner.go
+++ b/runner.go
@@ -32,11 +32,6 @@ func (r *runner) Run(ctx context.Context, args []string) int {
 		}
 		tasks = append(tasks, arg)
 	}
-	if r.defaultTask != "" {
-		if _, ok := r.tasks[r.defaultTask]; !ok {
-			panic(fmt.Sprintf("default task not defined: %s", r.defaultTask))
-		}
-	}
 
 	tasks = r.tasksToRun(tasks)
 


### PR DESCRIPTION
## Why

Safer API that can panic during registration.

## What

- Change the `Flow.DefaultTask` field to `Flow.SetDefault` and `Flow.Default` methods.

## Checklist

<!-- All items should be verified and marked as done.
     If an item doesn't apply to the introduced changes - check it as done too. -->

- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated.
- [x] The code changes follow [Effective Go](https://golang.org/doc/effective_go).
- [x] The code changes follow [CodeReviewComments](https://github.com/golang/go/wiki/CodeReviewComments).
- [x] The code changes are covered by tests.

<!-- markdownlint-disable-file MD041 -->
