### PR TITLE
Fix FailError checking

### DIFF
--- a/flow.go
+++ b/flow.go
@@ -338,7 +338,7 @@ func (err *FailError) Error() string {
 // Execute runs provided tasks and all their dependencies.
 // Each task is executed at most once.
 // Returns nil if no task has failed,
-// [FailError] if a task failed,
+// [*FailError] if a task failed,
 // other errors in case of invalid input or context error.
 func Execute(ctx context.Context, tasks []string, opts ...Option) error {
 	return DefaultFlow.Execute(ctx, tasks, opts...)
@@ -347,7 +347,7 @@ func Execute(ctx context.Context, tasks []string, opts ...Option) error {
 // Execute runs provided tasks and all their dependencies.
 // Each task is executed at most once.
 // Returns nil if no task has failed,
-// [FailError] if a task failed,
+// [*FailError] if a task failed,
 // other errors in case of invalid input or context error.
 func (f *Flow) Execute(ctx context.Context, tasks []string, opts ...Option) error {
 	var middlewares []Middleware
@@ -433,7 +433,8 @@ func (f *Flow) Main(args []string, opts ...Option) {
 
 func (f *Flow) main(ctx context.Context, args []string, opts ...Option) int {
 	err := f.Execute(ctx, args, opts...)
-	if _, ok := err.(*FailError); ok {
+	var ferr *FailError
+	if errors.As(err, &ferr) {
 		return exitCodeFail
 	}
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {

--- a/helper_test.go
+++ b/helper_test.go
@@ -1,6 +1,7 @@
 package goyek_test
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -62,14 +63,16 @@ func assertPass(tb testing.TB, got error, msg string) {
 
 func assertFail(tb testing.TB, got error, msg string) {
 	tb.Helper()
-	if _, ok := got.(*goyek.FailError); !ok {
+	var ferr *goyek.FailError
+	if !errors.As(got, &ferr) {
 		tb.Errorf("%s\nGOT: %v\nWANT: <FAIL>", msg, got)
 	}
 }
 
 func assertInvalid(tb testing.TB, got error, msg string) {
 	tb.Helper()
-	if _, ok := got.(*goyek.FailError); ok || got == nil {
+	var ferr *goyek.FailError
+	if errors.As(got, &ferr) || got == nil {
 		tb.Errorf("%s\nGOT: %v\nWANT: <INVALID>", msg, got)
 	}
 }


### PR DESCRIPTION
## Why

User may wrap the error using a custom `ExecutorMiddleware`.

## What

Use `errors.As` when checking if a task has failed.

