### PR TITLE
Add A.WithContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 
 ## [Unreleased](https://github.com/goyek/goyek/compare/v2.2.0...HEAD)
 
+### Added
+
+- Add `A.WithContext` that creates a derived `A` with a changed context.
+  Thanks to it `A` can be reused to pass cancelation and values via context
+  to the helper functions.
+
 ### Removed
 
 - Drop support for Go 1.13, 1.14, and 1.15.

--- a/a.go
+++ b/a.go
@@ -188,6 +188,12 @@ func (a *A) SkipNow() {
 	runtime.Goexit()
 }
 
+// WithContext returns a derived a with its context changed
+// to ctx. The provided ctx must be non-nil.
+func (a *A) WithContext(ctx context.Context) *A {
+	return a
+}
+
 // Helper marks the calling function as a helper function.
 // It calls logger's Helper method if implemented.
 // By default, when printing file and line information, that function will be skipped.

--- a/a.go
+++ b/a.go
@@ -192,6 +192,9 @@ func (a *A) SkipNow() {
 // WithContext returns a derived a with its context changed
 // to ctx. The provided ctx must be non-nil.
 func (a *A) WithContext(ctx context.Context) *A {
+	if ctx == nil {
+		panic("nil context")
+	}
 	res := *a
 	res.ctx = ctx
 	return &res

--- a/a.go
+++ b/a.go
@@ -193,6 +193,7 @@ func (a *A) SkipNow() {
 // to ctx. The provided ctx must be non-nil.
 func (a *A) WithContext(ctx context.Context) *A {
 	res := *a
+	res.ctx = ctx
 	return &res
 }
 

--- a/a_test.go
+++ b/a_test.go
@@ -69,7 +69,6 @@ func TestA_WithContext(t *testing.T) {
 				failed, skipped   bool
 				failed2, skipped2 bool
 			)
-
 			res := goyek.NewRunner(func(a *goyek.A) {
 				a2 := a.WithContext(newCtx)
 				got = a.Context()   // ctx
@@ -120,7 +119,7 @@ func TestA_WithContext_nil(t *testing.T) {
 	out := &strings.Builder{}
 	got := goyek.NewRunner(func(a *goyek.A) {
 		a.Log("1")
-		a.WithContext(nil) // panics
+		a.WithContext(nil) //nolint:staticcheck // panic intentionally
 		a.Log("2")
 	})(goyek.Input{Logger: &goyek.FmtLogger{}, Output: out})
 

--- a/a_test.go
+++ b/a_test.go
@@ -10,6 +10,110 @@ import (
 	"github.com/goyek/goyek/v2"
 )
 
+func TestA_WithContext(t *testing.T) {
+	testCases := []struct {
+		desc        string
+		fn          func(a, a2 *goyek.A)
+		wantStatus  goyek.Status
+		wantFailed  bool
+		wantSkipped bool
+	}{
+		{
+			desc:       "Pass",
+			fn:         func(_, _ *goyek.A) {},
+			wantStatus: goyek.StatusPassed,
+		},
+		{
+			desc: "Fail",
+			fn: func(a, _ *goyek.A) {
+				a.FailNow()
+			},
+			wantStatus: goyek.StatusFailed,
+			wantFailed: true,
+		},
+		{
+			desc: "FailDerived",
+			fn: func(_, a2 *goyek.A) {
+				a2.FailNow()
+			},
+			wantStatus: goyek.StatusFailed,
+			wantFailed: true,
+		},
+		{
+			desc: "Skip",
+			fn: func(a, _ *goyek.A) {
+				a.SkipNow()
+			},
+			wantStatus:  goyek.StatusSkipped,
+			wantSkipped: true,
+		},
+		{
+			desc: "SkipDerived",
+			fn: func(_, a2 *goyek.A) {
+				a2.SkipNow()
+			},
+			wantStatus:  goyek.StatusSkipped,
+			wantSkipped: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			sb := &strings.Builder{}
+
+			ctx := context.Background()
+			type ctxKey struct{}
+			newCtx := context.WithValue(ctx, ctxKey{}, 0)
+
+			var got1, got2 context.Context
+			var failed2, skipped2 bool
+			var failed, skipped bool
+
+			got := goyek.NewRunner(func(a *goyek.A) {
+				a2 := a.WithContext(newCtx)
+				got1 = a.Context()  // ctx
+				got2 = a2.Context() // newCtx
+				a2.Log("1")
+				a.Cleanup(func() {
+					skipped = a.Skipped()
+					failed = a.Failed()
+					a.Log("3")
+				})
+				a2.Cleanup(func() {
+					skipped2 = a2.Skipped()
+					failed2 = a2.Failed()
+					a2.Log("2")
+				})
+				tc.fn(a, a2)
+			})(goyek.Input{Context: ctx, Output: sb, Logger: goyek.FmtLogger{}})
+
+			if got.Status != tc.wantStatus {
+				t.Errorf("status was %s but want %s", got.Status, tc.wantStatus)
+			}
+			if got1 != ctx {
+				t.Errorf("orginal Context returned %v but want %v", got1, ctx)
+			}
+			if got2 != newCtx {
+				t.Errorf("derived Context returned %v but want %v", got2, newCtx)
+			}
+			if out, want := sb.String(), "1\n2\n3\n"; out != want {
+				t.Errorf("logging or cleanup failed, out was %q but want %q", out, want)
+			}
+			if failed != tc.wantFailed {
+				t.Errorf("orginal Failed returned %v but want %v", failed, tc.wantFailed)
+			}
+			if skipped != tc.wantSkipped {
+				t.Errorf("orginal Skipped returned %v but want %v", skipped, tc.wantSkipped)
+			}
+			if failed2 != tc.wantFailed {
+				t.Errorf("derived Failed returned %v but want %v", failed2, tc.wantFailed)
+			}
+			if skipped2 != tc.wantSkipped {
+				t.Errorf("derived Skipped returned %v but want %v", skipped2, tc.wantSkipped)
+			}
+		})
+	}
+}
+
 func TestA_Cleanup(t *testing.T) {
 	out := &strings.Builder{}
 

--- a/a_test.go
+++ b/a_test.go
@@ -114,6 +114,19 @@ func TestA_WithContext(t *testing.T) {
 	}
 }
 
+func TestA_WithContext_nil(t *testing.T) {
+	out := &strings.Builder{}
+	got := goyek.NewRunner(func(a *goyek.A) {
+		a.Log("1")
+		a.WithContext(nil) // panics
+		a.Log("2")
+	})(goyek.Input{Logger: &goyek.FmtLogger{}, Output: out})
+
+	assertEqual(t, got.Status, goyek.StatusFailed, "shoud return proper status")
+	assertEqual(t, got.PanicValue, "nil context", "shoud return proper panic value")
+	assertEqual(t, out.String(), "1\n", "should interrupt execution")
+}
+
 func TestA_Cleanup(t *testing.T) {
 	out := &strings.Builder{}
 

--- a/a_test.go
+++ b/a_test.go
@@ -123,8 +123,8 @@ func TestA_WithContext_nil(t *testing.T) {
 		a.Log("2")
 	})(goyek.Input{Logger: &goyek.FmtLogger{}, Output: out})
 
-	assertEqual(t, got.Status, goyek.StatusFailed, "shoud return proper status")
-	assertEqual(t, got.PanicValue, "nil context", "shoud return proper panic value")
+	assertEqual(t, got.Status, goyek.StatusFailed, "should return proper status")
+	assertEqual(t, got.PanicValue, "nil context", "should return proper panic value")
 	assertEqual(t, out.String(), "1\n", "should interrupt execution")
 }
 
@@ -149,8 +149,8 @@ func TestA_Cleanup(t *testing.T) {
 		})
 	})(goyek.Input{Logger: &goyek.FmtLogger{}, Output: out})
 
-	assertEqual(t, got.Status, goyek.StatusFailed, "shoud return proper status")
-	assertEqual(t, got.PanicValue, "first panic", "shoud return proper panic value")
+	assertEqual(t, got.Status, goyek.StatusFailed, "should return proper status")
+	assertEqual(t, got.PanicValue, "first panic", "should return proper panic value")
 	assertContains(t, out, "1\n2\n3\n4\n5", "should call cleanup funcs in LIFO order")
 }
 
