### PR TITLE
Fix arg expansion in Shell wrapper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ set -euo pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 cd "$DIR"
-go run ./build $@
+go run ./build "$@"
 ```
 
 PowerShell - `goyek.ps1`:

--- a/goyek.sh
+++ b/goyek.sh
@@ -3,4 +3,4 @@ set -euo pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 cd "$DIR/build"
-go run . $@
+go run . "$@"


### PR DESCRIPTION
## Why

The script was not handling cases like: `./goyek.sh -cmd="echo 1" formods`

## What

Fix arg expansion in Shell wrapper script
## Checklist

<!-- All items should be verified and marked as done.
     If an item doesn't apply to the introduced changes - check it as done too. -->

- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated.
- [x] The code changes follow [Effective Go](https://golang.org/doc/effective_go).
- [x] The code changes follow [CodeReviewComments](https://github.com/golang/go/wiki/CodeReviewComments).
- [x] The code changes are covered by tests.

<!-- markdownlint-disable-file MD041 -->
