### PR TITLE
BREAKING: Change A.Context to match testing.T.Context behavior

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,7 +13,4 @@
     },
     // golangci-lint  
     "go.lintTool": "golangci-lint",
-    "go.lintFlags": [
-        "--fast"
-    ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 
 ## [Unreleased](https://github.com/goyek/goyek/compare/v2.3.0...HEAD)
 
+### Changed
+
+- **BREAKING**: Change `A.Context` behavior to be canceled just before cleanup
+  functions are called, matching `testing.T.Context` behavior. The context
+  still cancels when the original context is canceled (e.g. flow interruption).
+  This ensures cleanup functions can wait for resources that shut down on
+  `context.Context.Done` before the task action completes.
+
 ## [2.3.0](https://github.com/goyek/goyek/releases/tag/v2.3.0) - 2025-02-25
 
 This release adds `A.WithContext` inspired by `http.Request.WithContext`

--- a/runner.go
+++ b/runner.go
@@ -83,11 +83,11 @@ func (r taskRunner) run(in Input) Result {
 		failed:   &failed,
 		skipped:  &skipped,
 		cleanups: &[]func(){},
-		ctx:      ctx,
 		name:     in.TaskName,
 		output:   out,
 		logger:   logger,
 	}
+	a = a.WithContext(ctx)
 
 	finished, panicVal, panicStack := a.run(r.action)
 


### PR DESCRIPTION
## Why

Fixes https://github.com/goyek/goyek/issues/511

## What

**BREAKING**: Change `A.Context` behavior to be canceled just before cleanup functions are called, matching `testing.T.Context` behavior. The context still cancels when the original context is canceled (e.g. flow interruption). This ensures cleanup functions can wait for resources that shut down on `context.Context.Done` before the task action completes.

## Checklist

<!-- All items should be verified and marked as done.
     If an item doesn't apply to the introduced changes - check it as done too. -->

- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated.
- [x] The code changes follow [Effective Go](https://golang.org/doc/effective_go).
- [x] The code changes follow [CodeReviewComments](https://github.com/golang/go/wiki/CodeReviewComments).
- [x] The code changes are covered by tests.

<!-- markdownlint-disable-file MD041 -->
