### PR TITLE
Add middleware.ReportFlow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,8 +37,6 @@ jobs:
       fail-fast: false
       matrix:
         go-version:
-          - '1.11'
-          - '1.12'
           - '1.13'
           - '1.14'
           - '1.15'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,7 @@ linters-settings:
     lines: 100
     statements: 50
   gocyclo:
-    min-complexity: 20
+    min-complexity: 15
   goimports:
     local-prefixes: github.com/goyek/goyek/v2
   govet:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,7 @@ linters-settings:
     lines: 100
     statements: 50
   gocyclo:
-    min-complexity: 15
+    min-complexity: 20
   goimports:
     local-prefixes: github.com/goyek/goyek/v2
   govet:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
   Add the middleware using `Flow.UseExecutor` to achieve  a backwards compatible
   behavior.
 
+### Removed
+
+- Drop support for Go 1.11 and 1.12.
+
 ## [2.1.0](https://github.com/goyek/goyek/compare/v2.0.0...v2.1.0) - 2024-01-17
 
 This release adds parallel task execution support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 ### Change
 
 - Extract the flow result reporting from `Flow.Main` to `middleware.ReportFlow`.
-  Add the middleware using `Flow.UseExecutor` to acheive a backwards compatible behavior.
+  Add the middleware using `Flow.UseExecutor` to achieve  a backwards compatible
+  behavior.
 
 ## [2.1.0](https://github.com/goyek/goyek/compare/v2.0.0...v2.1.0) - 2024-01-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 ### Change
 
 - Extract the flow result reporting from `Flow.Main` to `middleware.ReportFlow`.
-  Add the middleware using `Flow.UseExecutor` to achieve a backwards compatible
+  Add the middleware using `Flow.UseExecutor` to achieve a backward compatible
   behavior.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 ### Change
 
 - Extract the flow result reporting from `Flow.Main` to `middleware.ReportFlow`.
-  Add the middleware using `Flow.UseExecutor` to achieve  a backwards compatible
+  Add the middleware using `Flow.UseExecutor` to achieve a backwards compatible
   behavior.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 ### Added
 
 - Add `Flow.UseExecutor` method to support flow execution interception using middlewares.
