### PR TITLE
Fix data races in output buffering middlewares

### DIFF
--- a/flow.go
+++ b/flow.go
@@ -355,7 +355,7 @@ func (f *Flow) Execute(ctx context.Context, tasks []string, opts ...Option) erro
 		runner = middleware(runner)
 	}
 
-	out := synchronizeWriter(f.Output())
+	out := Sync(f.Output())
 
 	in := ExecuteInput{
 		Context:   ctx,

--- a/middleware/bufferparallel.go
+++ b/middleware/bufferparallel.go
@@ -17,7 +17,7 @@ func BufferParallel(next goyek.Runner) goyek.Runner {
 
 		orginalOut := in.Output
 		streamWriter := &strings.Builder{}
-		in.Output = streamWriter
+		in.Output = goyek.Sync(streamWriter)
 
 		result := next(in)
 		io.Copy(orginalOut, strings.NewReader(streamWriter.String())) //nolint:errcheck // not checking errors when writing to output

--- a/middleware/race_test.go
+++ b/middleware/race_test.go
@@ -1,0 +1,55 @@
+package middleware_test
+
+import (
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/goyek/goyek/v3"
+	"github.com/goyek/goyek/v3/middleware"
+)
+
+func TestBufferParallel_Race(t *testing.T) {
+	runner := middleware.BufferParallel(func(in goyek.Input) goyek.Result {
+		var wg sync.WaitGroup
+		for i := 0; i < 10; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for j := 0; j < 100; j++ {
+					io.WriteString(in.Output, "a")
+				}
+			}()
+		}
+		wg.Wait()
+		return goyek.Result{Status: goyek.StatusPassed}
+	})
+
+	in := goyek.Input{
+		Parallel: true,
+		Output:   io.Discard,
+	}
+	runner(in)
+}
+
+func TestSilentNonFailed_Race(t *testing.T) {
+	runner := middleware.SilentNonFailed(func(in goyek.Input) goyek.Result {
+		var wg sync.WaitGroup
+		for i := 0; i < 10; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for j := 0; j < 100; j++ {
+					io.WriteString(in.Output, "a")
+				}
+			}()
+		}
+		wg.Wait()
+		return goyek.Result{Status: goyek.StatusFailed}
+	})
+
+	in := goyek.Input{
+		Output: io.Discard,
+	}
+	runner(in)
+}

--- a/middleware/race_test.go
+++ b/middleware/race_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/goyek/goyek/v3/middleware"
 )
 
-func TestBufferParallel_Race(t *testing.T) {
+func TestBufferParallel_Race(_ *testing.T) {
 	runner := middleware.BufferParallel(func(in goyek.Input) goyek.Result {
 		var wg sync.WaitGroup
 		for i := 0; i < 10; i++ {
@@ -17,7 +17,7 @@ func TestBufferParallel_Race(t *testing.T) {
 			go func() {
 				defer wg.Done()
 				for j := 0; j < 100; j++ {
-					io.WriteString(in.Output, "a")
+					io.WriteString(in.Output, "a") //nolint:errcheck // not checking errors when writing to output
 				}
 			}()
 		}
@@ -32,7 +32,7 @@ func TestBufferParallel_Race(t *testing.T) {
 	runner(in)
 }
 
-func TestSilentNonFailed_Race(t *testing.T) {
+func TestSilentNonFailed_Race(_ *testing.T) {
 	runner := middleware.SilentNonFailed(func(in goyek.Input) goyek.Result {
 		var wg sync.WaitGroup
 		for i := 0; i < 10; i++ {
@@ -40,7 +40,7 @@ func TestSilentNonFailed_Race(t *testing.T) {
 			go func() {
 				defer wg.Done()
 				for j := 0; j < 100; j++ {
-					io.WriteString(in.Output, "a")
+					io.WriteString(in.Output, "a") //nolint:errcheck // not checking errors when writing to output
 				}
 			}()
 		}

--- a/middleware/verbose.go
+++ b/middleware/verbose.go
@@ -14,7 +14,7 @@ func SilentNonFailed(next goyek.Runner) goyek.Runner {
 	return func(in goyek.Input) goyek.Result {
 		orginalOut := in.Output
 		streamWriter := &strings.Builder{}
-		in.Output = streamWriter
+		in.Output = goyek.Sync(streamWriter)
 
 		result := next(in)
 

--- a/runner.go
+++ b/runner.go
@@ -68,7 +68,7 @@ func (r taskRunner) run(in Input) Result {
 	}
 
 	out := in.Output
-	out = synchronizeWriter(out)
+	out = Sync(out)
 
 	logger := in.Logger
 	if logger == nil {
@@ -108,7 +108,7 @@ func (r taskRunner) run(in Input) Result {
 
 func synchronizeRunner(next Runner) Runner {
 	return func(in Input) Result {
-		in.Output = synchronizeWriter(in.Output)
+		in.Output = Sync(in.Output)
 		return next(in)
 	}
 }

--- a/syncwriter.go
+++ b/syncwriter.go
@@ -5,23 +5,38 @@ import (
 	"sync"
 )
 
-type syncWriter struct {
-	io.Writer
-	mtx sync.Mutex
+// SyncWriter is a thread-safe [io.Writer] and [io.StringWriter] wrapper.
+type SyncWriter struct {
+	Writer io.Writer
+	mu     sync.Mutex
 }
 
-func (w *syncWriter) Write(p []byte) (int, error) {
-	defer func() { w.mtx.Unlock() }()
-	w.mtx.Lock()
+// Write implements [io.Writer].
+func (w *SyncWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	return w.Writer.Write(p)
 }
 
-func synchronizeWriter(w io.Writer) io.Writer {
-	if w == nil {
-		return io.Discard
+// WriteString implements [io.StringWriter].
+func (w *SyncWriter) WriteString(s string) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if sw, ok := w.Writer.(io.StringWriter); ok {
+		return sw.WriteString(s)
 	}
-	if syncW, ok := w.(*syncWriter); ok {
+	return io.WriteString(w.Writer, s)
+}
+
+// Sync returns a [SyncWriter] that wraps w.
+// It returns w if it is already a [*SyncWriter].
+// If w is nil, it returns a [*SyncWriter] wrapping [io.Discard].
+func Sync(w io.Writer) *SyncWriter {
+	if w == nil {
+		return &SyncWriter{Writer: io.Discard}
+	}
+	if syncW, ok := w.(*SyncWriter); ok {
 		return syncW
 	}
-	return &syncWriter{Writer: w}
+	return &SyncWriter{Writer: w}
 }


### PR DESCRIPTION
Identified and fixed a security risk (CWE-362: Data Race) in the `BufferParallel` and `SilentNonFailed` middlewares. These middlewares were using `strings.Builder` to buffer task output without synchronization, leading to data races if a task logged from multiple goroutines.

Changes:
- Modified `syncwriter.go` to export `SyncWriter` and the `Sync` constructor.
- Implemented `WriteString` for `SyncWriter` to satisfy `io.StringWriter`.
- Updated internal usages in `runner.go` and `flow.go` to use the exported `Sync` function.
- Fixed `middleware/bufferparallel.go` and `middleware/verbose.go` by wrapping their internal `strings.Builder` with `goyek.Sync`.
- Added `middleware/race_test.go` with end-to-end tests that reproduce the race and verify the fix.

All tests passed with the `-race` flag.

---
*PR created automatically by Jules for task [3692570419920202356](https://jules.google.com/task/3692570419920202356) started by @pellared*