### PR TITLE
Remove taskSnapshot and use DefinedTask directly

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -24,9 +24,9 @@ type (
 	ExecutorMiddleware func(Executor) Executor
 
 	executor struct {
-		defined     map[string]*taskSnapshot
+		defined     map[string]*DefinedTask
 		middlewares []Middleware
-		defaultTask *taskSnapshot
+		defaultTask *DefinedTask
 	}
 )
 
@@ -89,7 +89,7 @@ func (r *executor) Execute(in ExecuteInput) error {
 			continue
 		}
 
-		tasksToRun := []*taskSnapshot{task}
+		tasksToRun := []*DefinedTask{task}
 
 		// Find all parallel tasks that have not been run
 		// and have no dependencies.
@@ -137,7 +137,7 @@ func (r *executor) validate(in ExecuteInput) error {
 	return nil
 }
 
-func (r *executor) canRunTask(task *taskSnapshot, visited map[string]bool, noDeps bool) bool {
+func (r *executor) canRunTask(task *DefinedTask, visited map[string]bool, noDeps bool) bool {
 	if visited[task.name] {
 		return false
 	}
@@ -161,7 +161,7 @@ func (r *executor) canRunTask(task *taskSnapshot, visited map[string]bool, noDep
 	return true
 }
 
-func (r *executor) runParallelTasks(ctx context.Context, tasks []*taskSnapshot, output io.Writer, logger Logger) error {
+func (r *executor) runParallelTasks(ctx context.Context, tasks []*DefinedTask, output io.Writer, logger Logger) error {
 	var err error
 	errCh := make(chan error, len(tasks))
 	for _, parallelTask := range tasks {
@@ -178,7 +178,7 @@ func (r *executor) runParallelTasks(ctx context.Context, tasks []*taskSnapshot, 
 	return err
 }
 
-func (r *executor) runTask(ctx context.Context, task *taskSnapshot, output io.Writer, logger Logger) error {
+func (r *executor) runTask(ctx context.Context, task *DefinedTask, output io.Writer, logger Logger) error {
 	// prepare runner
 	runner := NewRunner(task.action)
 

--- a/flow.go
+++ b/flow.go
@@ -20,8 +20,8 @@ type Flow struct {
 	usage  func()
 	logger Logger
 
-	tasks               map[string]*taskSnapshot // snapshot of defined tasks
-	defaultTask         *taskSnapshot            // task to run when none is explicitly provided
+	tasks               map[string]*DefinedTask // snapshot of defined tasks
+	defaultTask         *DefinedTask            // task to run when none is explicitly provided
 	middlewares         []Middleware
 	executorMiddlewares []ExecutorMiddleware
 }
@@ -29,15 +29,6 @@ type Flow struct {
 // DefaultFlow is the default flow.
 // The top-level functions such as Define, Main, and so on are wrappers for the methods of Flow.
 var DefaultFlow = &Flow{}
-
-// taskSnapshot is a copy of the task to make the flow usage safer.
-type taskSnapshot struct {
-	name     string
-	usage    string
-	deps     []*taskSnapshot
-	action   func(a *A)
-	parallel bool
-}
 
 // Tasks returns all tasks sorted in lexicographical order.
 func Tasks() []*DefinedTask {
@@ -48,7 +39,7 @@ func Tasks() []*DefinedTask {
 func (f *Flow) Tasks() []*DefinedTask {
 	var tasks []*DefinedTask
 	for _, task := range f.tasks {
-		tasks = append(tasks, &DefinedTask{task, f})
+		tasks = append(tasks, task)
 	}
 	sort.Slice(tasks, func(i, j int) bool { return tasks[i].Name() < tasks[j].Name() })
 	return tasks
@@ -69,24 +60,21 @@ func (f *Flow) Define(task Task) *DefinedTask {
 		panic("task with the same name is already defined")
 	}
 	for _, dep := range task.Deps {
-		if !f.isDefined(dep.Name(), dep.flow) {
-			panic("dependency was not defined: " + dep.Name())
+		if !f.isDefined(dep.name, dep.flow) {
+			panic("dependency was not defined: " + dep.name)
 		}
 	}
 
-	var deps []*taskSnapshot
-	for _, dep := range task.Deps {
-		deps = append(deps, dep.taskSnapshot)
-	}
-	taskCopy := &taskSnapshot{
+	taskCopy := &DefinedTask{
 		name:     task.Name,
 		usage:    task.Usage,
-		deps:     deps,
+		deps:     task.Deps,
 		action:   task.Action,
 		parallel: task.Parallel,
+		flow:     f,
 	}
 	f.tasks[task.Name] = taskCopy
-	return &DefinedTask{taskCopy, f}
+	return taskCopy
 }
 
 // Undefine unregisters the task. It panics in case of any error.
@@ -96,35 +84,34 @@ func Undefine(task *DefinedTask) {
 
 // Undefine unregisters the task. It panics in case of any error.
 func (f *Flow) Undefine(task *DefinedTask) {
-	snapshot := task.taskSnapshot
-	if !f.isDefined(snapshot.name, task.flow) {
-		panic("task was not defined: " + snapshot.name)
+	if !f.isDefined(task.name, task.flow) {
+		panic("task was not defined: " + task.name)
 	}
 
-	delete(f.tasks, snapshot.name)
+	delete(f.tasks, task.name)
 
-	for _, task := range f.tasks {
-		if len(task.deps) == 0 {
+	for _, t := range f.tasks {
+		if len(t.deps) == 0 {
 			continue
 		}
-		var cleanDep []*taskSnapshot
-		for _, dep := range task.deps {
-			if dep == snapshot {
+		var cleanDep []*DefinedTask
+		for _, dep := range t.deps {
+			if dep == task {
 				continue
 			}
 			cleanDep = append(cleanDep, dep)
 		}
-		task.deps = cleanDep
+		t.deps = cleanDep
 	}
 
-	if f.defaultTask == snapshot {
+	if f.defaultTask == task {
 		f.defaultTask = nil
 	}
 }
 
 func (f *Flow) isDefined(name string, flow *Flow) bool {
 	if f.tasks == nil {
-		f.tasks = map[string]*taskSnapshot{}
+		f.tasks = map[string]*DefinedTask{}
 	}
 	if f != flow {
 		return false // defined in other flow
@@ -239,10 +226,7 @@ func Default() *DefinedTask {
 // Default returns the default task.
 // nil is returned if default was not set.
 func (f *Flow) Default() *DefinedTask {
-	if f.defaultTask == nil {
-		return nil
-	}
-	return &DefinedTask{f.defaultTask, f}
+	return f.defaultTask
 }
 
 // SetDefault sets a task to run when none is explicitly provided.
@@ -260,10 +244,10 @@ func (f *Flow) SetDefault(task *DefinedTask) {
 		return
 	}
 
-	if !f.isDefined(task.Name(), task.flow) {
-		panic("task was not defined: " + task.Name())
+	if !f.isDefined(task.name, task.flow) {
+		panic("task was not defined: " + task.name)
 	}
-	f.defaultTask = task.taskSnapshot
+	f.defaultTask = task
 }
 
 // Use adds task runner middlewares (interceptors).

--- a/task.go
+++ b/task.go
@@ -25,8 +25,12 @@ type Task struct {
 // DefinedTask represents a task that has been defined.
 // It can be used as a dependency for another task.
 type DefinedTask struct {
-	*taskSnapshot
-	flow *Flow
+	name     string
+	usage    string
+	deps     []*DefinedTask
+	action   func(a *A)
+	parallel bool
+	flow     *Flow
 }
 
 // Deps represents a collection of dependencies.
@@ -43,10 +47,9 @@ func (r *DefinedTask) SetName(s string) {
 		panic("task with the same name is already defined")
 	}
 	oldName := r.name
-	snap := r.flow.tasks[oldName]
-	snap.name = s
-	r.flow.tasks[s] = snap
+	r.flow.tasks[s] = r
 	delete(r.flow.tasks, oldName)
+	r.name = s
 }
 
 // Usage returns the description of the task.
@@ -71,21 +74,17 @@ func (r *DefinedTask) SetAction(fn func(a *A)) {
 
 // Deps returns all task's dependencies.
 func (r *DefinedTask) Deps() Deps {
-	count := len(r.deps)
-	if count == 0 {
+	if len(r.deps) == 0 {
 		return nil
 	}
-	deps := make(Deps, 0, count)
-	for _, dep := range r.deps {
-		deps = append(deps, &DefinedTask{r.flow.tasks[dep.name], r.flow})
-	}
+	deps := make(Deps, len(r.deps))
+	copy(deps, r.deps)
 	return deps
 }
 
 // SetDeps sets all task's dependencies.
 func (r *DefinedTask) SetDeps(deps Deps) {
-	count := len(deps)
-	if count == 0 {
+	if len(deps) == 0 {
 		r.deps = nil
 		return
 	}
@@ -100,12 +99,7 @@ func (r *DefinedTask) SetDeps(deps Deps) {
 	if ok := r.noCycle(deps, visited); !ok {
 		panic("circular dependency")
 	}
-	depNames := make([]*taskSnapshot, 0, count)
-	for _, dep := range deps {
-		depNames = append(depNames, dep.taskSnapshot)
-	}
-
-	r.deps = depNames
+	r.deps = deps
 }
 
 func (r *DefinedTask) noCycle(deps Deps, visited map[string]bool) bool {
@@ -113,15 +107,15 @@ func (r *DefinedTask) noCycle(deps Deps, visited map[string]bool) bool {
 		return true
 	}
 	for _, dep := range deps {
-		name := dep.Name()
+		name := dep.name
 		if visited[name] {
-			return true
+			continue
 		}
 		visited[name] = true
 		if name == r.name {
 			return false
 		}
-		if !r.noCycle(dep.Deps(), visited) {
+		if !r.noCycle(dep.deps, visited) {
 			return false
 		}
 	}

--- a/task.go
+++ b/task.go
@@ -109,7 +109,7 @@ func (r *DefinedTask) noCycle(deps Deps, visited map[string]bool) bool {
 	for _, dep := range deps {
 		name := dep.name
 		if visited[name] {
-			continue
+			continue // already checked this branch
 		}
 		visited[name] = true
 		if name == r.name {


### PR DESCRIPTION
This PR removes the redundant `taskSnapshot` struct and refactors the codebase to use `DefinedTask` as the primary internal and external representation of a defined task.

Key changes:
- Moved fields from `taskSnapshot` to `DefinedTask` in `task.go`.
- Removed `taskSnapshot` struct in `flow.go`.
- Updated `Flow` and `executor` to use `*DefinedTask` instead of `*taskSnapshot`.
- Updated methods in `task.go`, `flow.go`, and `executor.go` to reflect these changes.
- Improved the `noCycle` detection logic in `task.go`.


---
*PR created automatically by Jules for task [13215391972342730303](https://jules.google.com/task/13215391972342730303) started by @pellared*