### PR TITLE
Add Go license and copyright notice to LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -22,5 +22,7 @@ SOFTWARE.
 
 The Initial Developer of some parts of the software, which are copied from,
 or derived from the Go standard library (https://cs.opensource.google/go/go),
+which is available under the MIT License
+(https://cs.opensource.google/go/go/+/master:LICENSE),
 are The Go Authors.
 Copyright (c) 2009 The Go Authors. All rights reserved.

--- a/LICENSE
+++ b/LICENSE
@@ -19,3 +19,8 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+The Initial Developer of some parts of the software, which are copied from,
+or derived from the Go standard library (https://cs.opensource.google/go/go),
+are The Go Authors.
+Copyright (c) 2009 The Go Authors. All rights reserved.


### PR DESCRIPTION
## Why

`a.go` and `logger.go` contains code copied from or derived from https://cs.opensource.google/go/go/+/refs/tags/go1.20.2:src/testing/testing.go

## What

Add The Go license and copyright notices to `LICENSE`.
