### PR TITLE
Fix build issues (gosec G118) in a.go

### DIFF
--- a/a.go
+++ b/a.go
@@ -203,7 +203,7 @@ func (a *A) WithContext(ctx context.Context) *A {
 	}
 
 	res := *a
-	res.ctx, res.ctxCancel = context.WithCancel(ctx) //nolint:gosec // the cancel function is called in runCleanups
+	res.ctx, res.ctxCancel = context.WithCancel(ctx) //nolint:gosec // The cancel function is called in runCleanups.
 	return &res
 }
 

--- a/a.go
+++ b/a.go
@@ -202,10 +202,8 @@ func (a *A) WithContext(ctx context.Context) *A {
 		panic("nil context")
 	}
 
-	derivedCtx, cancel := context.WithCancel(ctx)
 	res := *a
-	res.ctx = derivedCtx
-	res.ctxCancel = cancel
+	res.ctx, res.ctxCancel = context.WithCancel(ctx) //nolint:gosec // the cancel function is called in runCleanups
 	return &res
 }
 


### PR DESCRIPTION
I've fixed the build issue by suppressing the `gosec` G118 false positive in `a.go`. 

The error was:
`a.go:205:42: G118: context cancellation function returned by WithCancel/WithTimeout/WithDeadline is not called (gosec)`

I've added a `//nolint:gosec` directive with an explanatory comment:
`res.ctx, res.ctxCancel = context.WithCancel(ctx) //nolint:gosec // the cancel function is called in runCleanups`

I've verified that `./goyek.sh golint` and `./goyek.sh test` pass successfully.

---
*PR created automatically by Jules for task [4456347449968499201](https://jules.google.com/task/4456347449968499201) started by @pellared*