### PR TITLE
Release 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 as well as to [Module version numbering](https://go.dev/doc/modules/version-numbers).
 
-## [Unreleased](https://github.com/goyek/goyek/compare/v2.1.0...HEAD)
+## [2.2.0](https://github.com/goyek/goyek/compare/v2.1.0...v2.2.0) - 2024-08-19
+
+This release adds flow execution middlewares.
 
 ### Added
 
-- Add `Flow.UseExecutor` method to support flow execution interception using middlewares.
+- Add `Flow.UseExecutor` to support flow execution interception using middlewares.
 - Add `middleware.ReportFlow` flow execution middleware which reports the flow
   execution status.
 

--- a/build/mdlint.go
+++ b/build/mdlint.go
@@ -23,7 +23,7 @@ var mdlint = goyek.Define(goyek.Task{
 		if len(mdFiles) == 0 {
 			a.Skip("no .md files")
 		}
-		dockerImage := "ghcr.io/igorshubovych/markdownlint-cli:v0.36.0"
+		dockerImage := "ghcr.io/igorshubovych/markdownlint-cli:v0.41.0"
 		Exec(a, dirRoot, "docker run --rm -v '"+curDir+":/workdir' "+dockerImage+" "+strings.Join(mdFiles, " "))
 	},
 })


### PR DESCRIPTION
This release adds flow execution middlewares.

### Added

- Add `Flow.UseExecutor` to support flow execution interception using middlewares.
- Add `middleware.ReportFlow` flow execution middleware which reports the flow execution status.

### Change

- Extract the flow result reporting from `Flow.Main` to `middleware.ReportFlow`. Add the middleware using `Flow.UseExecutor` to achieve a backward compatible behavior.

### Removed

- Drop support for Go 1.11 and 1.12.