@@ -176,8 +176,8 @@ func TestA_Cleanup_when_action_panics(t *testing.T) {
 		panic("action panic")
 	})(goyek.Input{Logger: &goyek.FmtLogger{}, Output: out})
 
-	assertEqual(t, got.Status, goyek.StatusFailed, "shoud return proper status")
-	assertEqual(t, got.PanicValue, "action panic", "shoud return proper panic value")
+	assertEqual(t, got.Status, goyek.StatusFailed, "should return proper status")
+	assertEqual(t, got.PanicValue, "action panic", "should return proper panic value")
 	assertContains(t, out, "1\n2\n3\n4\n5", "should call cleanup funcs in LIFO order")
 }
 
@@ -188,7 +188,7 @@ func TestA_Cleanup_Fail(t *testing.T) {
 		})
 	})(goyek.Input{})
 
-	assertEqual(t, got.Status, goyek.StatusFailed, "shoud return proper status")
+	assertEqual(t, got.Status, goyek.StatusFailed, "should return proper status")
 }
 
 func TestA_Cleanup_nil(t *testing.T) {
@@ -202,7 +202,7 @@ func TestA_Cleanup_nil(t *testing.T) {
 		a.Log("2")
 	})(goyek.Input{Logger: &goyek.FmtLogger{}, Output: out})
 
