### PR TITLE
DefinedTask.Deps returns Deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 
 ## [Unreleased](https://github.com/goyek/goyek/compare/v2.0.0-rc.3...HEAD)
 
+### Changed
+
+- `DefinedTask.Deps` returns `Deps` to facilitate reusing defined task's dependencies
+  when creating a new one or redefining existing one.
+
 ## [2.0.0-rc.3](https://github.com/goyek/goyek/compare/v2.0.0-rc.2...v2.0.0-rc.3)
 
 This release focuses on improving usability, extensibility, and customization.

--- a/flow.go
+++ b/flow.go
@@ -50,7 +50,7 @@ func Tasks() []DefinedTask {
 func (f *Flow) Tasks() []DefinedTask {
 	var tasks []DefinedTask
 	for _, task := range f.tasks {
-		tasks = append(tasks, registeredTask{task})
+		tasks = append(tasks, registeredTask{task, f})
 	}
 	sort.Slice(tasks, func(i, j int) bool { return tasks[i].Name() < tasks[j].Name() })
 	return tasks
@@ -87,7 +87,7 @@ func (f *Flow) Define(task Task) DefinedTask {
 		action: task.Action,
 	}
 	f.tasks[task.Name] = taskCopy
-	return registeredTask{taskCopy}
+	return registeredTask{taskCopy, f}
 }
 
 func (f *Flow) isDefined(name string) bool {
@@ -185,7 +185,7 @@ func (f *Flow) Default() DefinedTask {
 	if f.defaultTask == "" {
 		return nil
 	}
-	return registeredTask{f.tasks[f.defaultTask]}
+	return registeredTask{f.tasks[f.defaultTask], f}
 }
 
 // SetDefault sets a task to run when none is explicitly provided.
@@ -381,7 +381,11 @@ func (f *Flow) Print() {
 		}
 		deps := ""
 		if len(task.Deps()) > 0 {
-			deps = " (depends on: " + strings.Join(task.Deps(), ", ") + ")"
+			depNames := make([]string, 0, len(task.Deps()))
+			for _, dep := range task.Deps() {
+				depNames = append(depNames, dep.Name())
+			}
+			deps = " (depends on: " + strings.Join(depNames, ", ") + ")"
 		}
 		fmt.Fprintf(w, "  %s\t%s\n", task.Name(), task.Usage()+deps)
 	}

--- a/flow_test.go
+++ b/flow_test.go
@@ -493,7 +493,7 @@ func TestFlow_Tasks(t *testing.T) {
 	assertEqual(t, got[1].Name(), "three", "should then return one (sorted)")
 	assertEqual(t, got[2].Name(), "two", "should next return two")
 	assertEqual(t, got[2].Usage(), "action", "should return usage")
-	assertEqual(t, got[2].Deps()[0], "one", "should return dependency")
+	assertEqual(t, got[2].Deps()[0], t1, "should return dependency")
 }
 
 func TestFlow_Default(t *testing.T) {

--- a/task.go
+++ b/task.go
@@ -26,7 +26,7 @@ type Task struct {
 type DefinedTask interface {
 	Name() string
 	Usage() string
-	Deps() []string
+	Deps() Deps
 	sealed()
 }
 
@@ -36,6 +36,7 @@ type Deps []DefinedTask
 // registeredTask implements (and encapsulates) DefinedTask.
 type registeredTask struct {
 	taskSnapshot
+	flow *Flow
 }
 
 // Name returns the name of the task.
@@ -49,13 +50,15 @@ func (r registeredTask) Usage() string {
 }
 
 // Deps returns the names of all task's dependencies.
-func (r registeredTask) Deps() []string {
+func (r registeredTask) Deps() Deps {
 	count := len(r.deps)
 	if count == 0 {
 		return nil
 	}
-	deps := make([]string, count)
-	copy(deps, r.deps)
+	deps := make(Deps, 0, count)
+	for _, dep := range r.deps {
+		deps = append(deps, registeredTask{r.flow.tasks[dep], r.flow})
+	}
 	return deps
 }
 


### PR DESCRIPTION
## Why

Related to https://github.com/goyek/goyek/issues/241

## What

`DefinedTask.Deps` returns `Deps` to facilitate reusing defined task's dependencies when defining a new one or redefining existing one.

## Checklist

<!-- All items should be verified and marked as done.
     If an item doesn't apply to the introduced changes - check it as done too. -->

- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated.
- [x] The code changes follow [Effective Go](https://golang.org/doc/effective_go).
- [x] The code changes follow [CodeReviewComments](https://github.com/golang/go/wiki/CodeReviewComments).
- [x] The code changes are covered by tests.

<!-- markdownlint-disable-file MD041 -->