+- Add `middleware.ReportFlow` flow execution middleware which reports the flow
+  execution status.
+
+### Change
+
+- Extract the flow result reporting from `Flow.Main` to `middleware.ReportFlow`.
+  Add the middleware using `Flow.UseExecutor` to acheive a backwards compatible behavior.
 
 ## [2.1.0](https://github.com/goyek/goyek/compare/v2.0.0...v2.1.0) - 2024-01-17
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Here are some good parts:
 - It is highly customizable.
 - It does not use any third-party dependency other than the Go standard library.
   You can find supplumental features in [`goyek/x`](https://github.com/goyek/x).
-- Minimal supported Go version is 1.11.
+- Minimal supported Go version is 1.13.
 
 ## Quick start
 

--- a/build/main.go
+++ b/build/main.go
@@ -44,6 +44,8 @@ func main() {
 	flag.Usage = usage
 	flag.Parse()
 
+	goyek.UseExecutor(middleware.ReportFlow)
+
 	if *dryRun {
 		*v = true // needed to report the task status
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -95,6 +95,7 @@ func Example_flag() {
 	flag.Parse()
 
 	// configure middlewares
+	goyek.UseExecutor(middleware.ReportFlow)
 	goyek.Use(middleware.ReportStatus)
 	if !*verbose {
 		goyek.Use(middleware.SilentNonFailed)

--- a/executor.go
+++ b/executor.go
@@ -113,6 +113,9 @@ func (r *executor) Execute(in ExecuteInput) error {
 }
 
 func (r *executor) validate(in ExecuteInput) error {
+	if len(in.Tasks) == 0 {
+		return errors.New("no task provided")
+	}
 	for _, task := range in.Tasks {
 		if task == "" {
 			return errors.New("task name cannot be empty")
@@ -120,10 +123,6 @@ func (r *executor) validate(in ExecuteInput) error {
 		if _, ok := r.defined[task]; !ok {
 			return errors.New("task provided but not defined: " + task)
 		}
-	}
-
-	if len(in.Tasks) == 0 {
-		return errors.New("no task provided")
 	}
 
 	for _, skippedTask := range in.SkipTasks {

--- a/executor.go
+++ b/executor.go
@@ -32,6 +32,8 @@ type (
 
 // Execute runs provided tasks and all their dependencies.
 // Each task is executed at most once.
+//
+//nolint:gocyclo // Contains graph traversal logic.
 func (r *executor) Execute(in ExecuteInput) error {
 	// Handle default task.
 	if len(in.Tasks) == 0 && r.defaultTask != nil {

--- a/flow.go
+++ b/flow.go
@@ -2,7 +2,6 @@ package goyek
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -10,7 +9,6 @@ import (
 	"sort"
 	"strings"
 	"text/tabwriter"
-	"time"
 )
 
 // Flow is the root type of the package.
@@ -351,21 +349,6 @@ func Execute(ctx context.Context, tasks []string, opts ...Option) error {
 // [FailError] if a task failed,
 // other errors in case of invalid input or context error.
 func (f *Flow) Execute(ctx context.Context, tasks []string, opts ...Option) error {
-	for _, task := range tasks {
-		if task == "" {
-			return errors.New("task name cannot be empty")
-		}
-		if _, ok := f.tasks[task]; !ok {
-			return errors.New("task provided but not defined: " + task)
-		}
-	}
-	if len(tasks) == 0 && f.defaultTask != nil {
-		tasks = append(tasks, f.defaultTask.name)
-	}
-	if len(tasks) == 0 {
-		return errors.New("no task provided")
-	}
-
 	var middlewares []Middleware
 	middlewares = append(middlewares, f.middlewares...)
 
@@ -374,19 +357,11 @@ func (f *Flow) Execute(ctx context.Context, tasks []string, opts ...Option) erro
 		opt.apply(cfg)
 	}
 
-	for _, skippedTask := range cfg.skipTasks {
-		if skippedTask == "" {
-			return errors.New("skipped task name cannot be empty")
-		}
-		if _, ok := f.tasks[skippedTask]; !ok {
-			return errors.New("skipped task provided but not defined: " + skippedTask)
-		}
-	}
-
 	// prepare runner
 	r := &executor{
 		defined:     f.tasks,
 		middlewares: middlewares,
+		defaultTask: f.defaultTask,
 	}
 	runner := r.Execute
 
@@ -456,24 +431,17 @@ func (f *Flow) Main(args []string, opts ...Option) {
 }
 
 func (f *Flow) main(ctx context.Context, args []string, opts ...Option) int {
-	out := f.Output()
-
-	from := time.Now()
 	err := f.Execute(ctx, args, opts...)
 	if _, ok := err.(*FailError); ok {
-		fmt.Fprintf(out, "%v\t%.3fs\n", err, time.Since(from).Seconds())
 		return exitCodeFail
 	}
 	if err == context.Canceled || err == context.DeadlineExceeded {
-		fmt.Fprintf(out, "%v\t%.3fs\n", err, time.Since(from).Seconds())
 		return exitCodeFail
 	}
 	if err != nil {
-		fmt.Fprintln(out, err.Error())
 		f.Usage()()
 		return exitCodeInvalid
 	}
-	fmt.Fprintf(out, "ok\t%.3fs\n", time.Since(from).Seconds())
 	return exitCodePass
 }
 

--- a/flow.go
+++ b/flow.go
@@ -2,6 +2,7 @@ package goyek
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -435,7 +436,7 @@ func (f *Flow) main(ctx context.Context, args []string, opts ...Option) int {
 	if _, ok := err.(*FailError); ok {
 		return exitCodeFail
 	}
-	if err == context.Canceled || err == context.DeadlineExceeded {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return exitCodeFail
 	}
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/goyek/goyek/v2
 
-go 1.11
+go 1.13

--- a/middleware/reportflow.go
+++ b/middleware/reportflow.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -16,17 +15,8 @@ func ReportFlow(next goyek.Executor) goyek.Executor {
 		out := in.Output
 
 		from := time.Now()
-		err := next(in)
-		if _, ok := err.(*goyek.FailError); ok {
+		if err := next(in); err != nil {
 			fmt.Fprintf(out, "%v\t%.3fs\n", err, time.Since(from).Seconds())
-			return err
-		}
-		if err == context.Canceled || err == context.DeadlineExceeded {
-			fmt.Fprintf(out, "%v\t%.3fs\n", err, time.Since(from).Seconds())
-			return err
-		}
-		if err != nil {
-			fmt.Fprintln(out, err.Error())
 			return err
 		}
 		fmt.Fprintf(out, "ok\t%.3fs\n", time.Since(from).Seconds())

--- a/middleware/reportflow.go
+++ b/middleware/reportflow.go
@@ -1,0 +1,35 @@
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/goyek/goyek/v2"
+)
+
+// ReportStatus is a middleware which reports the flow execution status.
+//
+// The format is based on the reports provided by the Go test runner.
+func ReportFlow(next goyek.Executor) goyek.Executor {
+	return func(in goyek.ExecuteInput) error {
+		out := in.Output
+
+		from := time.Now()
+		err := next(in)
+		if _, ok := err.(*goyek.FailError); ok {
+			fmt.Fprintf(out, "%v\t%.3fs\n", err, time.Since(from).Seconds())
+			return err
+		}
+		if err == context.Canceled || err == context.DeadlineExceeded {
+			fmt.Fprintf(out, "%v\t%.3fs\n", err, time.Since(from).Seconds())
+			return err
+		}
+		if err != nil {
+			fmt.Fprintln(out, err.Error())
+			return err
+		}
+		fmt.Fprintf(out, "ok\t%.3fs\n", time.Since(from).Seconds())
+		return nil
+	}
+}

--- a/middleware/reportflow_test.go
+++ b/middleware/reportflow_test.go
@@ -11,7 +11,6 @@ import (
 
 func TestReportFlow(t *testing.T) {
 	flow := &goyek.Flow{}
-
 	flow.Define(goyek.Task{Name: "task"})
 	flow.Define(goyek.Task{Name: "failing", Action: func(a *goyek.A) { a.Fail() }})
 	flow.UseExecutor(middleware.ReportFlow)

--- a/middleware/reportflow_test.go
+++ b/middleware/reportflow_test.go
@@ -1,0 +1,59 @@
+package middleware_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/goyek/goyek/v2"
+	"github.com/goyek/goyek/v2/middleware"
+)
+
+func TestReportFlow(t *testing.T) {
+	flow := &goyek.Flow{}
+
+	flow.Define(goyek.Task{Name: "task"})
+	flow.Define(goyek.Task{Name: "failing", Action: func(a *goyek.A) { a.Fail() }})
+	flow.UseExecutor(middleware.ReportFlow)
+
+	testCases := []struct {
+		desc string
+		want string
+		act  func()
+	}{
+		{
+			desc: "pass",
+			want: "ok",
+			act:  func() { _ = flow.Execute(context.Background(), []string{"task"}) },
+		},
+		{
+			desc: "fail",
+			want: "task failed: failing",
+			act:  func() { _ = flow.Execute(context.Background(), []string{"failing"}) },
+		},
+		{
+			desc: "invalid",
+			want: "task provided but not defined: bad",
+			act:  func() { _ = flow.Execute(context.Background(), []string{"bad"}) },
+		},
+		{
+			desc: "canceled",
+			want: "context canceled",
+			act: func() {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				_ = flow.Execute(ctx, []string{"task"})
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			b := &strings.Builder{}
+			flow.SetOutput(b)
+			tc.act()
+			if got := b.String(); !strings.Contains(got, tc.want) {
+				t.Errorf("got: %s; should contain: %s", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why

Fixes https://github.com/goyek/goyek/issues/416 (second part)

Follows https://github.com/goyek/goyek/pull/418

## What

- Add `middleware.ReportFlow` flow execution middleware which reports the flow execution status.
- Extract the flow result reporting from `Flow.Main` to `middleware.ReportFlow`. Add the middleware using `Flow.UseExecutor` to achieve a backwards compatible behavior.

## Checklist

<!-- All items should be verified and marked as done.
     If an item doesn't apply to the introduced changes - check it as done too. -->

- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated.
- [x] The code changes follow [Effective Go](https://golang.org/doc/effective_go).
- [x] The code changes follow [CodeReviewComments](https://github.com/golang/go/wiki/CodeReviewComments).
- [x] The code changes are covered by tests.

<!-- markdownlint-disable-file MD041 -->
