### PR TITLE
Release 2.0.0-rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 as well as to [Module version numbering](https://go.dev/doc/modules/version-numbers).
 
-## [Unreleased](https://github.com/goyek/goyek/compare/v2.0.0-rc.3...HEAD)
+## [Unreleased](https://github.com/goyek/goyek/compare/v2.0.0-rc.4...HEAD)
+
+<!-- markdownlint-disable-next-line line-length -->
+## [2.0.0-rc.4](https://github.com/goyek/goyek/compare/v2.0.0-rc.3...v2.0.0-rc.4) - 2022-10-25
 
 This release focuses on improving the API to make creating and customizing
 reusable build pipelines easier.
@@ -25,9 +28,11 @@ reusable build pipelines easier.
 - `DefinedTask.Deps` returns `Deps` to facilitate reusing defined task's dependencies
   when creating a new one or redefining existing one.
 - Rename `Reporter` middleware to `ReportStatus`.
-- Change `Flow.Execute` to accept `[]string` instead of `...string`.
+- Change `Flow.Execute` to accept `[]string` instead of `...string` to make the API
+  forward compatible.
 
-## [2.0.0-rc.3](https://github.com/goyek/goyek/compare/v2.0.0-rc.2...v2.0.0-rc.3)
+<!-- markdownlint-disable-next-line line-length -->
+## [2.0.0-rc.3](https://github.com/goyek/goyek/compare/v2.0.0-rc.2...v2.0.0-rc.3) - 2022-10-19
 
 This release focuses on improving usability, extensibility, and customization.
 
@@ -73,7 +78,8 @@ This release focuses on improving usability, extensibility, and customization.
 
 - Fix panic handling so that `panic(nil)` and `runtime.Goexit()` now cause task failure.
 
-## [2.0.0-rc.2](https://github.com/goyek/goyek/compare/v2.0.0-rc.1...v2.0.0-rc.2)
+<!-- markdownlint-disable-next-line line-length -->
+## [2.0.0-rc.2](https://github.com/goyek/goyek/compare/v2.0.0-rc.1...v2.0.0-rc.2) - 2022-10-14
 
 This release focuses on improving usability and encapsulation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ reusable build pipelines easier.
 - Add `DefinedTask.SetName`, `DefinedTask.SetUsage`, `DefinedTask.Action`,
   `DefinedTask.SetAction`, `DefinedTask.SetAction`, `DefinedTask.SetDeps`
   to enable modifying the task after the initial definition.
-- Add `Flow.Undefine` method and `Undefine` function to unregister a task.
+- Add `Flow.Undefine` to unregister a task.
 - Passing `nil` to `Flow.SetDefault` unsets the default task.
 - Add `DryRun`, `ReportLongRun` middlewares.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 This release focuses on improving the API to make creating and customizing
 reusable build pipelines easier.
 
-## Added
+### Added
 
 - Add `DefinedTask.SetName`, `DefinedTask.SetUsage`, `DefinedTask.Action`,
   `DefinedTask.SetAction`, `DefinedTask.SetAction`, `DefinedTask.SetDeps`

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Please ⭐ `Star` this repository if you find it valuable and worth maintaining.
 
 ---
 
-This README documents the latest `v2.0.0-rc.3` release.
+This README documents the latest `v2.0.0-rc.4` release.
 The documentation for `v1.1.0` can be found on [pkg.go.dev](https://pkg.go.dev/github.com/goyek/goyek).
 
 ---
@@ -193,8 +193,8 @@ Simply add them to your repository's root directory
 and make sure to add the `+x` permission:
 
 ```sh
-curl -sSfL https://raw.githubusercontent.com/goyek/goyek/v2.0.0-rc.3/goyek.sh -O
-curl -sSfL https://raw.githubusercontent.com/goyek/goyek/v2.0.0-rc.3/goyek.ps1 -O
+curl -sSfL https://raw.githubusercontent.com/goyek/goyek/v2.0.0-rc.4/goyek.sh -O
+curl -sSfL https://raw.githubusercontent.com/goyek/goyek/v2.0.0-rc.4/goyek.ps1 -O
 git add --chmod=+x goyek.sh goyek.ps1
 ```
 

--- a/build/go.mod
+++ b/build/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/client9/misspell v0.3.4
 	github.com/golangci/golangci-lint v1.50.1
-	github.com/goyek/goyek/v2 v2.0.0-rc.3
+	github.com/goyek/goyek/v2 v2.0.0-rc.4
 	github.com/mattn/go-shellwords v1.0.12
 )
 


### PR DESCRIPTION
This release focuses on improving the API to make creating and customizing reusable build pipelines easier.

### Added

- Add `DefinedTask.SetName`, `DefinedTask.SetUsage`, `DefinedTask.Action`, `DefinedTask.SetAction`, `DefinedTask.SetAction`, `DefinedTask.SetDeps` to enable modifying the task after the initial definition.
- Add `Flow.Undefine` to unregister a task.
- Passing `nil` to `Flow.SetDefault` unsets the default task.
- Add `DryRun`, `ReportLongRun` middlewares.

### Changed

- `DefinedTask.Deps` returns `Deps` to facilitate reusing defined task's dependencies when creating a new one or redefining existing one.
- Rename `Reporter` middleware to `ReportStatus`.
- Change `Flow.Execute` to accept `[]string` instead of `...string` to make the API forward compatible.