### PR TITLE
Add LogDecorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 
 ## [Unreleased](https://github.com/goyek/goyek/compare/v2.0.0-rc.2...HEAD)
 
+### Added
+
+- Add `Flow.LogDecorator` for setting a custom log decorator
+  that is used by `TF` logging methods.
+- Add `DecorateLog` function which is the default `Flow.LogDecorator`.
+
 ## Changed
 
 - Usually, the task does not call `panic` directly.

--- a/flow.go
+++ b/flow.go
@@ -32,6 +32,10 @@ type Flow struct {
 	// a custom error handler. By default it calls Print.
 	Usage func()
 
+	// LogDecorator used by TF's logging functions to decorate the text.
+	// DecorateLog by default.
+	LogDecorator func(string) string
+
 	tasks       map[string]taskSnapshot // snapshot of defined tasks
 	defaultTask string                  // task to run when none is explicitly provided
 }
@@ -101,11 +105,11 @@ func (f *Flow) Run(ctx context.Context, args ...string) int {
 	var tasks []string
 	for _, arg := range args {
 		if arg == "" {
-			fmt.Fprintln(out, "task name cannot be empty")
+			fmt.Fprintln(out, "task name cannot be empty") // TODO: move to Main
 			return f.invalid()
 		}
 		if _, ok := f.tasks[arg]; !ok {
-			fmt.Fprintf(out, "task provided but not defined: %s\n", arg)
+			fmt.Fprintf(out, "task provided but not defined: %s\n", arg) // TODO: move to Main
 			return f.invalid()
 		}
 		tasks = append(tasks, arg)
@@ -114,14 +118,15 @@ func (f *Flow) Run(ctx context.Context, args ...string) int {
 		tasks = append(tasks, f.defaultTask)
 	}
 	if len(tasks) == 0 {
-		fmt.Fprintln(out, "no task provided")
+		fmt.Fprintln(out, "no task provided") // TODO: move to Main
 		return f.invalid()
 	}
 
 	r := &flowRunner{
-		output:  out,
-		defined: f.tasks,
-		verbose: f.Verbose,
+		output:       out,
+		defined:      f.tasks,
+		verbose:      f.Verbose,
+		logDecorator: f.LogDecorator,
 	}
 	if ctx == nil {
 		ctx = context.Background()

--- a/flow_runner.go
+++ b/flow_runner.go
@@ -11,9 +11,10 @@ import (
 )
 
 type flowRunner struct {
-	output  io.Writer
-	defined map[string]taskSnapshot
-	verbose bool
+	output       io.Writer
+	defined      map[string]taskSnapshot
+	verbose      bool
+	logDecorator func(string) string
 }
 
 // Run runs provided tasks and all their dependencies.
@@ -23,11 +24,11 @@ func (r *flowRunner) Run(ctx context.Context, tasks []string) bool {
 	executedTasks := map[string]bool{}
 	for _, name := range tasks {
 		if err := r.run(ctx, name, executedTasks); err != nil {
-			fmt.Fprintf(r.output, "%v\t%.3fs\n", err, time.Since(from).Seconds())
+			fmt.Fprintf(r.output, "%v\t%.3fs\n", err, time.Since(from).Seconds()) // TODO: move to Main
 			return false
 		}
 	}
-	fmt.Fprintf(r.output, "ok\t%.3fs\n", time.Since(from).Seconds())
+	fmt.Fprintf(r.output, "ok\t%.3fs\n", time.Since(from).Seconds()) // TODO: move to Main
 	return true
 }
 
@@ -70,9 +71,10 @@ func (r *flowRunner) runTask(ctx context.Context, task taskSnapshot) bool {
 
 	// run task
 	tf := &TF{
-		ctx:    ctx,
-		name:   task.name,
-		output: writer,
+		ctx:       ctx,
+		name:      task.name,
+		output:    writer,
+		decorator: r.logDecorator,
 	}
 	result := tf.run(task.action)
 

--- a/flow_test.go
+++ b/flow_test.go
@@ -483,6 +483,21 @@ func TestFlow_Usage_custom(t *testing.T) {
 	assertTrue(t, called, "should invoke the custom message instead")
 }
 
+func TestFlow_LogDecorator(t *testing.T) {
+	out := &strings.Builder{}
+	flow := &goyek.Flow{Output: out, Verbose: true, LogDecorator: strings.ToUpper}
+	flow.Define(goyek.Task{
+		Name: "task",
+		Action: func(tf *goyek.TF) {
+			tf.Log("msg")
+		},
+	})
+
+	flow.Run(context.Background(), "task")
+
+	assertContains(t, out, "MSG", "should decorate the text")
+}
+
 func assertTrue(tb testing.TB, got bool, msg string) {
 	tb.Helper()
 	if got {

--- a/flow_test.go
+++ b/flow_test.go
@@ -489,13 +489,15 @@ func TestFlow_LogDecorator(t *testing.T) {
 	flow.Define(goyek.Task{
 		Name: "task",
 		Action: func(tf *goyek.TF) {
-			tf.Log("msg")
+			tf.Log("first")
+			tf.Logf("second")
 		},
 	})
 
 	flow.Run(context.Background(), "task")
 
-	assertContains(t, out, "MSG", "should decorate the text")
+	assertContains(t, out, "FIRST", "should decorate Log")
+	assertContains(t, out, "SECOND", "should decorate Logf")
 }
 
 func assertTrue(tb testing.TB, got bool, msg string) {


### PR DESCRIPTION
## Why

Make it possible to customize all reporting.

## What

- Add `Flow.LogDecorator` for setting a custom log decorator
  that is used by `TF` logging methods.
- Add `DecorateLog` function which is the default `Flow.LogDecorator`.