-	assertEqual(t, got.Status, goyek.StatusPassed, "shoud return proper status")
+	assertEqual(t, got.Status, goyek.StatusPassed, "should return proper status")
 	assertEqual(t, out.String(), "1\n2\n3\n", "should continue execution")
 }
 
@@ -217,7 +217,7 @@ func TestA_Setenv(t *testing.T) {
 		assertEqual(t, got, val, "should set the value")
 	})(goyek.Input{})
 
-	assertEqual(t, res.Status, goyek.StatusPassed, "shoud return proper status")
+	assertEqual(t, res.Status, goyek.StatusPassed, "should return proper status")
 	got := os.Getenv(key)
 	assertEqual(t, got, "", "should restore the value after the action")
 }
@@ -236,7 +236,7 @@ func TestA_Setenv_restore(t *testing.T) {
 		assertEqual(t, got, val, "should set the value")
 	})(goyek.Input{})
 
-	assertEqual(t, res.Status, goyek.StatusPassed, "shoud return proper status")
+	assertEqual(t, res.Status, goyek.StatusPassed, "should return proper status")
 	got := os.Getenv(key)
 	assertEqual(t, got, prev, "should restore the value after the action")
 }
@@ -250,7 +250,7 @@ func TestA_TempDir(t *testing.T) {
 		assertEqual(t, err, nil, "the dir should exixt")
 	})(goyek.Input{TaskName: "0!ą😊"})
 
-	assertEqual(t, res.Status, goyek.StatusPassed, "shoud return proper status")
+	assertEqual(t, res.Status, goyek.StatusPassed, "should return proper status")
 	_, err := os.Lstat(dir)
 	assertTrue(t, os.IsNotExist(err), "should remove the dir after the action")
 }

