### PR TITLE
Release 2.0.0-rc.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 as well as to [Module version numbering](https://go.dev/doc/modules/version-numbers).
 
-## [Unreleased](https://github.com/goyek/goyek/compare/v2.0.0-rc.2...HEAD)
+## [Unreleased](https://github.com/goyek/goyek/compare/v2.0.0-rc.3...HEAD)
+
+## [2.0.0-rc.3](https://github.com/goyek/goyek/compare/v2.0.0-rc.2...v2.0.0-rc.3)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 - Add the top-level functions such as `Define`, `Main`, and so on which are wrappers
   for the methods of `Flow` called for `DefaultFlow`.
 
-## Changed
+### Changed
 
 - Usually, the task does not call `panic` directly.
   `panic` failure message no longer contains a prefix with file and line information.
@@ -43,7 +43,7 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 - Change `Flow.Output` field to `Flow.SetOutput` setter and `Flow.Output` getter.
 - Change `Flow.Usage` field to `Flow.SetUsage` setter and `Flow.Usage` getter.
 
-## Removed
+### Removed
 
 - `Flow.Verbose` is removed.
   To be non-verbose use `Flow.Use(middleware.SilentNonFailed)` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 
 ### Added
 
-- Add `Flow.SetLogger` for setting a custom log decorator.
+- Add `Flow.SetLogger` for setting a custom log decorator
   that is used by `TF` logging methods.
 - Add `Flow.Logger` for getting the log decorator (`CodeLineLogger` by default).
 - Add `CodeLineLogger` which is the default for `Flow.Logger`.
@@ -22,7 +22,7 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 - Add `Flow.Use` method o support task run interception using middlewares.
 - Add `middleware` package with `Reporter` and `SilentNonFailed` middlewares.
 - `TF.Error`, `TF.Errorf`, `TF.Fail` may be called simultaneously from multiple goroutines.
-- Add `DefaultFlow` that is the default flowa
+- Add `DefaultFlow` that is the default flow.
 - Add the top-level functions such as `Define`, `Main`, and so on which are wrappers
   for the methods of `Flow` called for `DefaultFlow`.
 

--- a/README.md
+++ b/README.md
@@ -190,8 +190,8 @@ Simply add them to your repository's root directory
 and make sure to add the `+x` permission:
 
 ```sh
-curl -sSfL https://raw.githubusercontent.com/goyek/goyek/v2.0.0-rc.2/goyek.sh -O
-curl -sSfL https://raw.githubusercontent.com/goyek/goyek/v2.0.0-rc.2/goyek.ps1 -O
+curl -sSfL https://raw.githubusercontent.com/goyek/goyek/v2.0.0-rc.3/goyek.sh -O
+curl -sSfL https://raw.githubusercontent.com/goyek/goyek/v2.0.0-rc.3/goyek.ps1 -O
 git add --chmod=+x goyek.sh goyek.ps1
 ```
 

--- a/build/go.mod
+++ b/build/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/client9/misspell v0.3.4
 	github.com/golangci/golangci-lint v1.50.0
-	github.com/goyek/goyek/v2 v2.0.0-rc.2
+	github.com/goyek/goyek/v2 v2.0.0-rc.3
 	github.com/mattn/go-shellwords v1.0.12
 )
 


### PR DESCRIPTION
### Added

- Add `Flow.SetLogger` for setting a custom log decorator that is used by `TF` logging methods.
- Add `Flow.Logger` for getting the log decorator (`CodeLineLogger` by default).
- Add `CodeLineLogger` which is the default for `Flow.Logger`.
- Add `FmtLogger` which is the default when using `NewRunner`.
- Add `NOOP` status report for tasks that were intentionally not run to differentiate from being skipped during execution.
- Add `Flow.Use` method o support task run interception using middlewares.
- Add `middleware` package with `Reporter` and `SilentNonFailed` middlewares.
- `TF.Error`, `TF.Errorf`, `TF.Fail` may be called simultaneously from multiple goroutines.
- Add `DefaultFlow` that is the default flow.
- Add the top-level functions such as `Define`, `Main`, and so on which are wrappers for the methods of `Flow` called for `DefaultFlow`.

### Changed

- Usually, the task does not call `panic` directly.
  `panic` failure message no longer contains a prefix with file and line information.
  The stack trace is printed instead. The behavior is based on `testing` package.
- `Flow.Main` changes the working directory to parent.
- Rename `Flow.Run` to `Flow.Execute` to reduce possible confusion with `Runner`.
- Report `PASS` for a task without an action.
- Task status reporting is disabled by default. It can be enabled by calling `Flow.Use(middleware.Reporter)`.
- `Flow.Print` output format is similar to `flag.PrintDefaults`. Moreover, it does not print tasks with empty `Task.Usage`.
- Change `Flow.Execute` to return an error instead of returning the exit code and printing to output.
- Change `Flow.Output` field to `Flow.SetOutput` setter and `Flow.Output` getter.
- Change `Flow.Usage` field to `Flow.SetUsage` setter and `Flow.Usage` getter.

### Removed

- `Flow.Verbose` is removed. To be non-verbose use `Flow.Use(middleware.SilentNonFailed)` instead.

### Fixed

- Fix panic handling so that `panic(nil)` and `runtime.Goexit()` now cause task failure.