### PR TITLE
Fix resource leak in A.WithContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 
 - Fix a resource leak in `A.Chdir` where a file descriptor could remain
   open.
+- Fix a resource leak in `A.WithContext` where derived contexts were
+  not canceled when the task finished.
 
 ## [3.0.1](https://github.com/goyek/goyek/releases/tag/v3.0.1) - 2025-12-09
 

--- a/a.go
+++ b/a.go
@@ -204,6 +204,7 @@ func (a *A) WithContext(ctx context.Context) *A {
 	}
 
 	derivedCtx, cancel := context.WithCancel(ctx)
+	a.Cleanup(cancel)
 	res := *a
 	res.ctx = derivedCtx
 	res.ctxCancel = cancel

--- a/a_test.go
+++ b/a_test.go
@@ -155,6 +155,23 @@ func TestA_WithContext(t *testing.T) {
 	}
 }
 
+func TestA_WithContext_cancels_on_cleanup(t *testing.T) {
+	var ctx context.Context
+	res := goyek.NewRunner(func(a *goyek.A) {
+		ctx = a.WithContext(context.Background()).Context()
+	})(goyek.Input{})
+
+	if res.Status != goyek.StatusPassed {
+		t.Errorf("status was %s but want %s", res.Status, goyek.StatusPassed)
+	}
+
+	select {
+	case <-ctx.Done():
+	default:
+		t.Error("context should be cancelled after the task finishes")
+	}
+}
+
 func TestA_WithContext_nil(t *testing.T) {
 	out := &strings.Builder{}
 	got := goyek.NewRunner(func(a *goyek.A) {


### PR DESCRIPTION
This PR fixes a resource leak in the `A.WithContext` method. In Go, failing to call the cancellation function returned by `context.WithCancel` can lead to goroutine and memory leaks. By registering the `cancel` function using `a.Cleanup(cancel)`, we ensure that resources are automatically released when the task completes.

Added a regression test `TestA_WithContext_cancels_on_cleanup` in `a_test.go`.

---
*PR created automatically by Jules for task [15130242317713987514](https://jules.google.com/task/15130242317713987514) started by @pellared*