### PR TITLE
Fix panic handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 
 ## [Unreleased](https://github.com/goyek/goyek/compare/v2.0.0-rc.2...HEAD)
 
+### Fixed
+
+- Fix panic handling so that `panic(nil)` and `runtime.Goexit()` now cause task failure.
+
 ## [2.0.0-rc.2](https://github.com/goyek/goyek/compare/v2.0.0-rc.1...v2.0.0-rc.2)
 
 This release focuses on improving usability and encapsulation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 
 ## [Unreleased](https://github.com/goyek/goyek/compare/v2.0.0-rc.2...HEAD)
 
+## Changed
+
+- Usually, the task does not call `panic` directly.
+  `panic` failure message no longer contains a prefix with file and line information.
+  The stack trace is printed instead.
+
 ### Fixed
 
 - Fix panic handling so that `panic(nil)` and `runtime.Goexit()` now cause task failure.

--- a/build/build.go
+++ b/build/build.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"io"
 	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/goyek/goyek/v2"
@@ -93,8 +94,12 @@ func taskBuild() goyek.Task {
 func taskMarkdownLint() goyek.Task {
 	return goyek.Task{
 		Name:  "mdlint",
-		Usage: "markdownlint-cli (requires docker)",
+		Usage: "markdownlint-cli (uses docker)",
 		Action: func(tf *goyek.TF) {
+			if _, err := exec.LookPath("docker"); err != nil {
+				tf.Skip(err)
+			}
+
 			curDir, err := os.Getwd()
 			if err != nil {
 				tf.Fatal(err)

--- a/runner.go
+++ b/runner.go
@@ -87,7 +87,7 @@ func (r *runner) runTask(ctx context.Context, task taskSnapshot) bool {
 	fmt.Fprintf(writer, "----- %s: %s (%.2fs)\n", status, task.name, result.duration.Seconds())
 
 	if streamWriter != nil && result.failed {
-		io.Copy(r.output, strings.NewReader(streamWriter.String())) //nolint // not checking errors when writing to output
+		io.Copy(r.output, strings.NewReader(streamWriter.String())) //nolint:errcheck,gosec // not checking errors when writing to output
 	}
 
 	return passed

--- a/tf.go
+++ b/tf.go
@@ -154,13 +154,13 @@ func (tf *TF) run(action func(tf *TF)) runResult {
 		finished := false
 		from := time.Now()
 		defer func() {
-			if r := recover(); r != nil {
-				txt := fmt.Sprintf("panic: %v", r)
-				txt = decorate(txt, skipCount)
-				io.WriteString(tf.output, txt) //nolint // not checking errors when writing to output
-				tf.failed = true
-			} else if !finished && !tf.skipped && !tf.failed {
-				txt := "panic(nil) or runtime.Goexit() called"
+			if !finished && !tf.skipped && !tf.failed {
+				var txt string
+				if r := recover(); r != nil {
+					txt = fmt.Sprintf("panic: %v", r)
+				} else {
+					txt = "panic(nil) or runtime.Goexit() called"
+				}
 				txt = decorate(txt, skipCount)
 				io.WriteString(tf.output, txt) //nolint // not checking errors when writing to output
 				tf.failed = true


### PR DESCRIPTION
## Why

Fixes https://github.com/goyek/goyek/issues/232

## What

- Fix panic handling so that `panic(nil)` and `runtime.Goexit()` now cause task failure.
- Usually, the task does not call `panic` directly.
  `panic` failure message no longer contains a prefix with file and line information.
  The stack trace is printed instead.


## Checklist

<!-- All items should be verified and marked as done.
     If an item doesn't apply to the introduced changes - check it as done too. -->

- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated.
- [x] The code changes follow [Effective Go](https://golang.org/doc/effective_go).
- [x] The code changes follow [CodeReviewComments](https://github.com/golang/go/wiki/CodeReviewComments).
- [x] The code changes are covered by tests.

<!-- markdownlint-disable-file MD041 -->
