### PR TITLE
Truncate task name in A.TempDir() to prevent filesystem errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
   open.
 - Fix a resource leak in `A.WithContext` where derived contexts were
   not canceled when the task finished.
+- `A.TempDir` now truncates the sanitized task name to 64 characters to
+  prevent "file name too long" errors.
 
 ## [3.0.1](https://github.com/goyek/goyek/releases/tag/v3.0.1) - 2025-12-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
   open.
 - Fix a resource leak in `A.WithContext` where derived contexts were
   not canceled when the task finished.
-- `A.TempDir` now truncates the sanitized task name to 64 characters to
-  prevent "file name too long" errors.
+- `A.TempDir` now truncates the sanitized task name to prevent
+  "file name too long" errors.
 
 ## [3.0.1](https://github.com/goyek/goyek/releases/tag/v3.0.1) - 2025-12-09
 

--- a/a.go
+++ b/a.go
@@ -13,6 +13,8 @@ import (
 	"unicode/utf8"
 )
 
+const maxTempDirTaskNameLen = 64
+
 // A is a type passed to [Task.Action] functions to manage task state
 // and support formatted task logs.
 //
@@ -287,8 +289,8 @@ func (a *A) TempDir() string {
 		return -1
 	}
 	name := strings.Map(mapper, a.Name())
-	if len(name) > 64 {
-		name = name[:64]
+	if len(name) > maxTempDirTaskNameLen {
+		name = name[:maxTempDirTaskNameLen]
 	}
 
 	dir, err := os.MkdirTemp("", "goyek-"+name+"-*")

--- a/a.go
+++ b/a.go
@@ -287,6 +287,9 @@ func (a *A) TempDir() string {
 		return -1
 	}
 	name := strings.Map(mapper, a.Name())
+	if len(name) > 64 {
+		name = name[:64]
+	}
 
 	dir, err := os.MkdirTemp("", "goyek-"+name+"-*")
 	if err != nil {

--- a/a_test.go
+++ b/a_test.go
@@ -392,6 +392,20 @@ func TestA_TempDir(t *testing.T) {
 	assertTrue(t, os.IsNotExist(err), "should remove the dir after the action")
 }
 
+func TestA_TempDir_long_name(t *testing.T) {
+	var dir string
+	res := goyek.NewRunner(func(a *goyek.A) {
+		dir = a.TempDir()
+
+		_, err := os.Lstat(dir)
+		assertEqual(t, err, nil, "the dir should exist")
+	})(goyek.Input{TaskName: strings.Repeat("a", 300)})
+
+	assertEqual(t, res.Status, goyek.StatusPassed, "should return proper status")
+	_, err := os.Lstat(dir)
+	assertTrue(t, os.IsNotExist(err), "should remove the dir after the action")
+}
+
 func TestA_Chdir(t *testing.T) {
 	oldDir, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
This change hardens the `A.TempDir()` function against extremely long task names by truncating the sanitized name used as a prefix for temporary directory creation. This prevents potential failures on filesystems with filename length limits.

---
*PR created automatically by Jules for task [14400754727358428302](https://jules.google.com/task/14400754727358428302) started by @pellared*