### PR TITLE
Add A.Setenv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 ### Added
 
 - Add `A.Cleanup` method that registers an action's cleanup function.
+- Add `A.Setenv` method that sets the environment variable
+  and returns the previous value during cleanup.
 
 <!-- markdownlint-disable-next-line line-length -->
 ## [2.0.0-rc.9](https://github.com/goyek/goyek/compare/v2.0.0-rc.8...v2.0.0-rc.9) - 2022-11-06

--- a/a_test.go
+++ b/a_test.go
@@ -4,10 +4,107 @@ import (
 	"context"
 	"io"
 	"io/ioutil"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/goyek/goyek/v2"
 )
+
+func TestA_Cleanup(t *testing.T) {
+	out := &strings.Builder{}
+
+	got := goyek.NewRunner(func(a *goyek.A) {
+		a.Cleanup(func() {
+			a.Cleanup(func() {
+				a.Log("5")
+				panic("second panic")
+			})
+			a.Cleanup(func() {
+				a.Log("4")
+			})
+			a.Log("3")
+			panic("first panic")
+		})
+		a.Log("1")
+		a.Cleanup(func() {
+			a.Log("2")
+		})
+	})(goyek.Input{Logger: &goyek.FmtLogger{}, Output: out})
+
+	assertEqual(t, got.Status, goyek.StatusFailed, "shoud return proper status")
+	assertEqual(t, got.PanicValue, "first panic", "shoud return proper panic value")
+	assertContains(t, out, "1\n2\n3\n4\n5", "should call cleanup funcs in LIFO order")
+}
+
+func TestA_Cleanup_when_action_panics(t *testing.T) {
+	out := &strings.Builder{}
+
+	got := goyek.NewRunner(func(a *goyek.A) {
+		a.Cleanup(func() {
+			a.Cleanup(func() {
+				a.Log("5")
+				panic("second panic")
+			})
+			a.Cleanup(func() {
+				a.Log("4")
+			})
+			a.Log("3")
+			panic("first panic")
+		})
+		a.Log("1")
+		a.Cleanup(func() {
+			a.Log("2")
+		})
+		panic("action panic")
+	})(goyek.Input{Logger: &goyek.FmtLogger{}, Output: out})
+
+	assertEqual(t, got.Status, goyek.StatusFailed, "shoud return proper status")
+	assertEqual(t, got.PanicValue, "action panic", "shoud return proper panic value")
+	assertContains(t, out, "1\n2\n3\n4\n5", "should call cleanup funcs in LIFO order")
+}
+
+func TestA_Cleanup_Fail(t *testing.T) {
+	got := goyek.NewRunner(func(a *goyek.A) {
+		a.Cleanup(func() {
+			a.Fail()
+		})
+	})(goyek.Input{})
+
+	assertEqual(t, got.Status, goyek.StatusFailed, "shoud return proper status")
+}
+
+func TestA_Setenv(t *testing.T) {
+	key := "GOYEK_TEST_ENV"
+	val := "1"
+	goyek.NewRunner(func(a *goyek.A) {
+		a.Setenv(key, val)
+
+		got := os.Getenv(key)
+		assertEqual(t, got, val, "should set the value")
+	})(goyek.Input{})
+
+	got := os.Getenv(key)
+	assertEqual(t, got, "", "should restore the value after the action")
+}
+
+func TestA_Setenv_restore(t *testing.T) {
+	key := "GOYEK_TEST_ENV"
+	prev := "0"
+	val := "1"
+	os.Setenv(key, prev)   //nolint:errcheck,gosec // should never happen
+	defer os.Unsetenv(key) //nolint:errcheck // should never happen
+
+	goyek.NewRunner(func(a *goyek.A) {
+		a.Setenv(key, val)
+
+		got := os.Getenv(key)
+		assertEqual(t, got, val, "should set the value")
+	})(goyek.Input{})
+
+	got := os.Getenv(key)
+	assertEqual(t, got, prev, "should restore the value after the action")
+}
 
 func TestA_uses_Logger_dynamic_interface(t *testing.T) {
 	testCases := []struct {

--- a/runner_test.go
+++ b/runner_test.go
@@ -1,7 +1,6 @@
 package goyek_test
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/goyek/goyek/v2"
@@ -57,67 +56,4 @@ func TestRunner_panic(t *testing.T) {
 
 	assertEqual(t, got.Status, goyek.StatusFailed, "shoud return proper status")
 	assertEqual(t, got.PanicValue, payload, "shoud return proper panic value")
-}
-
-func TestCleanup(t *testing.T) {
-	out := &strings.Builder{}
-
-	got := goyek.NewRunner(func(t *goyek.A) {
-		t.Cleanup(func() {
-			t.Cleanup(func() {
-				t.Log("5")
-				panic("second panic")
-			})
-			t.Cleanup(func() {
-				t.Log("4")
-			})
-			t.Log("3")
-			panic("first panic")
-		})
-		t.Log("1")
-		t.Cleanup(func() {
-			t.Log("2")
-		})
-	})(goyek.Input{Logger: &goyek.FmtLogger{}, Output: out})
-
-	assertEqual(t, got.Status, goyek.StatusFailed, "shoud return proper status")
-	assertEqual(t, got.PanicValue, "first panic", "shoud return proper panic value")
-	assertContains(t, out, "1\n2\n3\n4\n5", "should call cleanup funcs in LIFO order")
-}
-
-func TestCleanup_when_action_panics(t *testing.T) {
-	out := &strings.Builder{}
-
-	got := goyek.NewRunner(func(t *goyek.A) {
-		t.Cleanup(func() {
-			t.Cleanup(func() {
-				t.Log("5")
-				panic("second panic")
-			})
-			t.Cleanup(func() {
-				t.Log("4")
-			})
-			t.Log("3")
-			panic("first panic")
-		})
-		t.Log("1")
-		t.Cleanup(func() {
-			t.Log("2")
-		})
-		panic("action panic")
-	})(goyek.Input{Logger: &goyek.FmtLogger{}, Output: out})
-
-	assertEqual(t, got.Status, goyek.StatusFailed, "shoud return proper status")
-	assertEqual(t, got.PanicValue, "action panic", "shoud return proper panic value")
-	assertContains(t, out, "1\n2\n3\n4\n5", "should call cleanup funcs in LIFO order")
-}
-
-func TestCleanup_Fail(t *testing.T) {
-	got := goyek.NewRunner(func(t *goyek.A) {
-		t.Cleanup(func() {
-			t.Fail()
-		})
-	})(goyek.Input{})
-
-	assertEqual(t, got.Status, goyek.StatusFailed, "shoud return proper status")
 }


### PR DESCRIPTION
## Why

Fixes https://github.com/goyek/goyek/issues/287
## What

Add `A.Setenv` method that sets the environment variable and returns the previous value during cleanup.

## Checklist

<!-- All items should be verified and marked as done.
     If an item doesn't apply to the introduced changes - check it as done too. -->

- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated.
- [x] The code changes follow [Effective Go](https://golang.org/doc/effective_go).
- [x] The code changes follow [CodeReviewComments](https://github.com/golang/go/wiki/CodeReviewComments).
- [x] The code changes are covered by tests.

<!-- markdownlint-disable-file MD041 -->
