### PR TITLE
Add A.WithContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 
 ## [Unreleased](https://github.com/goyek/goyek/compare/v2.2.0...HEAD)
 
+- Added `A.WithContext` to support changing the context of an action by the user.
+  The intended use is to pass task parameters via context.
+
 ### Removed
 
 - Drop support for Go 1.13, 1.14, and 1.15.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 
 ## [Unreleased](https://github.com/goyek/goyek/compare/v2.2.0...HEAD)
 
-- Added `A.WithContext` to support changing the context of an action by the user.
-  The intended use is to pass task parameters via context.
+- Add `A.WithContext` that creates a derived `A` with a changed context.
+  Thanks to it `A` can be reused to pass cancelation and values via context
+  to the helper functions.
 
 ### Removed
 

--- a/a.go
+++ b/a.go
@@ -125,13 +125,11 @@ func (a *A) Failed() bool {
 
 // Fail marks the function as having failed but continues execution.
 func (a *A) Fail() {
-	var call func()
 	a.mu.Lock()
 	a.failed = true
-	call = a.failedCall
 	a.mu.Unlock()
-	if call != nil {
-		call()
+	if a.failedCall != nil {
+		a.failedCall()
 	}
 }
 
@@ -217,13 +215,11 @@ func (a *A) Skipf(format string, args ...interface{}) {
 // not from other goroutines created during its execution.
 // Calling SkipNow does not stop those other goroutines.
 func (a *A) SkipNow() {
-	var call func()
 	a.mu.Lock()
 	a.skipped = true
-	call = a.skippedCall
 	a.mu.Unlock()
-	if call != nil {
-		call()
+	if a.skippedCall != nil {
+		a.skippedCall()
 	}
 	runtime.Goexit()
 }

--- a/a.go
+++ b/a.go
@@ -61,8 +61,7 @@ func (a *A) WithContext(ctx context.Context) *A {
 	}
 
 	a.cleanups = append(a.cleanups, func() {
-		for result.callLastCleanup() {
-		}
+		result.callCleanups()
 	})
 
 	return result
@@ -356,8 +355,7 @@ func (a *A) runCleanups(finished *bool, panicVal *interface{}, panicStack *[]byt
 		}
 	}()
 
-	for a.callLastCleanup() {
-	}
+	a.callCleanups()
 	cleanupFinished = true
 }
 
@@ -375,4 +373,9 @@ func (a *A) callLastCleanup() bool {
 	}
 	cleanup()
 	return true
+}
+
+func (a *A) callCleanups() {
+	for a.callLastCleanup() {
+	}
 }

--- a/a.go
+++ b/a.go
@@ -41,7 +41,8 @@ func (a *A) Context() context.Context {
 }
 
 // WithContext returns a derived a with its context changed
-// to ctx. The provided ctx must be non-nil.
+// to ctx and cancelFunc. The provided ctx must be non-nil and
+// returned cancelFunc must be called with defer.
 func (a *A) WithContext(ctx context.Context) (*A, context.CancelFunc) {
 	if ctx == nil {
 		panic("nil context")

--- a/a.go
+++ b/a.go
@@ -37,6 +37,16 @@ func (a *A) Context() context.Context {
 	return a.ctx
 }
 
+// WithContext modifies ctx in the current object a and returns it.
+// The provided ctx must be non-null.
+func (a *A) WithContext(ctx context.Context) *A {
+	if ctx == nil {
+		panic("nil context")
+	}
+	a.ctx = ctx
+	return a
+}
+
 // Name returns the name of the running task.
 func (a *A) Name() string {
 	return a.name

--- a/a.go
+++ b/a.go
@@ -39,7 +39,7 @@ func (a *A) Context() context.Context {
 	return a.ctx
 }
 
-// WithContext returns a shallow copy of a with its context changed
+// WithContext returns a derived a with its context changed
 // to ctx. The provided ctx must be non-nil.
 func (a *A) WithContext(ctx context.Context) *A {
 	if ctx == nil {

--- a/a.go
+++ b/a.go
@@ -355,23 +355,19 @@ func (a *A) runCleanups(finished *bool, panicVal *interface{}, panicStack *[]byt
 	cleanupFinished = true
 }
 
-func (a *A) callLastCleanup() bool {
-	var cleanup func()
-	a.mu.Lock()
-	if len(a.cleanups) > 0 {
-		last := len(a.cleanups) - 1
-		cleanup = a.cleanups[last]
-		a.cleanups = a.cleanups[:last]
-	}
-	a.mu.Unlock()
-	if cleanup == nil {
-		return false
-	}
-	cleanup()
-	return true
-}
-
 func (a *A) callCleanups() {
-	for a.callLastCleanup() {
+	for {
+		var cleanup func()
+		a.mu.Lock()
+		if len(a.cleanups) > 0 {
+			last := len(a.cleanups) - 1
+			cleanup = a.cleanups[last]
+			a.cleanups = a.cleanups[:last]
+		}
+		a.mu.Unlock()
+		if cleanup == nil {
+			return
+		}
+		cleanup()
 	}
 }

--- a/a_test.go
+++ b/a_test.go
@@ -365,7 +365,7 @@ func TestA_WithContextFatal(t *testing.T) {
 
 			expectedFatalCalls := 1
 			if parallel {
-				expectedFatalCalls = len(childTasksResults)
+				expectedFatalCalls = len(childTasks)
 			}
 
 			assertTrue(t, loggerSpy.called, "logger call")

--- a/a_test.go
+++ b/a_test.go
@@ -245,7 +245,7 @@ func TestA_WithContext(t *testing.T) {
 							}
 
 							prevCtx := a.Context()
-							newA := a.WithContext(context.WithValue(a.Context(), ctxKey, i))
+							newA := a.WithContext(context.WithValue(prevCtx, ctxKey, i))
 							assertEqual(t, newA.Name(), a.Name(), "name changed for "+a.Name())
 							assertEqual(t, a.Context(), prevCtx, "context changed for "+a.Name())
 
@@ -278,6 +278,25 @@ func TestA_WithContext(t *testing.T) {
 			})
 		}
 	}
+}
+
+func TestA_WithContextNilCtx(t *testing.T) {
+	t.Parallel()
+
+	flow := &goyek.Flow{}
+
+	flow.SetOutput(io.Discard)
+	loggerSpy := &helperLoggerSpy{}
+	flow.SetLogger(loggerSpy)
+
+	task := flow.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			a.WithContext(nil)
+		},
+	})
+
+	assertFail(t, flow.Execute(context.Background(), []string{task.Name()}), "must contain error")
 }
 
 func onceCall(t *testing.T, name string) func() {

--- a/a_test.go
+++ b/a_test.go
@@ -407,13 +407,6 @@ func prepareFlowAndTask(t *testing.T, childCount int, ctxKey interface{}, additi
 	loggerSpy := &helperLoggerSpy{}
 	flow.SetLogger(loggerSpy)
 
-	depsTask := flow.Define(goyek.Task{
-		Name: "deps",
-		Action: func(a *goyek.A) {
-			a.Cleanup(onceCall(t, a.Name()+" cleanup"))
-		},
-	})
-
 	childTasksResults := make([]bool, childCount)
 	return flow, flow.Define(goyek.Task{
 		Name: "task",
@@ -429,7 +422,6 @@ func prepareFlowAndTask(t *testing.T, childCount int, ctxKey interface{}, additi
 
 			additionalAction(a, k)
 		},
-		Deps: goyek.Deps{depsTask},
 	}), childTasksResults, loggerSpy
 }
 

--- a/a_test.go
+++ b/a_test.go
@@ -276,12 +276,12 @@ func TestA_WithContextFatal(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			flow, task, childTasksResults, loggerSpy := prepareFlowAndTask(t, 3, ctxKey, func(a *goyek.A, i int) {
-				a.Fatal(i)
-
 				a.Cleanup(func() {
 					failed := a.Failed()
 					assertTrue(t, failed, "a.Failed() should return true for "+a.Name())
 				})
+
+				a.Fatal(i)
 			})
 			childTasks := prepareTasks(t, flow, len(childTasksResults), c.parallel, task, func(i int) func(a *goyek.A) {
 				return func(a *goyek.A) {
@@ -293,14 +293,16 @@ func TestA_WithContextFatal(t *testing.T) {
 					assertEqual(t, newA.Name(), a.Name(), "name changed for "+a.Name())
 					assertEqual(t, a.Context(), prevCtx, "context changed for "+a.Name())
 					call()
-					task.Action()(newA)
 
-					call()
-					assertEqual(t, a.Context(), prevCtx, "context changed for "+a.Name()+" after "+task.Name()+" action call")
 					a.Cleanup(func() {
 						failed := a.Failed()
 						assertTrue(t, failed, "a.Failed() should return true for "+a.Name())
 					})
+
+					task.Action()(newA)
+
+					call()
+					assertEqual(t, a.Context(), prevCtx, "context changed for "+a.Name()+" after "+task.Name()+" action call")
 				}
 			})
 
@@ -352,12 +354,12 @@ func TestA_WithContextSkipped(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			flow, task, childTasksResults, loggerSpy := prepareFlowAndTask(t, 3, ctxKey, func(a *goyek.A, i int) {
-				a.Skip(i)
-
 				a.Cleanup(func() {
 					skipped := a.Skipped()
 					assertTrue(t, skipped, "a.Skipped() should return true for "+a.Name())
 				})
+
+				a.Skip(i)
 			})
 			childTasks := prepareTasks(t, flow, len(childTasksResults), c.parallel, task, func(i int) func(a *goyek.A) {
 				return func(a *goyek.A) {
@@ -370,13 +372,14 @@ func TestA_WithContextSkipped(t *testing.T) {
 					assertEqual(t, newA.Name(), a.Name(), "name changed for "+a.Name())
 					assertEqual(t, a.Context(), prevCtx, "context changed for "+a.Name())
 
-					task.Action()(newA)
-
-					call()
 					a.Cleanup(func() {
 						skipped := a.Skipped()
 						assertTrue(t, skipped, "a.Skipped() should return true for "+a.Name())
 					})
+
+					task.Action()(newA)
+
+					call()
 				}
 			})
 

--- a/a_test.go
+++ b/a_test.go
@@ -247,8 +247,9 @@ func TestA_WithContext(t *testing.T) {
 							prevCtx := a.Context()
 							newA := a.WithContext(context.WithValue(a.Context(), ctxKey, i))
 							assertEqual(t, newA.Name(), a.Name(), "name changed for "+a.Name())
-							task.Action()(newA)
 							assertEqual(t, a.Context(), prevCtx, "context changed for "+a.Name())
+
+							task.Action()(newA)
 						},
 						Deps:     goyek.Deps{depsTask},
 						Parallel: parallel,

--- a/a_test.go
+++ b/a_test.go
@@ -470,14 +470,14 @@ func TestA_WithContextNilCtx(t *testing.T) {
 func onceCall(t *testing.T, name string) func() {
 	t.Helper()
 
-	var callsCount atomic.Int64
+	var callsCount int64
 
 	t.Cleanup(func() {
-		assertEqual(t, callsCount.Load(), int64(1), "unexpected number of calls '"+name+"'")
+		assertEqual(t, callsCount, int64(1), "unexpected number of calls '"+name+"'")
 	})
 
 	return func() {
-		callsCount.Add(1)
+		atomic.AddInt64(&callsCount, 1)
 	}
 }
 

--- a/helper_test.go
+++ b/helper_test.go
@@ -20,6 +20,14 @@ func assertTrue(tb testing.TB, got bool, msg string) {
 	tb.Errorf("%s\nGOT: %v, WANT: true", msg, got)
 }
 
+func assertFalse(tb testing.TB, got bool, msg string) {
+	tb.Helper()
+	if !got {
+		return
+	}
+	tb.Errorf("%s\nGOT: %v, WANT: false", msg, got)
+}
+
 func assertContains(tb testing.TB, got fmt.Stringer, want string, msg string) {
 	tb.Helper()
 	gotTxt := got.String()

--- a/helper_test.go
+++ b/helper_test.go
@@ -85,6 +85,18 @@ func assertInvalid(tb testing.TB, got error, msg string) {
 	}
 }
 
+func assertErrorContains(tb testing.TB, got error, want string, msg string) {
+	tb.Helper()
+	if got == nil {
+		tb.Errorf("%s\nGOT: nil\nSHOULD CONTAIN:\n%s", msg, want)
+		return
+	}
+	if strings.Contains(got.Error(), want) {
+		return
+	}
+	tb.Errorf("%s\nGOT:\n%s\nSHOULD CONTAIN:\n%s", msg, got.Error(), want)
+}
+
 func assertPanics(tb testing.TB, fn func(), msg string) {
 	tb.Helper()
 	tryPanic := func() bool {


### PR DESCRIPTION
## Why

There was a need to pass additional parameters between actions without using environment variables because the tasks are executed in parallel. No other simpler mechanism was provided.

## What

Add `A.WithContext` that creates a derived `A` with a changed context.
Thanks to it `A` can be reused to pass cancelation and values via context to the helper functions.

## Checklist

<!-- All items should be verified and marked as done.
     If an item doesn't apply to the introduced changes - check it as done too. -->

- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated.
- [x] The code changes follow [Effective Go](https://golang.org/doc/effective_go).
- [x] The code changes follow [CodeReviewComments](https://github.com/golang/go/wiki/CodeReviewComments).
- [x] The code changes are covered by tests.

<!-- markdownlint-disable-file MD041 -->
