### PR TITLE
Add Flow.Undefine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ reusable build pipelines easier.
 - Add `DefinedTask.SetName`, `DefinedTask.SetUsage`, `DefinedTask.Action`,
   `DefinedTask.SetAction`, `DefinedTask.SetAction`, `DefinedTask.SetDeps`
   to enable modifying the task after the initial definition.
+- Add `Flow.Undefine` to register the task.
+- Passing `nil` to `Flow.SetDefault` unsets the default task.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ reusable build pipelines easier.
 - Add `DefinedTask.SetName`, `DefinedTask.SetUsage`, `DefinedTask.Action`,
   `DefinedTask.SetAction`, `DefinedTask.SetAction`, `DefinedTask.SetDeps`
   to enable modifying the task after the initial definition.
-- Add `Flow.Undefine` to register the task.
+- Add `Flow.Undefine` method and `Undefine` function to unregister a task.
 - Passing `nil` to `Flow.SetDefault` unsets the default task.
 
 ### Changed

--- a/flow.go
+++ b/flow.go
@@ -90,7 +90,12 @@ func (f *Flow) Define(task Task) DefinedTask {
 	return registeredTask{taskCopy, f}
 }
 
-// Undefine registers the task. It panics in case of any error.
+// Undefine unregisters the task. It panics in case of any error.
+func Undefine(task DefinedTask) {
+	DefaultFlow.Undefine(task)
+}
+
+// Undefine unregisters the task. It panics in case of any error.
 func (f *Flow) Undefine(task DefinedTask) {
 	snapshot := task.sealed().taskSnapshot
 	if !f.isDefined(snapshot.name, task.sealed().flow) {

--- a/flow_test.go
+++ b/flow_test.go
@@ -615,7 +615,7 @@ func TestFlow_Undefine(t *testing.T) {
 	flow := &goyek.Flow{}
 	task := flow.Define(goyek.Task{Name: "name"})
 	dep := flow.Define(goyek.Task{Name: "dep"})
-	flow.Define(goyek.Task{Name: "task", Deps: goyek.Deps{dep, task}})
+	pipeline := flow.Define(goyek.Task{Name: "task", Deps: goyek.Deps{dep, task}})
 
 	flow.SetDefault(task)
 	flow.Undefine(task)
@@ -625,10 +625,11 @@ func TestFlow_Undefine(t *testing.T) {
 	assertEqual(t, len(got), 2, "should return only one task")
 	assertEqual(t, got[1].Name(), "task", "should first return one")
 	assertEqual(t, got[1].Deps(), goyek.Deps{dep}, "should remove dependency")
+	assertEqual(t, pipeline.Deps(), goyek.Deps{dep}, "should remove dependency")
 	assertEqual(t, flow.Default(), nil, "should clear default")
 }
 
-func Test_Define_bad_task(t *testing.T) {
+func TestFlow_Undefine_bad_task(t *testing.T) {
 	flow := &goyek.Flow{}
 	otherFlow := &goyek.Flow{}
 	task := otherFlow.Define(goyek.Task{Name: "different-flow"})

--- a/flow_test.go
+++ b/flow_test.go
@@ -24,6 +24,8 @@ func Test_DefaultFlow(t *testing.T) {
 	goyek.Usage()()
 
 	task := goyek.Define(goyek.Task{Name: "task"})
+	other := goyek.Define(goyek.Task{Name: "other"})
+	goyek.Undefine(other)
 	assertEqual(t, goyek.Tasks()[0].Name(), "task", "Tasks")
 
 	goyek.SetDefault(task)

--- a/helper_test.go
+++ b/helper_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/goyek/goyek/v2"
 )
 
+var noDeps goyek.Deps
+
 func assertTrue(tb testing.TB, got bool, msg string) {
 	tb.Helper()
 	if got {

--- a/task_test.go
+++ b/task_test.go
@@ -127,9 +127,8 @@ func TestDefinedTask_SetDeps_clear(t *testing.T) {
 
 	t2.SetDeps(nil)
 
-	var want goyek.Deps
 	got := t2.Deps()
-	assertEqual(t, got, want, "should clear the dependencies")
+	assertEqual(t, got, noDeps, "should clear the dependencies")
 
 	err := flow.Execute(context.Background(), "two")
 	assertPass(t, err, "should pass")


### PR DESCRIPTION
## Why

Fixes https://github.com/goyek/goyek/issues/241

## What

- Add `Flow.Undefine` and `Undefine` to unregister a task.
- Passing `nil` to `Flow.SetDefault` unsets the default task.

## Checklist

<!-- All items should be verified and marked as done.
     If an item doesn't apply to the introduced changes - check it as done too. -->

- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated.
- [x] The code changes follow [Effective Go](https://golang.org/doc/effective_go).
- [x] The code changes follow [CodeReviewComments](https://github.com/golang/go/wiki/CodeReviewComments).
- [x] The code changes are covered by tests.

<!-- markdownlint-disable-file MD041 -->
