### PR TITLE
Add pools support to limit task concurrency

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -8,6 +8,8 @@ Each task consists of an Action function that executes when the task runs.
 
 Tasks can have dependencies, set via Deps. By default, dependencies run sequentially,
 but setting Parallel allows a task to run concurrently with other parallel tasks.
+Tasks can also be assigned to pools (set via Pools) to limit the number
+of concurrent task instances.
 
 A task executes at most once per [Flow.Main] or [Flow.Execute] call.
 It is valid to define a task with dependencies but no action.

--- a/doc.go
+++ b/doc.go
@@ -8,8 +8,10 @@ Each task consists of an Action function that executes when the task runs.
 
 Tasks can have dependencies, set via Deps. By default, dependencies run sequentially,
 but setting Parallel allows a task to run concurrently with other parallel tasks.
+
 Tasks can also be assigned to pools (set via Pools) to limit the number
-of concurrent task instances.
+of concurrent task instances. A task can consume multiple slots from a pool
+by including it multiple times in the [Task.Pools] field.
 
 A task executes at most once per [Flow.Main] or [Flow.Execute] call.
 It is valid to define a task with dependencies but no action.

--- a/executor.go
+++ b/executor.go
@@ -24,9 +24,9 @@ type (
 	ExecutorMiddleware func(Executor) Executor
 
 	executor struct {
-		defined     map[string]*taskSnapshot
+		defined     map[string]*DefinedTask
 		middlewares []Middleware
-		defaultTask *taskSnapshot
+		defaultTask *DefinedTask
 	}
 )
 
@@ -89,7 +89,7 @@ func (r *executor) Execute(in ExecuteInput) error {
 			continue
 		}
 
-		tasksToRun := []*taskSnapshot{task}
+		tasksToRun := []*DefinedTask{task}
 
 		// Find all parallel tasks that have not been run
 		// and have no dependencies.
@@ -137,7 +137,7 @@ func (r *executor) validate(in ExecuteInput) error {
 	return nil
 }
 