--- a/a_test.go
+++ b/a_test.go
@@ -64,13 +64,15 @@ func TestA_WithContext(t *testing.T) {
 			type ctxKey struct{}
 			newCtx := context.WithValue(ctx, ctxKey{}, 0)
 
-			var got1, got2 context.Context
-			var failed2, skipped2 bool
-			var failed, skipped bool
+			var (
+				got, got2         context.Context
+				failed, skipped   bool
+				failed2, skipped2 bool
+			)
 
-			got := goyek.NewRunner(func(a *goyek.A) {
+			res := goyek.NewRunner(func(a *goyek.A) {
 				a2 := a.WithContext(newCtx)
-				got1 = a.Context()  // ctx
+				got = a.Context()   // ctx
 				got2 = a2.Context() // newCtx
 				a2.Log("1")
 				a.Cleanup(func() {
@@ -86,11 +88,11 @@ func TestA_WithContext(t *testing.T) {
 				tc.fn(a, a2)
 			})(goyek.Input{Context: ctx, Output: sb, Logger: goyek.FmtLogger{}})
 
-			if got.Status != tc.wantStatus {
-				t.Errorf("status was %s but want %s", got.Status, tc.wantStatus)
+			if res.Status != tc.wantStatus {
+				t.Errorf("status was %s but want %s", res.Status, tc.wantStatus)
 			}
-			if got1 != ctx {
-				t.Errorf("original Context returned %v but want %v", got1, ctx)
+			if got != ctx {
+				t.Errorf("original Context returned %v but want %v", got, ctx)
 			}
 			if got2 != newCtx {
 				t.Errorf("derived Context returned %v but want %v", got2, newCtx)

--- a/a_test.go
+++ b/a_test.go
@@ -90,7 +90,7 @@ func TestA_WithContext(t *testing.T) {
 				t.Errorf("status was %s but want %s", got.Status, tc.wantStatus)
 			}
 			if got1 != ctx {
-				t.Errorf("orginal Context returned %v but want %v", got1, ctx)
+				t.Errorf("original Context returned %v but want %v", got1, ctx)
 			}
 			if got2 != newCtx {
 				t.Errorf("derived Context returned %v but want %v", got2, newCtx)
@@ -99,10 +99,10 @@ func TestA_WithContext(t *testing.T) {
 				t.Errorf("logging or cleanup failed, out was %q but want %q", out, want)
 			}
 			if failed != tc.wantFailed {
-				t.Errorf("orginal Failed returned %v but want %v", failed, tc.wantFailed)
+				t.Errorf("original Failed returned %v but want %v", failed, tc.wantFailed)
 			}
 			if skipped != tc.wantSkipped {
-				t.Errorf("orginal Skipped returned %v but want %v", skipped, tc.wantSkipped)
+				t.Errorf("original Skipped returned %v but want %v", skipped, tc.wantSkipped)
 			}
 			if failed2 != tc.wantFailed {
 				t.Errorf("derived Failed returned %v but want %v", failed2, tc.wantFailed)

--- a/flow_test.go
+++ b/flow_test.go
@@ -7,33 +7,39 @@ import (
 	"reflect"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/goyek/goyek/v2"
 )
 
+var onceDefaultFlow sync.Once
+
 func Test_DefaultFlow(t *testing.T) {
-	goyek.SetOutput(io.Discard)
-	assertEqual(t, goyek.Output(), io.Discard, "Output")
+	// Run only once as registering a task with the same name twice panics.
+	onceDefaultFlow.Do(func() {
+		goyek.SetOutput(io.Discard)
+		assertEqual(t, goyek.Output(), io.Discard, "Output")
 
-	goyek.SetLogger(goyek.FmtLogger{})
-	assertEqual(t, goyek.GetLogger(), goyek.FmtLogger{}, "Logger")
+		goyek.SetLogger(goyek.FmtLogger{})
+		assertEqual(t, goyek.GetLogger(), goyek.FmtLogger{}, "Logger")
 
-	goyek.SetUsage(goyek.Print)
-	goyek.Usage()()
+		goyek.SetUsage(goyek.Print)
+		goyek.Usage()()
 
-	task := goyek.Define(goyek.Task{Name: "task"})
-	other := goyek.Define(goyek.Task{Name: "other"})
-	goyek.Undefine(other)
-	assertEqual(t, goyek.Tasks()[0].Name(), "task", "Tasks")
+		task := goyek.Define(goyek.Task{Name: "task"})
+		other := goyek.Define(goyek.Task{Name: "other"})
+		goyek.Undefine(other)
+		assertEqual(t, goyek.Tasks()[0].Name(), "task", "Tasks")
 
-	goyek.SetDefault(task)
-	assertEqual(t, goyek.Default(), task, "Default")
+		goyek.SetDefault(task)
+		assertEqual(t, goyek.Default(), task, "Default")
 
-	goyek.Use(func(r goyek.Runner) goyek.Runner { return r })
-	goyek.UseExecutor(func(e goyek.Executor) goyek.Executor { return e })
-	assertPass(t, goyek.Execute(context.Background(), nil), "Execute")
+		goyek.Use(func(r goyek.Runner) goyek.Runner { return r })
+		goyek.UseExecutor(func(e goyek.Executor) goyek.Executor { return e })
+		assertPass(t, goyek.Execute(context.Background(), nil), "Execute")
+	})
 }
 
 func Test_Define_empty_name(t *testing.T) {

--- a/flow_test.go
+++ b/flow_test.go
@@ -348,9 +348,9 @@ func Test_concurrent_printing(t *testing.T) {
 	flow.Define(goyek.Task{
 		Name: "task",
 		Action: func(a *goyek.A) {
-			ch := make(chan struct{}, 1)
+			ch := make(chan struct{})
 			go func() {
-				defer func() { ch <- struct{}{} }()
+				defer func() { close(ch) }()
 				a.Log("from child goroutine\nwith new line")
 			}()
 			a.Error("from main goroutine")

--- a/runner.go
+++ b/runner.go
@@ -3,6 +3,7 @@ package goyek
 import (
 	"context"
 	"io"
+	"sync"
 )
 
 // Task runner types.
@@ -76,11 +77,16 @@ func (r taskRunner) run(in Input) Result {
 		logger = FmtLogger{}
 	}
 
+	var failed, skipped bool
 	a := &A{
-		ctx:    ctx,
-		name:   in.TaskName,
-		output: out,
-		logger: logger,
+		mu:       &sync.Mutex{},
+		failed:   &failed,
+		skipped:  &skipped,
+		cleanups: &[]func(){},
+		ctx:      ctx,
+		name:     in.TaskName,
+		output:   out,
+		logger:   logger,
 	}
 
 	finished, panicVal, panicStack := a.run(r.action)

--- a/runner_test.go
+++ b/runner_test.go
@@ -43,7 +43,7 @@ func TestRunner(t *testing.T) {
 			r := goyek.NewRunner(tc.action)
 			got := r(goyek.Input{})
 
-			assertEqual(t, got, tc.want, "shoud return proper result")
+			assertEqual(t, got, tc.want, "should return proper result")
 		})
 	}
 }
@@ -54,6 +54,6 @@ func TestRunner_panic(t *testing.T) {
 
 	got := r(goyek.Input{})
 
-	assertEqual(t, got.Status, goyek.StatusFailed, "shoud return proper status")
-	assertEqual(t, got.PanicValue, payload, "shoud return proper panic value")
+	assertEqual(t, got.Status, goyek.StatusFailed, "should return proper status")
+	assertEqual(t, got.PanicValue, payload, "should return proper panic value")
 }


### PR DESCRIPTION
## Why

Fixes https://github.com/goyek/goyek/issues/457

## What

Add `A.WithContext` that creates a derived `A` with a changed context.
Thanks to it `A` can be reused to pass cancelation and values via context to the helper functions.

## Checklist

<!-- All items should be verified and marked as done.
     If an item doesn't apply to the introduced changes - check it as done too. -->

- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated.
- [x] The code changes follow [Effective Go](https://golang.org/doc/effective_go).
- [x] The code changes follow [CodeReviewComments](https://github.com/golang/go/wiki/CodeReviewComments).
- [x] The code changes are covered by tests.

<!-- markdownlint-disable-file MD041 -->
