### PR TITLE
Release 2.0.0-rc.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 as well as to [Module version numbering](https://go.dev/doc/modules/version-numbers).
 
-## [Unreleased](https://github.com/goyek/goyek/compare/v2.0.0-rc.11...HEAD)
+## [Unreleased](https://github.com/goyek/goyek/compare/v2.0.0-rc.12...HEAD)
+
+<!-- markdownlint-disable-next-line line-length -->
+## [2.0.0-rc.12](https://github.com/goyek/goyek/compare/v2.0.0-rc.11...v2.0.0-rc.12) - 2022-11-24
 
 ### Removed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,10 +20,8 @@ Make sure to be familiar with our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Developing
 
-Go and Docker is required.
-
 Run `./goyek.sh` (Bash) or `.\goyek.ps1` (PowerShell)
-[wrapper scripts](README.md#wrapper-scripts) to execute the build pipeline.
+to execute the build pipeline.
 
 The repository contains basic confiugration for
 [Visual Studio Code](https://code.visualstudio.com/).
@@ -32,16 +30,12 @@ The repository contains basic confiugration for
 
 ### Pre-release
 
-Create a pull request named `Release <version>` that does the following:
+Create a pull request named `Release <version>` to update the [`CHANGELOG.md`](CHANGELOG.md):
 
-1. Review all places where the current version is used [`README.md`](README.md).
-1. Remove the changed API warning in [`README.md`](README.md) if it is present.
-1. Add documentation or examples if it they are missing.
-1. Update [`CHANGELOG.md`](CHANGELOG.md).
-   - Change the `Unreleased` header to represent the new release.
-   - Consider adding a description for the new release.
-     Especially if it adds new features or introduces breaking changes.
-   - Add a new `Unreleased` header above the new release, with no details.
+- Change the `Unreleased` header to represent the new release.
+- Consider adding a description for the new release.
+  Especially if it adds new features or introduces breaking changes.
+- Add a new `Unreleased` header above the new release, with no details.
 
 ### Release
 


### PR DESCRIPTION
### Removed

- Remove `A.Cmd`. Use [`github.com/goyek/goyek/x/cmd`](https://pkg.go.dev/github.com/goyek/x/cmd) or your own helper instead.