### PR TITLE
Change Execute to return error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
   It can be enabled by calling `Flow.Use(middleware.Reporter)`.
 - `Flow.Print` output format is similar to `flag.PrintDefaults`.
   Moreover, it does not print tasks with empty `Task.Usage`.
+- Change `Flow.Execute` to return an error instead of returning the exit code
+  and printing to output.
 
 ## Removed
 

--- a/executor.go
+++ b/executor.go
@@ -2,9 +2,7 @@ package goyek
 
 import (
 	"context"
-	"fmt"
 	"io"
-	"time"
 )
 
 type executor struct {
@@ -16,17 +14,14 @@ type executor struct {
 
 // Execute runs provided tasks and all their dependencies.
 // Each task is executed at most once.
-func (r *executor) Execute(ctx context.Context, tasks []string) bool {
-	from := time.Now()
+func (r *executor) Execute(ctx context.Context, tasks []string) error {
 	executedTasks := map[string]bool{}
 	for _, name := range tasks {
 		if err := r.run(ctx, name, executedTasks); err != nil {
-			fmt.Fprintf(r.output, "%v\t%.3fs\n", err, time.Since(from).Seconds()) // TODO: move to Main
-			return false
+			return err
 		}
 	}
-	fmt.Fprintf(r.output, "ok\t%.3fs\n", time.Since(from).Seconds()) // TODO: move to Main
-	return true
+	return nil
 }
 
 func (r *executor) run(ctx context.Context, name string, executed map[string]bool) error {
@@ -43,7 +38,7 @@ func (r *executor) run(ctx context.Context, name string, executed map[string]boo
 		return err
 	}
 	if !r.runTask(ctx, task) {
-		return fmt.Errorf("task failed: %s", task.name)
+		return &FailError{Task: task.name}
 	}
 	executed[name] = true
 	return nil

--- a/flow.go
+++ b/flow.go
@@ -218,12 +218,16 @@ func (f *Flow) Main(args []string) {
 		os.Exit(exitCodeInvalid)
 	}
 
-	// run flow
+	exitCode := f.run(ctx, out, args)
+	os.Exit(exitCode)
+}
+
+func (f *Flow) run(ctx context.Context, out io.Writer, args []string) int {
 	from := time.Now()
 	err := f.Execute(ctx, args...)
 	if _, ok := err.(*FailError); ok {
 		fmt.Fprintf(out, "%v\t%.3fs\n", err, time.Since(from).Seconds())
-		os.Exit(exitCodeFail)
+		return exitCodeFail
 	}
 	if err != nil {
 		fmt.Fprintln(out, err.Error())
@@ -232,10 +236,10 @@ func (f *Flow) Main(args []string) {
 		} else {
 			f.Print()
 		}
-		os.Exit(exitCodeInvalid)
+		return exitCodeInvalid
 	}
 	fmt.Fprintf(out, "ok\t%.3fs\n", time.Since(from).Seconds())
-	os.Exit(exitCodePass)
+	return exitCodePass
 }
 
 // Print prints, to os.Stdout unless configured otherwise,


### PR DESCRIPTION
## Why

Fixes https://github.com/goyek/goyek/issues/245

## What

Change Execute to return error instead of int

## Checklist

<!-- All items should be verified and marked as done.
     If an item doesn't apply to the introduced changes - check it as done too. -->

- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated.
- [x] The code changes follow [Effective Go](https://golang.org/doc/effective_go).
- [x] The code changes follow [CodeReviewComments](https://github.com/golang/go/wiki/CodeReviewComments).
- [x] The code changes are covered by tests.

<!-- markdownlint-disable-file MD041 -->
