### PR TITLE
Add possibility to modify defined task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 
 ## [Unreleased](https://github.com/goyek/goyek/compare/v2.0.0-rc.3...HEAD)
 
+This release focuses on improving the API to make creating and customizing
+reusable build pipelines easier.
+
+## Added
+
+- Add `DefinedTask.SetName`, `DefinedTask.SetUsage`, `DefinedTask.Action`,
+  `DefinedTask.SetAction`, `DefinedTask.SetAction`, `DefinedTask.SetDeps`
+  to enable modifying the task after the initial definition.
+
 ### Changed
 
 - `DefinedTask.Deps` returns `Deps` to facilitate reusing defined task's dependencies

--- a/executor.go
+++ b/executor.go
@@ -7,7 +7,7 @@ import (
 
 type executor struct {
 	output      io.Writer
-	defined     map[string]taskSnapshot
+	defined     map[string]*taskSnapshot
 	logger      Logger
 	middlewares []Middleware
 }
@@ -44,7 +44,7 @@ func (r *executor) run(ctx context.Context, name string, executed map[string]boo
 	return nil
 }
 
-func (r *executor) runTask(ctx context.Context, task taskSnapshot) bool {
+func (r *executor) runTask(ctx context.Context, task *taskSnapshot) bool {
 	// prepare runner
 	action := task.action
 	if action == nil {

--- a/flow.go
+++ b/flow.go
@@ -21,8 +21,8 @@ type Flow struct {
 	usage  func()
 	logger Logger // TODO: If Helper() is implemented then it is called when TF.Helper() is called.
 
-	tasks       map[string]taskSnapshot // snapshot of defined tasks
-	defaultTask string                  // task to run when none is explicitly provided
+	tasks       map[string]*taskSnapshot // snapshot of defined tasks
+	defaultTask string                   // task to run when none is explicitly provided
 	middlewares []Middleware
 }
 
@@ -68,7 +68,7 @@ func (f *Flow) Define(task Task) DefinedTask {
 		panic("task name cannot be empty")
 	}
 	if f.isDefined(task.Name) {
-		panic(fmt.Sprintf("task was already defined: %s", task.Name))
+		panic("task with the same name is already defined")
 	}
 	for _, dep := range task.Deps {
 		if !f.isDefined(dep.Name()) {
@@ -80,7 +80,7 @@ func (f *Flow) Define(task Task) DefinedTask {
 	for _, dep := range task.Deps {
 		deps = append(deps, dep.Name())
 	}
-	taskCopy := taskSnapshot{
+	taskCopy := &taskSnapshot{
 		name:   task.Name,
 		usage:  task.Usage,
 		deps:   deps,
@@ -92,7 +92,7 @@ func (f *Flow) Define(task Task) DefinedTask {
 
 func (f *Flow) isDefined(name string) bool {
 	if f.tasks == nil {
-		f.tasks = map[string]taskSnapshot{}
+		f.tasks = map[string]*taskSnapshot{}
 	}
 	_, ok := f.tasks[name]
 	return ok

--- a/flow_test.go
+++ b/flow_test.go
@@ -2,7 +2,6 @@ package goyek_test
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"reflect"
@@ -14,7 +13,7 @@ import (
 	"github.com/goyek/goyek/v2"
 )
 
-func Test_DefaultTask(t *testing.T) {
+func Test_DefaultFlow(t *testing.T) {
 	goyek.SetOutput(ioutil.Discard)
 	assertEqual(t, goyek.Output(), ioutil.Discard, "Output")
 
@@ -602,88 +601,4 @@ func TestFlow_Use_nil_middleware(t *testing.T) {
 	}
 
 	assertPanics(t, act, "should panic on nil middleware")
-}
-
-func assertTrue(tb testing.TB, got bool, msg string) {
-	tb.Helper()
-	if got {
-		return
-	}
-	tb.Errorf("%s\nGOT: %v, WANT: true", msg, got)
-}
-
-func assertContains(tb testing.TB, got fmt.Stringer, want string, msg string) {
-	tb.Helper()
-	gotTxt := got.String()
-	if strings.Contains(gotTxt, want) {
-		return
-	}
-	tb.Errorf("%s\nGOT:\n%s\nSHOULD CONTAIN:\n%s", msg, gotTxt, want)
-}
-
-func assertNotContains(tb testing.TB, got fmt.Stringer, want string, msg string) {
-	tb.Helper()
-	gotTxt := got.String()
-	if !strings.Contains(gotTxt, want) {
-		return
-	}
-	tb.Errorf("%s\nGOT:\n%s\nSHOULD NOT CONTAIN:\n%s", msg, gotTxt, want)
-}
-
-func requireEqual(tb testing.TB, got interface{}, want interface{}, msg string) {
-	tb.Helper()
-	if reflect.DeepEqual(got, want) {
-		return
-	}
-	tb.Fatalf("%s\nGOT: %v\nWANT: %v", msg, got, want)
-}
-
-func assertEqual(tb testing.TB, got interface{}, want interface{}, msg string) {
-	tb.Helper()
-	if reflect.DeepEqual(got, want) {
-		return
-	}
-	tb.Errorf("%s\nGOT: %v\nWANT: %v", msg, got, want)
-}
-
-func assertPass(tb testing.TB, got error, msg string) {
-	tb.Helper()
-	if got != nil {
-		tb.Errorf("%s\nGOT: %v\nWANT: <PASS>", msg, got)
-	}
-}
-
-func assertFail(tb testing.TB, got error, msg string) {
-	tb.Helper()
-	if _, ok := got.(*goyek.FailError); !ok {
-		tb.Errorf("%s\nGOT: %v\nWANT: <FAIL>", msg, got)
-	}
-}
-
-func assertInvalid(tb testing.TB, got error, msg string) {
-	tb.Helper()
-	if _, ok := got.(*goyek.FailError); ok || got == nil {
-		tb.Errorf("%s\nGOT: %v\nWANT: <INVALID>", msg, got)
-	}
-}
-
-func assertPanics(tb testing.TB, fn func(), msg string) {
-	tb.Helper()
-	tryPanic := func() bool {
-		didPanic := false
-		func() {
-			defer func() {
-				if info := recover(); info != nil {
-					didPanic = true
-				}
-			}()
-			fn()
-		}()
-		return didPanic
-	}
-
-	if tryPanic() {
-		return
-	}
-	tb.Errorf("%s\ndid not panic, but expected to do so", msg)
 }

--- a/helper_test.go
+++ b/helper_test.go
@@ -1,0 +1,94 @@
+package goyek_test
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/goyek/goyek/v2"
+)
+
+func assertTrue(tb testing.TB, got bool, msg string) {
+	tb.Helper()
+	if got {
+		return
+	}
+	tb.Errorf("%s\nGOT: %v, WANT: true", msg, got)
+}
+
+func assertContains(tb testing.TB, got fmt.Stringer, want string, msg string) {
+	tb.Helper()
+	gotTxt := got.String()
+	if strings.Contains(gotTxt, want) {
+		return
+	}
+	tb.Errorf("%s\nGOT:\n%s\nSHOULD CONTAIN:\n%s", msg, gotTxt, want)
+}
+
+func assertNotContains(tb testing.TB, got fmt.Stringer, want string, msg string) {
+	tb.Helper()
+	gotTxt := got.String()
+	if !strings.Contains(gotTxt, want) {
+		return
+	}
+	tb.Errorf("%s\nGOT:\n%s\nSHOULD NOT CONTAIN:\n%s", msg, gotTxt, want)
+}
+
+func requireEqual(tb testing.TB, got interface{}, want interface{}, msg string) {
+	tb.Helper()
+	if reflect.DeepEqual(got, want) {
+		return
+	}
+	tb.Fatalf("%s\nGOT: %v\nWANT: %v", msg, got, want)
+}
+
+func assertEqual(tb testing.TB, got interface{}, want interface{}, msg string) {
+	tb.Helper()
+	if reflect.DeepEqual(got, want) {
+		return
+	}
+	tb.Errorf("%s\nGOT: %v\nWANT: %v", msg, got, want)
+}
+
+func assertPass(tb testing.TB, got error, msg string) {
+	tb.Helper()
+	if got != nil {
+		tb.Errorf("%s\nGOT: %v\nWANT: <PASS>", msg, got)
+	}
+}
+
+func assertFail(tb testing.TB, got error, msg string) {
+	tb.Helper()
+	if _, ok := got.(*goyek.FailError); !ok {
+		tb.Errorf("%s\nGOT: %v\nWANT: <FAIL>", msg, got)
+	}
+}
+
+func assertInvalid(tb testing.TB, got error, msg string) {
+	tb.Helper()
+	if _, ok := got.(*goyek.FailError); ok || got == nil {
+		tb.Errorf("%s\nGOT: %v\nWANT: <INVALID>", msg, got)
+	}
+}
+
+func assertPanics(tb testing.TB, fn func(), msg string) {
+	tb.Helper()
+	tryPanic := func() bool {
+		didPanic := false
+		func() {
+			defer func() {
+				if info := recover(); info != nil {
+					didPanic = true
+				}
+			}()
+			fn()
+		}()
+		return didPanic
+	}
+
+	if tryPanic() {
+		return
+	}
+	tb.Errorf("%s\ndid not panic, but expected to do so", msg)
+}

--- a/task.go
+++ b/task.go
@@ -28,6 +28,8 @@ type DefinedTask interface {
 	SetName(string)
 	Usage() string
 	SetUsage(string)
+	Action() func(tf *TF)
+	SetAction(func(tf *TF))
 	Deps() Deps
 	SetDeps(Deps)
 	sealed()
@@ -52,7 +54,15 @@ func (r registeredTask) SetName(s string) {
 	if _, ok := r.flow.tasks[s]; ok {
 		panic("task with the same name is already defined")
 	}
-	r.name = s
+	oldName := r.name
+	snap := r.flow.tasks[oldName]
+	delete(r.flow.tasks, oldName)
+	snap.name = s
+	r.flow.tasks[s] = snap
+
+	if r.flow.defaultTask == oldName {
+		r.flow.defaultTask = s
+	}
 }
 
 // Usage returns the description of the task.

--- a/task.go
+++ b/task.go
@@ -25,8 +25,11 @@ type Task struct {
 // It can be used as a dependency for another task.
 type DefinedTask interface {
 	Name() string
+	SetName(string)
 	Usage() string
+	SetUsage(string)
 	Deps() Deps
+	SetDeps(Deps)
 	sealed()
 }
 
@@ -35,7 +38,7 @@ type Deps []DefinedTask
 
 // registeredTask implements (and encapsulates) DefinedTask.
 type registeredTask struct {
-	taskSnapshot
+	*taskSnapshot
 	flow *Flow
 }
 
@@ -44,12 +47,35 @@ func (r registeredTask) Name() string {
 	return r.name
 }
 
+// Name changes the name of the task.
+func (r registeredTask) SetName(s string) {
+	if _, ok := r.flow.tasks[s]; ok {
+		panic("task with the same name is already defined")
+	}
+	r.name = s
+}
+
 // Usage returns the description of the task.
 func (r registeredTask) Usage() string {
 	return r.usage
 }
 
-// Deps returns the names of all task's dependencies.
+// SetUsage sets the description of the task.
+func (r registeredTask) SetUsage(s string) {
+	r.usage = s
+}
+
+// Action returns the action of the task.
+func (r registeredTask) Action() func(tf *TF) {
+	return r.action
+}
+
+// SetAction changes the action of the task.
+func (r registeredTask) SetAction(fn func(tf *TF)) {
+	r.action = fn
+}
+
+// Deps returns all task's dependencies.
 func (r registeredTask) Deps() Deps {
 	count := len(r.deps)
 	if count == 0 {
@@ -60,6 +86,47 @@ func (r registeredTask) Deps() Deps {
 		deps = append(deps, registeredTask{r.flow.tasks[dep], r.flow})
 	}
 	return deps
+}
+
+// Deps returns all task's dependencies.
+func (r registeredTask) SetDeps(deps Deps) {
+	count := len(deps)
+	if count == 0 {
+		r.deps = nil
+		return
+	}
+
+	visited := map[string]bool{}
+	if ok := r.noCycle(deps, visited); !ok {
+		panic("circular dependency")
+	}
+
+	depNames := make([]string, 0, count)
+	for _, dep := range deps {
+		depNames = append(depNames, dep.Name())
+	}
+
+	r.deps = depNames
+}
+
+func (r registeredTask) noCycle(deps Deps, visited map[string]bool) bool {
+	if len(deps) == 0 {
+		return true
+	}
+	for _, dep := range deps {
+		name := dep.Name()
+		if visited[name] {
+			return true
+		}
+		visited[name] = true
+		if name == r.name {
+			return false
+		}
+		if !r.noCycle(dep.Deps(), visited) {
+			return false
+		}
+	}
+	return true
 }
 
 func (r registeredTask) sealed() {}

--- a/task_test.go
+++ b/task_test.go
@@ -94,7 +94,7 @@ func TestDefinedTask_SetDeps(t *testing.T) {
 	t2 := flow.Define(goyek.Task{Name: "two", Deps: goyek.Deps{t1}})
 	t3 := flow.Define(goyek.Task{Name: "three"})
 
-	t3.SetDeps(goyek.Deps{t2})
+	t3.SetDeps(goyek.Deps{t1, t2})
 
 	got := t3.Deps()
 	assertEqual(t, got, goyek.Deps{t2}, "should update the dependencies")

--- a/task_test.go
+++ b/task_test.go
@@ -1,0 +1,74 @@
+package goyek_test
+
+import (
+	"context"
+	"io/ioutil"
+	"testing"
+
+	"github.com/goyek/goyek/v2"
+)
+
+func TestDefinedTask_SetName(t *testing.T) {
+	flow := &goyek.Flow{}
+	flow.SetOutput(ioutil.Discard)
+	called := false
+	task := flow.Define(goyek.Task{Name: "one", Action: func(tf *goyek.TF) { called = true }})
+
+	task.SetName("new")
+
+	got := task.Name()
+	assertEqual(t, got, "new", "should update the name")
+	err := flow.Execute(context.Background(), "new")
+	assertPass(t, err, "should pass")
+	assertTrue(t, called, "should call the action")
+}
+
+func TestDefinedTask_SetDeps(t *testing.T) {
+	flow := &goyek.Flow{}
+	flow.SetOutput(ioutil.Discard)
+	called := false
+	t1 := flow.Define(goyek.Task{Name: "one", Action: func(tf *goyek.TF) { called = true }})
+	t2 := flow.Define(goyek.Task{Name: "two", Deps: goyek.Deps{t1}})
+	t3 := flow.Define(goyek.Task{Name: "three"})
+
+	t3.SetDeps(goyek.Deps{t2})
+
+	got := t3.Deps()
+	assertEqual(t, got, goyek.Deps{t2}, "should update the dependencies")
+
+	err := flow.Execute(context.Background(), "three")
+	assertPass(t, err, "should pass")
+	assertTrue(t, called, "should call transitive dependency of t3")
+}
+
+func TestDefinedTask_SetDeps_clear(t *testing.T) {
+	flow := &goyek.Flow{}
+	flow.SetOutput(ioutil.Discard)
+	notCalled := true
+	t1 := flow.Define(goyek.Task{Name: "one", Action: func(tf *goyek.TF) { notCalled = false }})
+	t2 := flow.Define(goyek.Task{Name: "two", Deps: goyek.Deps{t1}})
+
+	t2.SetDeps(nil)
+
+	var want goyek.Deps
+	got := t2.Deps()
+	assertEqual(t, got, want, "should clear the dependencies")
+
+	err := flow.Execute(context.Background(), "two")
+	assertPass(t, err, "should pass")
+	assertTrue(t, notCalled, "should not call any dependency")
+}
+
+func TestDefinedTask_SetDeps_circular(t *testing.T) {
+	flow := &goyek.Flow{}
+	flow.SetOutput(ioutil.Discard)
+	t1 := flow.Define(goyek.Task{Name: "one"})
+	t2 := flow.Define(goyek.Task{Name: "two", Deps: goyek.Deps{t1}})
+	t3 := flow.Define(goyek.Task{Name: "three", Deps: goyek.Deps{t2}})
+
+	act := func() {
+		t1.SetDeps(goyek.Deps{t3})
+	}
+
+	assertPanics(t, act, "should panic in case of a cyclic dependency")
+}

--- a/task_test.go
+++ b/task_test.go
@@ -3,6 +3,8 @@ package goyek_test
 import (
 	"context"
 	"io/ioutil"
+	"reflect"
+	"runtime"
 	"testing"
 
 	"github.com/goyek/goyek/v2"
@@ -21,6 +23,67 @@ func TestDefinedTask_SetName(t *testing.T) {
 	err := flow.Execute(context.Background(), "new")
 	assertPass(t, err, "should pass")
 	assertTrue(t, called, "should call the action")
+}
+
+func TestDefinedTask_SetName_for_default(t *testing.T) {
+	flow := &goyek.Flow{}
+	flow.SetOutput(ioutil.Discard)
+	called := false
+	task := flow.Define(goyek.Task{Name: "one", Action: func(tf *goyek.TF) { called = true }})
+	flow.SetDefault(task)
+
+	task.SetName("new")
+
+	got := task.Name()
+	assertEqual(t, got, "new", "should update the name")
+	err := flow.Execute(context.Background())
+	assertPass(t, err, "should pass")
+	assertTrue(t, called, "should call the action")
+}
+
+func TestDefinedTask_SetName_conflict(t *testing.T) {
+	flow := &goyek.Flow{}
+	flow.SetOutput(ioutil.Discard)
+	task := flow.Define(goyek.Task{Name: "one"})
+	flow.Define(goyek.Task{Name: "two"})
+
+	act := func() { task.SetName("two") }
+
+	assertPanics(t, act, "should not allow setting existing task name")
+}
+
+func TestDefinedTask_SetUsage(t *testing.T) {
+	flow := &goyek.Flow{}
+	flow.SetOutput(ioutil.Discard)
+	task := flow.Define(goyek.Task{Name: "one"})
+
+	task.SetUsage("good task")
+	got := flow.Tasks()[0].Usage()
+
+	assertEqual(t, got, "good task", "should update the usage")
+}
+
+func TestDefinedTask_SetAction(t *testing.T) {
+	getFuncName := func(fn func(tf *goyek.TF)) string {
+		return runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()
+	}
+
+	flow := &goyek.Flow{}
+	flow.SetOutput(ioutil.Discard)
+	originalNotCalled := true
+	task := flow.Define(goyek.Task{Name: "one", Action: func(tf *goyek.TF) { originalNotCalled = false }})
+
+	newCalled := false
+	fn := func(tf *goyek.TF) { newCalled = true }
+	task.SetAction(fn)
+	want := getFuncName(fn)
+	got := getFuncName(task.Action())
+
+	assertEqual(t, got, want, "should update the action")
+	err := flow.Execute(context.Background(), "one")
+	assertPass(t, err, "should pass")
+	assertTrue(t, originalNotCalled, "should not call the previous action")
+	assertTrue(t, newCalled, "should not call the new action")
 }
 
 func TestDefinedTask_SetDeps(t *testing.T) {

--- a/task_test.go
+++ b/task_test.go
@@ -97,7 +97,7 @@ func TestDefinedTask_SetDeps(t *testing.T) {
 	t3.SetDeps(goyek.Deps{t1, t2})
 
 	got := t3.Deps()
-	assertEqual(t, got, goyek.Deps{t2}, "should update the dependencies")
+	assertEqual(t, got, goyek.Deps{t1, t2}, "should update the dependencies")
 
 	err := flow.Execute(context.Background(), "three")
 	assertPass(t, err, "should pass")


### PR DESCRIPTION
## Why

Fixes https://github.com/goyek/goyek/issues/242

## What

Add `DefinedTask.SetName`, `DefinedTask.SetUsage`, `DefinedTask.Action`, `DefinedTask.SetAction`, `DefinedTask.SetAction`, `DefinedTask.SetDeps` to enable modifying the task after the initial definition.

## Checklist

<!-- All items should be verified and marked as done.
     If an item doesn't apply to the introduced changes - check it as done too. -->

- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated.
- [x] The code changes follow [Effective Go](https://golang.org/doc/effective_go).
- [x] The code changes follow [CodeReviewComments](https://github.com/golang/go/wiki/CodeReviewComments).
- [x] The code changes are covered by tests.

<!-- markdownlint-disable-file MD041 -->
