### PR TITLE
Release 2.0.0-rc.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 
 This release introduces a breaking change as it renames
 the heavily used `TF` type to `A`. This follows the convention
-used in [`testing`](https://pkg.go.dev/testing)
+used in [`testing`](https://pkg.go.dev/testing) package
 to name the parameter type as the first letter of the "function type".
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 as well as to [Module version numbering](https://go.dev/doc/modules/version-numbers).
 
-## [Unreleased](https://github.com/goyek/goyek/compare/v2.0.0-rc.8...HEAD)
+## [Unreleased](https://github.com/goyek/goyek/compare/v2.0.0-rc.9...HEAD)
+
+<!-- markdownlint-disable-next-line line-length -->
+## [2.0.0-rc.9](https://github.com/goyek/goyek/compare/v2.0.0-rc.8...v2.0.0-rc.9) - 2022-11-06
+
+This release introduces a breaking change as it renames
+the heavily used `TF` type to `A`. This follows the convention
+used in [`testing`](https://pkg.go.dev/testing)
+to name the parameter type as the first letter of the "function type".
 
 ### Added
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,9 +34,7 @@ The repository contains basic confiugration for
 
 Create a pull request named `Release <version>` that does the following:
 
-1. Review all places where the current version is used:
-   - [`README.md`](README.md)
-   - [`build/go.mod`](build/go.mod)
+1. Review all places where the current version is used [`README.md`](README.md).
 1. Remove the changed API warning in [`README.md`](README.md) if it is present.
 1. Add documentation or examples if it they are missing.
 1. Update [`CHANGELOG.md`](CHANGELOG.md).

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Please ⭐ `Star` this repository if you find it valuable and worth maintaining.
 
 ---
 
-This README documents the latest `v2.0.0-rc.8` release.
+This README documents the latest `v2.0.0-rc.9` release.
 The documentation for `v1.1.0` can be found on [pkg.go.dev](https://pkg.go.dev/github.com/goyek/goyek).
 
 ---
@@ -219,8 +219,8 @@ Simply add them to your repository's root directory
 and make sure to add the `+x` permission:
 
 ```sh
-curl -sSfL https://raw.githubusercontent.com/goyek/goyek/v2.0.0-rc.8/goyek.sh -O
-curl -sSfL https://raw.githubusercontent.com/goyek/goyek/v2.0.0-rc.8/goyek.ps1 -O
+curl -sSfL https://raw.githubusercontent.com/goyek/goyek/v2.0.0-rc.9/goyek.sh -O
+curl -sSfL https://raw.githubusercontent.com/goyek/goyek/v2.0.0-rc.9/goyek.ps1 -O
 git add --chmod=+x goyek.sh goyek.ps1
 ```
 

--- a/build/go.mod
+++ b/build/go.mod
@@ -2,10 +2,12 @@ module github.com/goyek/goyek/build
 
 go 1.19
 
+replace github.com/goyek/goyek/v2 => ../
+
 require (
 	github.com/client9/misspell v0.3.4
 	github.com/golangci/golangci-lint v1.50.1
-	github.com/goyek/goyek/v2 v2.0.0-rc.8
+	github.com/goyek/goyek/v2 v2.0.0-00010101000000-000000000000
 	github.com/mattn/go-shellwords v1.0.12
 )
 
@@ -179,5 +181,3 @@ require (
 	mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b // indirect
 	mvdan.cc/unparam v0.0.0-20220706161116-678bad134442 // indirect
 )
-
-replace github.com/goyek/goyek/v2 => ../


### PR DESCRIPTION
This release introduces a breaking change as it renames the heavily used `TF` type to `A`. This follows the convention used in [`testing`](https://pkg.go.dev/testing) package to name the parameter type as the first letter of the "function type".

### Added

- Add `Status.String` method for printing `Status`.

### Changed

- Rename `TF` type to `A` as this is the `Action` parameter.