-func (r *executor) canRunTask(task *taskSnapshot, visited map[string]bool, noDeps bool) bool {
+func (r *executor) canRunTask(task *DefinedTask, visited map[string]bool, noDeps bool) bool {
 	if visited[task.name] {
 		return false
 	}
@@ -161,7 +161,7 @@ func (r *executor) canRunTask(task *taskSnapshot, visited map[string]bool, noDep
 	return true
 }
 
-func (r *executor) runParallelTasks(ctx context.Context, tasks []*taskSnapshot, output io.Writer, logger Logger) error {
+func (r *executor) runParallelTasks(ctx context.Context, tasks []*DefinedTask, output io.Writer, logger Logger) error {
 	var err error
 	errCh := make(chan error, len(tasks))
 	for _, parallelTask := range tasks {
@@ -178,7 +178,7 @@ func (r *executor) runParallelTasks(ctx context.Context, tasks []*taskSnapshot, 
 	return err
 }
 
-func (r *executor) runTask(ctx context.Context, task *taskSnapshot, output io.Writer, logger Logger) error {
+func (r *executor) runTask(ctx context.Context, task *DefinedTask, output io.Writer, logger Logger) error {
 	// acquire pool slots
 	var acquired int
 	defer func() {

--- a/executor.go
+++ b/executor.go
@@ -193,6 +193,14 @@ func (r *executor) runTask(ctx context.Context, task *taskSnapshot, output io.Wr
 			acquired++
 		case <-ctx.Done():
 			return ctx.Err()
+		default:
+			logger.Logf(output, "waiting for a slot in pool %s", pool.name)
+			select {
+			case pool.sem <- struct{}{}:
+				acquired++
+			case <-ctx.Done():
+				return ctx.Err()
+			}
 		}
 	}
 

--- a/executor.go
+++ b/executor.go
@@ -179,6 +179,23 @@ func (r *executor) runParallelTasks(ctx context.Context, tasks []*taskSnapshot, 
 }
 
 func (r *executor) runTask(ctx context.Context, task *taskSnapshot, output io.Writer, logger Logger) error {
+	// acquire pool slots
+	var acquired int
+	defer func() {
+		// release pool slots in reverse order
+		for i := acquired - 1; i >= 0; i-- {
+			<-task.pools[i].sem
+		}
+	}()
+	for _, pool := range task.pools {
+		select {
+		case pool.sem <- struct{}{}:
+			acquired++
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
 	// prepare runner
 	runner := NewRunner(task.action)
 

--- a/flow.go
+++ b/flow.go
@@ -21,6 +21,7 @@ type Flow struct {
 	logger Logger
 
 	tasks               map[string]*taskSnapshot // snapshot of defined tasks
+	pools               map[string]*poolSnapshot // snapshot of defined pools
 	defaultTask         *taskSnapshot            // task to run when none is explicitly provided
 	middlewares         []Middleware
 	executorMiddlewares []ExecutorMiddleware
@@ -35,6 +36,7 @@ type taskSnapshot struct {
 	name     string
 	usage    string
 	deps     []*taskSnapshot
+	pools    []*poolSnapshot
 	action   func(a *A)
 	parallel bool
 }
@@ -52,6 +54,21 @@ func (f *Flow) Tasks() []*DefinedTask {
 	}
 	sort.Slice(tasks, func(i, j int) bool { return tasks[i].Name() < tasks[j].Name() })
 	return tasks
+}
+
+// Pools returns all pools sorted in lexicographical order.
+func Pools() []*DefinedPool {
+	return DefaultFlow.Pools()
+}
+
+// Pools returns all pools sorted in lexicographical order.
+func (f *Flow) Pools() []*DefinedPool {
+	var pools []*DefinedPool
+	for _, pool := range f.pools {
+		pools = append(pools, &DefinedPool{pool, f})
+	}
+	sort.Slice(pools, func(i, j int) bool { return pools[i].Name() < pools[j].Name() })
+	return pools
 }
 
 // Define registers the task. It panics in case of any error.
@@ -73,20 +90,62 @@ func (f *Flow) Define(task Task) *DefinedTask {
 			panic("dependency was not defined: " + dep.Name())
 		}
 	}
+	for _, pool := range task.Pools {
+		if !f.isPoolDefined(pool.Name(), pool.flow) {
+			panic("pool was not defined: " + pool.Name())
+		}
+	}
 
 	var deps []*taskSnapshot
 	for _, dep := range task.Deps {
 		deps = append(deps, dep.taskSnapshot)
 	}
+	var pools []*poolSnapshot
+	for _, pool := range task.Pools {
+		pools = append(pools, pool.poolSnapshot)
+	}
+	sort.Slice(pools, func(i, j int) bool { return pools[i].name < pools[j].name })
+
 	taskCopy := &taskSnapshot{
 		name:     task.Name,
 		usage:    task.Usage,
 		deps:     deps,
+		pools:    pools,
 		action:   task.Action,
 		parallel: task.Parallel,
 	}
 	f.tasks[task.Name] = taskCopy
 	return &DefinedTask{taskCopy, f}
+}
+
+// DefinePool registers the pool. It panics in case of any error.
+func DefinePool(pool Pool) *DefinedPool {
+	return DefaultFlow.DefinePool(pool)
+}
+
+// DefinePool registers the pool. It panics in case of any error.
+func (f *Flow) DefinePool(pool Pool) *DefinedPool {
+	// validate
+	if pool.Name == "" {
+		panic("pool name cannot be empty")
+	}
+	if pool.Limit <= 0 {
+		panic("pool limit must be greater than 0")
+	}
+	if f.isPoolDefined(pool.Name, f) {
+		panic("pool with the same name is already defined")
+	}
+
+	poolCopy := &poolSnapshot{
+		name:  pool.Name,
+		limit: pool.Limit,
+		sem:   make(chan struct{}, pool.Limit),
+	}
+	if f.pools == nil {
+		f.pools = map[string]*poolSnapshot{}
+	}
+	f.pools[pool.Name] = poolCopy
+	return &DefinedPool{poolCopy, f}
 }
 
 // Undefine unregisters the task. It panics in case of any error.
@@ -130,6 +189,17 @@ func (f *Flow) isDefined(name string, flow *Flow) bool {
 		return false // defined in other flow
 	}
 	_, ok := f.tasks[name]
+	return ok
+}
+
+func (f *Flow) isPoolDefined(name string, flow *Flow) bool {
+	if f.pools == nil {
+		f.pools = map[string]*poolSnapshot{}
+	}
+	if f != flow {
+		return false // defined in other flow
+	}
+	_, ok := f.pools[name]
 	return ok
 }
 
@@ -462,6 +532,13 @@ func (f *Flow) Print() {
 		fmt.Fprintf(out, "Default task: %s\n", f.defaultTask.name)
 	}
 
+	if len(f.pools) > 0 {
+		fmt.Fprintln(out, "Pools:")
+		for _, pool := range f.Pools() {
+			fmt.Fprintf(out, "  %s\t(limit: %d)\n", pool.Name(), pool.Limit())
+		}
+	}
+
 	fmt.Fprintln(out, "Tasks:")
 	var (
 		minwidth      = 5
@@ -474,15 +551,22 @@ func (f *Flow) Print() {
 		if task.Usage() == "" {
 			continue
 		}
-		deps := ""
+		info := ""
 		if len(task.Deps()) > 0 {
 			depNames := make([]string, 0, len(task.Deps()))
 			for _, dep := range task.Deps() {
 				depNames = append(depNames, dep.Name())
 			}
-			deps = " (depends on: " + strings.Join(depNames, ", ") + ")"
+			info += " (depends on: " + strings.Join(depNames, ", ") + ")"
 		}
-		fmt.Fprintf(w, "  %s\t%s\n", task.Name(), task.Usage()+deps)
+		if len(task.Pools()) > 0 {
+			poolNames := make([]string, 0, len(task.Pools()))
+			for _, pool := range task.Pools() {
+				poolNames = append(poolNames, pool.Name())
+			}
+			info += " (pools: " + strings.Join(poolNames, ", ") + ")"
+		}
+		fmt.Fprintf(w, "  %s\t%s\n", task.Name(), task.Usage()+info)
 	}
 	w.Flush()
 }

--- a/flow.go
+++ b/flow.go
@@ -20,9 +20,9 @@ type Flow struct {
 	usage  func()
 	logger Logger
 
-	tasks               map[string]*taskSnapshot // snapshot of defined tasks
+	tasks               map[string]*DefinedTask // snapshot of defined tasks
 	pools               map[string]*poolSnapshot // snapshot of defined pools
-	defaultTask         *taskSnapshot            // task to run when none is explicitly provided
+	defaultTask         *DefinedTask            // task to run when none is explicitly provided
 	middlewares         []Middleware
 	executorMiddlewares []ExecutorMiddleware
 }
@@ -30,16 +30,6 @@ type Flow struct {
 // DefaultFlow is the default flow.
 // The top-level functions such as Define, Main, and so on are wrappers for the methods of Flow.
 var DefaultFlow = &Flow{}
-
-// taskSnapshot is a copy of the task to make the flow usage safer.
-type taskSnapshot struct {
-	name     string
-	usage    string
-	deps     []*taskSnapshot
-	pools    []*poolSnapshot
-	action   func(a *A)
-	parallel bool
-}
 
 // Tasks returns all tasks sorted in lexicographical order.
 func Tasks() []*DefinedTask {
@@ -50,7 +40,7 @@ func Tasks() []*DefinedTask {
 func (f *Flow) Tasks() []*DefinedTask {
 	var tasks []*DefinedTask
 	for _, task := range f.tasks {
-		tasks = append(tasks, &DefinedTask{task, f})
+		tasks = append(tasks, task)
 	}
 	sort.Slice(tasks, func(i, j int) bool { return tasks[i].Name() < tasks[j].Name() })
 	return tasks
@@ -86,8 +76,8 @@ func (f *Flow) Define(task Task) *DefinedTask {
 		panic("task with the same name is already defined")
 	}
 	for _, dep := range task.Deps {
-		if !f.isDefined(dep.Name(), dep.flow) {
-			panic("dependency was not defined: " + dep.Name())
+		if !f.isDefined(dep.name, dep.flow) {
+			panic("dependency was not defined: " + dep.name)
 		}
 	}
 	for _, pool := range task.Pools {
@@ -96,10 +86,6 @@ func (f *Flow) Define(task Task) *DefinedTask {
 		}
 	}
 
-	var deps []*taskSnapshot
-	for _, dep := range task.Deps {
-		deps = append(deps, dep.taskSnapshot)
-	}
 	var pools []*poolSnapshot
 	poolCounts := make(map[string]int)
 	for _, pool := range task.Pools {
@@ -111,16 +97,17 @@ func (f *Flow) Define(task Task) *DefinedTask {
 	}
 	sort.Slice(pools, func(i, j int) bool { return pools[i].name < pools[j].name })
 
-	taskCopy := &taskSnapshot{
+	taskCopy := &DefinedTask{
 		name:     task.Name,
 		usage:    task.Usage,
-		deps:     deps,
+		deps:     task.Deps,
 		pools:    pools,
 		action:   task.Action,
 		parallel: task.Parallel,
+		flow:     f,
 	}
 	f.tasks[task.Name] = taskCopy
-	return &DefinedTask{taskCopy, f}
+	return taskCopy
 }
 
 // DefinePool registers the pool. It panics in case of any error.
@@ -146,6 +133,9 @@ func (f *Flow) DefinePool(pool Pool) *DefinedPool {
 		limit: pool.Limit,
 		sem:   make(chan struct{}, pool.Limit),
 	}
+	if f.pools == nil {
+		f.pools = map[string]*poolSnapshot{}
+	}
 	f.pools[pool.Name] = poolCopy
 	return &DefinedPool{poolCopy, f}
 }
@@ -157,36 +147,33 @@ func Undefine(task *DefinedTask) {
 
 // Undefine unregisters the task. It panics in case of any error.
 func (f *Flow) Undefine(task *DefinedTask) {
-	snapshot := task.taskSnapshot
-	if !f.isDefined(snapshot.name, task.flow) {
-		panic("task was not defined: " + snapshot.name)
+	if !f.isDefined(task.name, task.flow) {
+		panic("task was not defined: " + task.name)
 	}
 
-	delete(f.tasks, snapshot.name)
+	delete(f.tasks, task.name)
 
-	for _, task := range f.tasks {
-		if len(task.deps) == 0 {
+	for _, t := range f.tasks {
+		if len(t.deps) == 0 {
 			continue
 		}
-		var cleanDep []*taskSnapshot
-		for _, dep := range task.deps {
-			if dep == snapshot {
+		var cleanDep []*DefinedTask
+		for _, dep := range t.deps {
+			if dep == task {
 				continue
 			}
 			cleanDep = append(cleanDep, dep)
 		}
-		task.deps = cleanDep
+		t.deps = cleanDep
 	}
 
-	if f.defaultTask == snapshot {
+	if f.defaultTask == task {
 		f.defaultTask = nil
 	}
 }
 
 func (f *Flow) isDefined(name string, flow *Flow) bool {
-	if f.tasks == nil {
-		f.tasks = map[string]*taskSnapshot{}
-	}
+	f.init()
 	if f != flow {
 		return false // defined in other flow
 	}
@@ -205,7 +192,7 @@ func (f *Flow) isPoolDefined(name string, flow *Flow) bool {
 
 func (f *Flow) init() {
 	if f.tasks == nil {
-		f.tasks = map[string]*taskSnapshot{}
+		f.tasks = map[string]*DefinedTask{}
 	}
 	if f.pools == nil {
 		f.pools = map[string]*poolSnapshot{}
@@ -318,10 +305,7 @@ func Default() *DefinedTask {
 // Default returns the default task.
 // nil is returned if default was not set.
 func (f *Flow) Default() *DefinedTask {
-	if f.defaultTask == nil {
-		return nil
-	}
-	return &DefinedTask{f.defaultTask, f}
+	return f.defaultTask
 }
 
 // SetDefault sets a task to run when none is explicitly provided.
@@ -339,10 +323,10 @@ func (f *Flow) SetDefault(task *DefinedTask) {
 		return
 	}
 
-	if !f.isDefined(task.Name(), task.flow) {
-		panic("task was not defined: " + task.Name())
+	if !f.isDefined(task.name, task.flow) {
+		panic("task was not defined: " + task.name)
 	}
-	f.defaultTask = task.taskSnapshot
+	f.defaultTask = task
 }
 
 // Use adds task runner middlewares (interceptors).

--- a/flow.go
+++ b/flow.go
@@ -141,9 +141,6 @@ func (f *Flow) DefinePool(pool Pool) *DefinedPool {
 		limit: pool.Limit,
 		sem:   make(chan struct{}, pool.Limit),
 	}
-	if f.pools == nil {
-		f.pools = map[string]*poolSnapshot{}
-	}
 	f.pools[pool.Name] = poolCopy
 	return &DefinedPool{poolCopy, f}
 }
@@ -193,14 +190,21 @@ func (f *Flow) isDefined(name string, flow *Flow) bool {
 }
 
 func (f *Flow) isPoolDefined(name string, flow *Flow) bool {
-	if f.pools == nil {
-		f.pools = map[string]*poolSnapshot{}
-	}
+	f.init()
 	if f != flow {
 		return false // defined in other flow
 	}
 	_, ok := f.pools[name]
 	return ok
+}
+
+func (f *Flow) init() {
+	if f.tasks == nil {
+		f.tasks = map[string]*taskSnapshot{}
+	}
+	if f.pools == nil {
+		f.pools = map[string]*poolSnapshot{}
+	}
 }
 
 // Output returns the destination used for printing messages.

--- a/flow.go
+++ b/flow.go
@@ -101,7 +101,12 @@ func (f *Flow) Define(task Task) *DefinedTask {
 		deps = append(deps, dep.taskSnapshot)
 	}
 	var pools []*poolSnapshot
+	poolCounts := make(map[string]int)
 	for _, pool := range task.Pools {
+		poolCounts[pool.Name()]++
+		if poolCounts[pool.Name()] > pool.Limit() {
+			panic(fmt.Sprintf("task requests %d slots from pool %s, which has a limit of %d", poolCounts[pool.Name()], pool.Name(), pool.Limit()))
+		}
 		pools = append(pools, pool.poolSnapshot)
 	}
 	sort.Slice(pools, func(i, j int) bool { return pools[i].name < pools[j].name })

--- a/flow_test.go
+++ b/flow_test.go
@@ -47,6 +47,10 @@ func Test_DefaultFlow(t *testing.T) {
 		goyek.Use(func(r goyek.Runner) goyek.Runner { return r })
 		goyek.UseExecutor(func(e goyek.Executor) goyek.Executor { return e })
 		assertPass(t, goyek.Execute(context.Background(), nil), "Execute")
+
+		pool := goyek.DefinePool(goyek.Pool{Name: "pool", Limit: 1})
+		assertEqual(t, goyek.Pools()[0].Name(), "pool", "Pools")
+		goyek.Define(goyek.Task{Name: "with-pool", Pools: goyek.DefinedPools{pool}})
 	})
 }
 
@@ -321,6 +325,42 @@ func Test_invalid_args(t *testing.T) {
 	}
 }
 
+func Test_Define_bad_pool(t *testing.T) {
+	flow := &goyek.Flow{}
+	otherFlow := &goyek.Flow{}
+	pool := otherFlow.DefinePool(goyek.Pool{Name: "different-flow", Limit: 1})
+
+	act := func() { flow.Define(goyek.Task{Name: "pool-from-different-flow", Pools: goyek.DefinedPools{pool}}) }
+
+	assertPanics(t, act, "should not be possible use pools from different flow")
+}
+
+func Test_DefinePool_empty_name(t *testing.T) {
+	flow := &goyek.Flow{}
+
+	act := func() { flow.DefinePool(goyek.Pool{Limit: 1}) }
+
+	assertPanics(t, act, "should panic on empty pool name")
+}
+
+func Test_DefinePool_bad_limit(t *testing.T) {
+	flow := &goyek.Flow{}
+
+	act := func() { flow.DefinePool(goyek.Pool{Name: "pool", Limit: 0}) }
+
+	assertPanics(t, act, "should panic on non-positive pool limit")
+}
+
+func Test_DefinePool_same_name(t *testing.T) {
+	flow := &goyek.Flow{}
+	pool := goyek.Pool{Name: "pool", Limit: 1}
+	flow.DefinePool(pool)
+
+	act := func() { flow.DefinePool(pool) }
+
+	assertPanics(t, act, "should not be possible to register pools with same name twice")
+}
+
 func Test_printing(t *testing.T) {
 	out := &strings.Builder{}
 	flow := &goyek.Flow{}
@@ -532,6 +572,20 @@ func TestFlow_Print(t *testing.T) {
 	assertContains(t, out, "Default task: task", "should print the default task")
 	assertNotContains(t, out, "hidden", "should not print task with no usage")
 	assertContains(t, out, "(depends on: task)", "should print the task dependencies")
+}
+
+func TestFlow_Print_pools(t *testing.T) {
+	out := &strings.Builder{}
+	flow := &goyek.Flow{}
+	flow.SetOutput(out)
+	p1 := flow.DefinePool(goyek.Pool{Name: "p1", Limit: 1})
+	flow.Define(goyek.Task{Name: "task", Usage: "use it", Pools: goyek.DefinedPools{p1}})
+
+	flow.Print()
+
+	assertContains(t, out, "Pools:", "should print Pools section")
+	assertContains(t, out, "p1\t(limit: 1)", "should print the pool")
+	assertContains(t, out, "(pools: p1)", "should print the task pools")
 }
 
 func TestFlow_Logger(t *testing.T) {

--- a/flow_test.go
+++ b/flow_test.go
@@ -50,6 +50,7 @@ func Test_DefaultFlow(t *testing.T) {
 
 		pool := goyek.DefinePool(goyek.Pool{Name: "pool", Limit: 1})
 		assertEqual(t, goyek.Pools()[0].Name(), "pool", "Pools")
+		assertEqual(t, goyek.Pools()[0].Limit(), 1, "Pool Limit")
 		goyek.Define(goyek.Task{Name: "with-pool", Pools: goyek.DefinedPools{pool}})
 	})
 }
@@ -605,6 +606,11 @@ func TestFlow_Logger(t *testing.T) {
 
 	assertContains(t, out, "first", "should call Log")
 	assertContains(t, out, "second", "should call Logf")
+}
+
+func Test_FailError_Error(t *testing.T) {
+	err := &goyek.FailError{Task: "task"}
+	assertEqual(t, err.Error(), "task failed: task", "Error()")
 }
 
 func TestFlow_Logger_default(t *testing.T) {

--- a/pool_test.go
+++ b/pool_test.go
@@ -195,3 +195,32 @@ func TestPoolSlotLeak(t *testing.T) {
 	err := flow.Execute(ctx2, []string{"blocker1", "blocker2"})
 	assertPass(t, err, "pools should not have leaked slots")
 }
+
+func TestPoolIntrospection(t *testing.T) {
+	flow := &goyek.Flow{}
+	p2 := flow.DefinePool(goyek.Pool{Name: "v2", Limit: 2})
+	p1 := flow.DefinePool(goyek.Pool{Name: "v1", Limit: 1})
+
+	pools := flow.Pools()
+	assertEqual(t, len(pools), 2, "should have 2 pools")
+	assertEqual(t, pools[0].Name(), "v1", "first pool name")
+	assertEqual(t, pools[0].Limit(), 1, "first pool limit")
+	assertEqual(t, pools[1].Name(), "v2", "second pool name")
+	assertEqual(t, pools[1].Limit(), 2, "second pool limit")
+
+	task := flow.Define(goyek.Task{
+		Name:  "task",
+		Pools: goyek.DefinedPools{p2, p1},
+	})
+	taskPools := task.Pools()
+	assertEqual(t, len(taskPools), 2, "task should have 2 pools")
+	// Task.Pools() returns them in the order they are in the snapshot, which is sorted by name
+	assertEqual(t, taskPools[0].Name(), "v1", "first task pool")
+	assertEqual(t, taskPools[1].Name(), "v2", "second task pool")
+}
+
+func TestFlow_Define_no_pools(t *testing.T) {
+	flow := &goyek.Flow{}
+	task := flow.Define(goyek.Task{Name: "no-pools"})
+	assertEqual(t, len(task.Pools()), 0, "should have no pools")
+}

--- a/pool_test.go
+++ b/pool_test.go
@@ -1,0 +1,197 @@
+package goyek_test
+
+import (
+	"context"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/goyek/goyek/v3"
+)
+
+func TestPool(t *testing.T) {
+	flow := &goyek.Flow{}
+	flow.SetOutput(io.Discard)
+
+	pool := flow.DefinePool(goyek.Pool{Name: "pool", Limit: 2})
+
+	var mu sync.Mutex
+	var running int
+	var maxRunning int
+
+	action := func(a *goyek.A) {
+		mu.Lock()
+		running++
+		if running > maxRunning {
+			maxRunning = running
+		}
+		mu.Unlock()
+
+		time.Sleep(10 * time.Millisecond)
+
+		mu.Lock()
+		running--
+		mu.Unlock()
+	}
+
+	flow.Define(goyek.Task{Name: "t1", Action: action, Pools: goyek.DefinedPools{pool}, Parallel: true})
+	flow.Define(goyek.Task{Name: "t2", Action: action, Pools: goyek.DefinedPools{pool}, Parallel: true})
+	flow.Define(goyek.Task{Name: "t3", Action: action, Pools: goyek.DefinedPools{pool}, Parallel: true})
+
+	err := flow.Execute(context.Background(), []string{"t1", "t2", "t3"})
+	assertPass(t, err, "Execute should pass")
+	assertEqual(t, maxRunning, 2, "maxRunning should be limited by pool size")
+}
+
+func TestMultiPool(t *testing.T) {
+	flow := &goyek.Flow{}
+	flow.SetOutput(io.Discard)
+
+	p1 := flow.DefinePool(goyek.Pool{Name: "p1", Limit: 1})
+	p2 := flow.DefinePool(goyek.Pool{Name: "p2", Limit: 1})
+
+	var mu sync.Mutex
+	var running int
+	var maxRunning int
+
+	action := func(a *goyek.A) {
+		mu.Lock()
+		running++
+		if running > maxRunning {
+			maxRunning = running
+		}
+		mu.Unlock()
+
+		time.Sleep(10 * time.Millisecond)
+
+		mu.Lock()
+		running--
+		mu.Unlock()
+	}
+
+	// t1 uses p1, t2 uses p2, t3 uses both p1 and p2
+	flow.Define(goyek.Task{Name: "t1", Action: action, Pools: goyek.DefinedPools{p1}, Parallel: true})
+	flow.Define(goyek.Task{Name: "t2", Action: action, Pools: goyek.DefinedPools{p2}, Parallel: true})
+	flow.Define(goyek.Task{Name: "t3", Action: action, Pools: goyek.DefinedPools{p1, p2}, Parallel: true})
+
+	err := flow.Execute(context.Background(), []string{"t1", "t2", "t3"})
+	assertPass(t, err, "Execute should pass")
+	// Since t3 needs both pools, it can only run when both p1 and p2 are free.
+	// t1 and t2 can run concurrently if they are the only ones.
+	// But any task using p1 or p2 will block t3.
+	// maxRunning could be 2 (t1 and t2).
+	assertTrue(t, maxRunning <= 2, "maxRunning should respect pool limits")
+}
+
+func TestPoolDeadlockAvoidance(t *testing.T) {
+	flow := &goyek.Flow{}
+	flow.SetOutput(io.Discard)
+
+	p1 := flow.DefinePool(goyek.Pool{Name: "p1", Limit: 1})
+	p2 := flow.DefinePool(goyek.Pool{Name: "p2", Limit: 1})
+
+	// Task A uses p1 then p2 (sorted: p1, p2)
+	flow.Define(goyek.Task{
+		Name:     "A",
+		Pools:    goyek.DefinedPools{p1, p2},
+		Parallel: true,
+		Action:   func(a *goyek.A) { time.Sleep(time.Millisecond) },
+	})
+	// Task B uses p2 then p1 (sorted: p1, p2)
+	flow.Define(goyek.Task{
+		Name:     "B",
+		Pools:    goyek.DefinedPools{p2, p1},
+		Parallel: true,
+		Action:   func(a *goyek.A) { time.Sleep(time.Millisecond) },
+	})
+
+	err := flow.Execute(context.Background(), []string{"A", "B"})
+	assertPass(t, err, "Execute should pass without deadlock")
+}
+
+func TestPoolContextCancellation(t *testing.T) {
+	flow := &goyek.Flow{}
+	flow.SetOutput(io.Discard)
+
+	p1 := flow.DefinePool(goyek.Pool{Name: "p1", Limit: 1})
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	flow.Define(goyek.Task{
+		Name:  "blocker",
+		Pools: goyek.DefinedPools{p1},
+		Action: func(a *goyek.A) {
+			cancel()
+			time.Sleep(100 * time.Millisecond)
+		},
+	})
+	flow.Define(goyek.Task{
+		Name:  "waiting",
+		Pools: goyek.DefinedPools{p1},
+	})
+
+	err := flow.Execute(ctx, []string{"blocker", "waiting"})
+	assertEqual(t, err, context.Canceled, "should return context.Canceled")
+}
+
+func TestPoolSlotLeak(t *testing.T) {
+	flow := &goyek.Flow{}
+	flow.SetOutput(io.Discard)
+
+	p1 := flow.DefinePool(goyek.Pool{Name: "p1", Limit: 1})
+	p2 := flow.DefinePool(goyek.Pool{Name: "p2", Limit: 1})
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// blocker1 takes p1
+	flow.Define(goyek.Task{
+		Name:  "blocker1",
+		Pools: goyek.DefinedPools{p1},
+		Action: func(a *goyek.A) {
+			time.Sleep(10 * time.Millisecond)
+		},
+	})
+	// leaky tries to take p1 then p2, but will fail on p1 if p1 is taken
+	// Actually, runTask will block on p1 acquisition.
+	// If we cancel the context while it's blocking on p1, it should not leak anything.
+	// If it already acquired p1 and blocks on p2, and we cancel, it should release p1.
+
+	flow.Define(goyek.Task{
+		Name:  "blocker2",
+		Pools: goyek.DefinedPools{p2},
+		Action: func(a *goyek.A) {
+			time.Sleep(50 * time.Millisecond)
+		},
+	})
+
+	flow.Define(goyek.Task{
+		Name:  "leaky",
+		Pools: goyek.DefinedPools{p1, p2},
+		Parallel: true,
+	})
+
+	// 1. blocker1 takes p1
+	// 2. blocker2 takes p2
+	// 3. leaky tries to take p1, blocks.
+	// 4. cancel context.
+	// 5. leaky should return.
+	// 6. after blocker1 and blocker2 finish, pools should be empty.
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_ = flow.Execute(ctx, []string{"blocker1", "blocker2", "leaky"})
+	}()
+
+	time.Sleep(20 * time.Millisecond) // ensure blockers have taken the slots
+	cancel()
+	wg.Wait()
+
+	// Now try to run a task that needs the pools. If they leaked, this will hang or fail.
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel2()
+	err := flow.Execute(ctx2, []string{"blocker1", "blocker2"})
+	assertPass(t, err, "pools should not have leaked slots")
+}

--- a/pool_test.go
+++ b/pool_test.go
@@ -224,3 +224,84 @@ func TestFlow_Define_no_pools(t *testing.T) {
 	task := flow.Define(goyek.Task{Name: "no-pools"})
 	assertEqual(t, len(task.Pools()), 0, "should have no pools")
 }
+
+func TestPoolMultipleSlots(t *testing.T) {
+	flow := &goyek.Flow{}
+	flow.SetOutput(io.Discard)
+
+	p1 := flow.DefinePool(goyek.Pool{Name: "p1", Limit: 2})
+
+	var mu sync.Mutex
+	var running int
+	var maxRunning int
+
+	action := func(_ *goyek.A) {
+		mu.Lock()
+		running++
+		if running > maxRunning {
+			maxRunning = running
+		}
+		mu.Unlock()
+		time.Sleep(10 * time.Millisecond)
+		mu.Lock()
+		running--
+		mu.Unlock()
+	}
+
+	// task takes both slots
+	flow.Define(goyek.Task{
+		Name:   "t1",
+		Pools:  goyek.DefinedPools{p1, p1},
+		Action: action,
+	})
+	// t2 will have to wait
+	flow.Define(goyek.Task{
+		Name:     "t2",
+		Pools:    goyek.DefinedPools{p1},
+		Action:   action,
+		Parallel: true,
+	})
+
+	err := flow.Execute(context.Background(), []string{"t1", "t2"})
+	assertPass(t, err, "Execute should pass")
+	assertEqual(t, maxRunning, 1, "only 1 task should run at a time because t1 takes all slots")
+}
+
+func TestFlow_Define_too_many_slots(t *testing.T) {
+	flow := &goyek.Flow{}
+	p1 := flow.DefinePool(goyek.Pool{Name: "p1", Limit: 1})
+
+	act := func() {
+		flow.Define(goyek.Task{
+			Name:  "t1",
+			Pools: goyek.DefinedPools{p1, p1},
+		})
+	}
+
+	assertPanics(t, act, "should panic when task requests more slots than pool limit")
+}
+
+func TestPoolWaitLog(t *testing.T) {
+	flow := &goyek.Flow{}
+	flow.SetOutput(io.Discard)
+	flow.SetLogger(goyek.FmtLogger{})
+
+	p1 := flow.DefinePool(goyek.Pool{Name: "p1", Limit: 1})
+
+	flow.Define(goyek.Task{
+		Name:  "blocker",
+		Pools: goyek.DefinedPools{p1},
+		Action: func(_ *goyek.A) {
+			time.Sleep(100 * time.Millisecond)
+		},
+		Parallel: true,
+	})
+	flow.Define(goyek.Task{
+		Name:  "waiting",
+		Pools: goyek.DefinedPools{p1},
+		Parallel: true,
+	})
+
+	err := flow.Execute(context.Background(), []string{"blocker", "waiting"})
+	assertPass(t, err, "Execute should pass")
+}

--- a/pool_test.go
+++ b/pool_test.go
@@ -20,7 +20,7 @@ func TestPool(t *testing.T) {
 	var running int
 	var maxRunning int
 
-	action := func(a *goyek.A) {
+	action := func(_ *goyek.A) {
 		mu.Lock()
 		running++
 		if running > maxRunning {
@@ -55,7 +55,7 @@ func TestMultiPool(t *testing.T) {
 	var running int
 	var maxRunning int
 
-	action := func(a *goyek.A) {
+	action := func(_ *goyek.A) {
 		mu.Lock()
 		running++
 		if running > maxRunning {
@@ -96,14 +96,14 @@ func TestPoolDeadlockAvoidance(t *testing.T) {
 		Name:     "A",
 		Pools:    goyek.DefinedPools{p1, p2},
 		Parallel: true,
-		Action:   func(a *goyek.A) { time.Sleep(time.Millisecond) },
+		Action:   func(_ *goyek.A) { time.Sleep(time.Millisecond) },
 	})
 	// Task B uses p2 then p1 (sorted: p1, p2)
 	flow.Define(goyek.Task{
 		Name:     "B",
 		Pools:    goyek.DefinedPools{p2, p1},
 		Parallel: true,
-		Action:   func(a *goyek.A) { time.Sleep(time.Millisecond) },
+		Action:   func(_ *goyek.A) { time.Sleep(time.Millisecond) },
 	})
 
 	err := flow.Execute(context.Background(), []string{"A", "B"})
@@ -121,7 +121,7 @@ func TestPoolContextCancellation(t *testing.T) {
 	flow.Define(goyek.Task{
 		Name:  "blocker",
 		Pools: goyek.DefinedPools{p1},
-		Action: func(a *goyek.A) {
+		Action: func(_ *goyek.A) {
 			cancel()
 			time.Sleep(100 * time.Millisecond)
 		},
@@ -148,7 +148,7 @@ func TestPoolSlotLeak(t *testing.T) {
 	flow.Define(goyek.Task{
 		Name:  "blocker1",
 		Pools: goyek.DefinedPools{p1},
-		Action: func(a *goyek.A) {
+		Action: func(_ *goyek.A) {
 			time.Sleep(10 * time.Millisecond)
 		},
 	})
@@ -160,7 +160,7 @@ func TestPoolSlotLeak(t *testing.T) {
 	flow.Define(goyek.Task{
 		Name:  "blocker2",
 		Pools: goyek.DefinedPools{p2},
-		Action: func(a *goyek.A) {
+		Action: func(_ *goyek.A) {
 			time.Sleep(50 * time.Millisecond)
 		},
 	})

--- a/task.go
+++ b/task.go
@@ -66,8 +66,13 @@ func (p *DefinedPool) Limit() int {
 // DefinedTask represents a task that has been defined.
 // It can be used as a dependency for another task.
 type DefinedTask struct {
-	*taskSnapshot
-	flow *Flow
+	name     string
+	usage    string
+	deps     []*DefinedTask
+	pools    []*poolSnapshot
+	action   func(a *A)
+	parallel bool
+	flow     *Flow
 }
 
 // Deps represents a collection of dependencies.
@@ -84,10 +89,9 @@ func (r *DefinedTask) SetName(s string) {
 		panic("task with the same name is already defined")
 	}
 	oldName := r.name
-	snap := r.flow.tasks[oldName]
-	snap.name = s
-	r.flow.tasks[s] = snap
+	r.flow.tasks[s] = r
 	delete(r.flow.tasks, oldName)
+	r.name = s
 }
 
 // Usage returns the description of the task.
@@ -112,14 +116,11 @@ func (r *DefinedTask) SetAction(fn func(a *A)) {
 
 // Deps returns all task's dependencies.
 func (r *DefinedTask) Deps() Deps {
-	count := len(r.deps)
-	if count == 0 {
+	if len(r.deps) == 0 {
 		return nil
 	}
-	deps := make(Deps, 0, count)
-	for _, dep := range r.deps {
-		deps = append(deps, &DefinedTask{r.flow.tasks[dep.name], r.flow})
-	}
+	deps := make(Deps, len(r.deps))
+	copy(deps, r.deps)
 	return deps
 }
 
@@ -138,8 +139,7 @@ func (r *DefinedTask) Pools() DefinedPools {
 
 // SetDeps sets all task's dependencies.
 func (r *DefinedTask) SetDeps(deps Deps) {
-	count := len(deps)
-	if count == 0 {
+	if len(deps) == 0 {
 		r.deps = nil
 		return
 	}
@@ -154,12 +154,7 @@ func (r *DefinedTask) SetDeps(deps Deps) {
 	if ok := r.noCycle(deps, visited); !ok {
 		panic("circular dependency")
 	}
-	depNames := make([]*taskSnapshot, 0, count)
-	for _, dep := range deps {
-		depNames = append(depNames, dep.taskSnapshot)
-	}
-
-	r.deps = depNames
+	r.deps = deps
 }
 
 func (r *DefinedTask) noCycle(deps Deps, visited map[string]bool) bool {
@@ -167,15 +162,15 @@ func (r *DefinedTask) noCycle(deps Deps, visited map[string]bool) bool {
 		return true
 	}
 	for _, dep := range deps {
-		name := dep.Name()
+		name := dep.name
 		if visited[name] {
-			return true
+			continue // already checked this branch
 		}
 		visited[name] = true
 		if name == r.name {
 			return false
 		}
-		if !r.noCycle(dep.Deps(), visited) {
+		if !r.noCycle(dep.deps, visited) {
 			return false
 		}
 	}

--- a/task.go
+++ b/task.go
@@ -23,6 +23,7 @@ type Task struct {
 
 	// Pools is a collection of defined pools
 	// that limit the number of concurrent task instances.
+	// A task can consume multiple slots from a pool by including it multiple times.
 	Pools DefinedPools
 }
 

--- a/task.go
+++ b/task.go
@@ -20,6 +20,46 @@ type Task struct {
 	// Parallel marks that this task can be run in parallel
 	// with (and only with) other parallel tasks.
 	Parallel bool
+
+	// Pools is a collection of defined pools
+	// that limit the number of concurrent task instances.
+	Pools DefinedPools
+}
+
+// Pool represents a named pool that can limit the number of concurrent task instances.
+type Pool struct {
+	// Name uniquely identifies the pool.
+	// It cannot be empty and should be easily representable on the CLI.
+	Name string
+
+	// Limit is the number of concurrent task instances assigned to the pool.
+	// It must be greater than 0.
+	Limit int
+}
+
+// DefinedPool represents a pool that has been defined.
+type DefinedPool struct {
+	*poolSnapshot
+	flow *Flow
+}
+
+// DefinedPools represents a collection of pools.
+type DefinedPools []*DefinedPool
+
+type poolSnapshot struct {
+	name  string
+	limit int
+	sem   chan struct{}
+}
+
+// Name returns the name of the pool.
+func (p *DefinedPool) Name() string {
+	return p.name
+}
+
+// Limit returns the limit of the pool.
+func (p *DefinedPool) Limit() int {
+	return p.limit
 }
 
 // DefinedTask represents a task that has been defined.
@@ -80,6 +120,19 @@ func (r *DefinedTask) Deps() Deps {
 		deps = append(deps, &DefinedTask{r.flow.tasks[dep.name], r.flow})
 	}
 	return deps
+}
+
+// Pools returns all task's pools.
+func (r *DefinedTask) Pools() DefinedPools {
+	count := len(r.pools)
+	if count == 0 {
+		return nil
+	}
+	pools := make(DefinedPools, 0, count)
+	for _, pool := range r.pools {
+		pools = append(pools, &DefinedPool{pool, r.flow})
+	}
+	return pools
 }
 
 // SetDeps sets all task's dependencies.


### PR DESCRIPTION
I have implemented the "Pools" feature in `goyek` as requested in issue #435. This feature allows users to limit the concurrency of specific tasks by assigning them to pools.

Key implementation details:
- **Concurrency Control**: Used buffered channels as semaphores within a `poolSnapshot` to manage slot allocation.
- **Deadlock Avoidance**: Enforced lexicographical acquisition order for pools assigned to a task.
- **Resource Safety**: Used a `defer` block with an acquisition counter in the executor to guarantee that all acquired slots are released, even if the task execution or slot acquisition is interrupted.
- **Visibility**: Updated the help output to show defined pools and their associations with tasks.
- **Verification**: Added unit tests for registration and introspection, and integration tests for concurrency limits, multi-pool scenarios, deadlock avoidance, and context cancellation.

All tests passed successfully.

---
*PR created automatically by Jules for task [6097945099470141057](https://jules.google.com/task/6097945099470141057) started by @pellared*