### PR TITLE
Fix data race in BufferParallel middleware and export SyncWriter

### DIFF
--- a/a_test.go
+++ b/a_test.go
@@ -2,6 +2,7 @@ package goyek_test
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -635,4 +636,82 @@ func TestA_Chdir_error(t *testing.T) {
 	})(goyek.Input{})
 
 	assertEqual(t, got.Status, goyek.StatusFailed, "should return proper status")
+}
+
+func TestA_TempDir_error(t *testing.T) {
+	got := goyek.NewRunner(func(a *goyek.A) {
+		a.Setenv("TMPDIR", "/not-exists")
+		a.TempDir()
+	})(goyek.Input{})
+
+	assertEqual(t, got.Status, goyek.StatusFailed, "should return proper status")
+}
+
+func TestFailError_Error(t *testing.T) {
+	err := &goyek.FailError{Task: "my-task"}
+	assertEqual(t, err.Error(), "task failed: my-task", "Error()")
+}
+
+func TestA_Logger_fallbacks(t *testing.T) {
+	out := &strings.Builder{}
+	logger := &minimalLogger{}
+	res := goyek.NewRunner(func(a *goyek.A) {
+		a.Error("err")
+		a.Errorf("errf")
+		a.Log("fatal")
+		a.FailNow()
+	})(goyek.Input{Output: out, Logger: logger})
+
+	assertEqual(t, res.Status, goyek.StatusFailed, "should fail")
+	assertContains(t, out, "err", "Error fallback")
+	assertContains(t, out, "errf", "Errorf fallback")
+	assertContains(t, out, "fatal", "Fatal fallback")
+
+	out.Reset()
+	res = goyek.NewRunner(func(a *goyek.A) {
+		a.Fatal("fatal")
+	})(goyek.Input{Output: out, Logger: logger})
+	assertEqual(t, res.Status, goyek.StatusFailed, "should fail")
+	assertContains(t, out, "fatal", "Fatal fallback")
+
+	out.Reset()
+	res = goyek.NewRunner(func(a *goyek.A) {
+		a.Fatalf("fatalf")
+	})(goyek.Input{Output: out, Logger: logger})
+	assertEqual(t, res.Status, goyek.StatusFailed, "should fail")
+	assertContains(t, out, "fatalf", "Fatalf fallback")
+}
+
+type minimalLogger struct{}
+
+func (l *minimalLogger) Log(w io.Writer, args ...interface{}) {
+	fmt.Fprintln(w, args...)
+}
+
+func (l *minimalLogger) Logf(w io.Writer, format string, args ...interface{}) {
+	fmt.Fprintf(w, format+"\n", args...)
+}
+
+func TestA_TempDir_non_ascii_number(t *testing.T) {
+	res := goyek.NewRunner(func(a *goyek.A) {
+		a.TempDir()
+	})(goyek.Input{TaskName: "１"}) // Fullwidth digit one
+	assertEqual(t, res.Status, goyek.StatusPassed, "should pass")
+}
+
+func TestA_Skip_fallbacks(t *testing.T) {
+	out := &strings.Builder{}
+	logger := &minimalLogger{}
+	res := goyek.NewRunner(func(a *goyek.A) {
+		a.Skip("skip")
+	})(goyek.Input{Output: out, Logger: logger})
+	assertEqual(t, res.Status, goyek.StatusSkipped, "should skip")
+	assertContains(t, out, "skip", "Skip fallback")
+
+	out.Reset()
+	res = goyek.NewRunner(func(a *goyek.A) {
+		a.Skipf("skipf")
+	})(goyek.Input{Output: out, Logger: logger})
+	assertEqual(t, res.Status, goyek.StatusSkipped, "should skip")
+	assertContains(t, out, "skipf", "Skipf fallback")
 }

--- a/flow.go
+++ b/flow.go
@@ -355,7 +355,7 @@ func (f *Flow) Execute(ctx context.Context, tasks []string, opts ...Option) erro
 		runner = middleware(runner)
 	}
 
-	out := synchronizeWriter(f.Output())
+	out := Sync(f.Output())
 
 	in := ExecuteInput{
 		Context:   ctx,

--- a/middleware/bufferparallel.go
+++ b/middleware/bufferparallel.go
@@ -17,7 +17,7 @@ func BufferParallel(next goyek.Runner) goyek.Runner {
 
 		orginalOut := in.Output
 		streamWriter := &strings.Builder{}
-		in.Output = streamWriter
+		in.Output = goyek.Sync(streamWriter)
 
 		result := next(in)
 		io.Copy(orginalOut, strings.NewReader(streamWriter.String())) //nolint:errcheck // not checking errors when writing to output

--- a/middleware/bufferparallel_test.go
+++ b/middleware/bufferparallel_test.go
@@ -47,6 +47,27 @@ func TestBufferParallel(t *testing.T) {
 	}
 }
 
+func TestBufferParallel_NonParallel(t *testing.T) {
+	out := &strings.Builder{}
+	flow := &goyek.Flow{}
+	flow.SetOutput(out)
+	flow.Use(middleware.BufferParallel)
+
+	flow.Define(goyek.Task{
+		Name:     "task",
+		Parallel: false,
+		Action: func(a *goyek.A) {
+			a.Log("Hello")
+		},
+	})
+
+	_ = flow.Execute(context.Background(), []string{"task"})
+
+	if !strings.Contains(out.String(), "Hello") {
+		t.Errorf("expected \"Hello\", got %q", out.String())
+	}
+}
+
 func TestBufferParallel_concurrent_printing(t *testing.T) {
 	out := &strings.Builder{}
 	flow := &goyek.Flow{}

--- a/runner.go
+++ b/runner.go
@@ -68,7 +68,7 @@ func (r taskRunner) run(in Input) Result {
 	}
 
 	out := in.Output
-	out = synchronizeWriter(out)
+	out = Sync(out)
 
 	logger := in.Logger
 	if logger == nil {
@@ -108,7 +108,7 @@ func (r taskRunner) run(in Input) Result {
 
 func synchronizeRunner(next Runner) Runner {
 	return func(in Input) Result {
-		in.Output = synchronizeWriter(in.Output)
+		in.Output = Sync(in.Output)
 		return next(in)
 	}
 }

--- a/syncwriter.go
+++ b/syncwriter.go
@@ -5,23 +5,40 @@ import (
 	"sync"
 )
 
-type syncWriter struct {
-	io.Writer
-	mtx sync.Mutex
+// SyncWriter is a thread-safe writer.
+// It also implements [io.StringWriter].
+type SyncWriter struct {
+	// Writer is the underlying writer.
+	Writer io.Writer
+	mu     sync.Mutex
 }
 
-func (w *syncWriter) Write(p []byte) (int, error) {
-	defer func() { w.mtx.Unlock() }()
-	w.mtx.Lock()
+// Write implements [io.Writer].
+func (w *SyncWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	return w.Writer.Write(p)
 }
 
-func synchronizeWriter(w io.Writer) io.Writer {
-	if w == nil {
-		return io.Discard
+// WriteString implements [io.StringWriter].
+func (w *SyncWriter) WriteString(s string) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if sw, ok := w.Writer.(io.StringWriter); ok {
+		return sw.WriteString(s)
 	}
-	if syncW, ok := w.(*syncWriter); ok {
+	return w.Writer.Write([]byte(s))
+}
+
+// Sync returns a thread-safe [io.Writer] and [io.StringWriter].
+// If w is already a [*SyncWriter] it is returned as is.
+// If w is nil, [io.Discard] is used.
+func Sync(w io.Writer) *SyncWriter {
+	if w == nil {
+		w = io.Discard
+	}
+	if syncW, ok := w.(*SyncWriter); ok {
 		return syncW
 	}
-	return &syncWriter{Writer: w}
+	return &SyncWriter{Writer: w}
 }

--- a/syncwriter_test.go
+++ b/syncwriter_test.go
@@ -1,0 +1,98 @@
+package goyek_test
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/goyek/goyek/v3"
+)
+
+func TestSyncWriter_Write_race(t *testing.T) {
+	sb := &strings.Builder{}
+	sw := goyek.Sync(sb)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			fmt.Fprintf(sw, "log from goroutine %d\n", i)
+		}(i)
+	}
+	wg.Wait()
+
+	got := sb.String()
+	for i := 0; i < 100; i++ {
+		msg := fmt.Sprintf("log from goroutine %d\n", i)
+		if !strings.Contains(got, msg) {
+			t.Errorf("missing log message: %q", msg)
+		}
+	}
+}
+
+func TestSyncWriter_WriteString_race(t *testing.T) {
+	sb := &strings.Builder{}
+	sw := goyek.Sync(sb)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			sw.WriteString(fmt.Sprintf("log from goroutine %d\n", i)) //nolint:errcheck // not checking errors when writing to output
+		}(i)
+	}
+	wg.Wait()
+
+	got := sb.String()
+	for i := 0; i < 100; i++ {
+		msg := fmt.Sprintf("log from goroutine %d\n", i)
+		if !strings.Contains(got, msg) {
+			t.Errorf("missing log message: %q", msg)
+		}
+	}
+}
+
+func TestSyncWriter_WriteString_fallback(t *testing.T) {
+	// A writer that doesn't implement io.StringWriter
+	mw := &mockWriter{}
+	sw := goyek.Sync(mw)
+
+	n, err := sw.WriteString("hello")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 5 {
+		t.Errorf("expected 5 bytes written, got %d", n)
+	}
+	if mw.sb.String() != "hello" {
+		t.Errorf("expected \"hello\", got %q", mw.sb.String())
+	}
+}
+
+type mockWriter struct {
+	sb strings.Builder
+}
+
+func (m *mockWriter) Write(p []byte) (int, error) {
+	return m.sb.Write(p)
+}
+
+func TestSync_Reuse(t *testing.T) {
+	sw1 := goyek.Sync(&strings.Builder{})
+	sw2 := goyek.Sync(sw1)
+
+	if sw1 != sw2 {
+		t.Error("Sync should return the same SyncWriter if already a SyncWriter")
+	}
+}
+
+func TestSync_Nil(t *testing.T) {
+	sw := goyek.Sync(nil)
+	if sw.Writer != io.Discard {
+		t.Error("Sync(nil) should use io.Discard")
+	}
+}

--- a/syncwriter_test.go
+++ b/syncwriter_test.go
@@ -1,6 +1,7 @@
 package goyek_test
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -42,7 +43,7 @@ func TestSyncWriter_WriteString_race(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			sw.WriteString(fmt.Sprintf("log from goroutine %d\n", i)) //nolint:errcheck // not checking errors when writing to output
+			fmt.Fprintf(sw, "log from goroutine %d\n", i) //nolint:errcheck // not checking errors when writing to output
 		}(i)
 	}
 	wg.Wait()
@@ -86,7 +87,7 @@ func (m *mockWriter) Write(p []byte) (int, error) {
 }
 
 func TestSyncWriter_Write_Error(t *testing.T) {
-	mw := &mockWriter{err: fmt.Errorf("error")}
+	mw := &mockWriter{err: errors.New("error")}
 	sw := goyek.Sync(mw)
 
 	_, err := sw.Write([]byte("hello"))
@@ -96,7 +97,7 @@ func TestSyncWriter_Write_Error(t *testing.T) {
 }
 
 func TestSyncWriter_WriteString_Error(t *testing.T) {
-	mw := &mockWriter{err: fmt.Errorf("error")}
+	mw := &mockWriter{err: errors.New("error")}
 	sw := goyek.Sync(mw)
 
 	_, err := sw.WriteString("hello")
@@ -106,7 +107,7 @@ func TestSyncWriter_WriteString_Error(t *testing.T) {
 }
 
 func TestSyncWriter_WriteString_StringWriter_Error(t *testing.T) {
-	mw := &mockStringWriter{err: fmt.Errorf("error")}
+	mw := &mockStringWriter{err: errors.New("error")}
 	sw := goyek.Sync(mw)
 
 	_, err := sw.WriteString("hello")
@@ -119,11 +120,11 @@ type mockStringWriter struct {
 	err error
 }
 
-func (m *mockStringWriter) Write(p []byte) (int, error) {
+func (m *mockStringWriter) Write(_ []byte) (int, error) {
 	return 0, nil
 }
 
-func (m *mockStringWriter) WriteString(s string) (int, error) {
+func (m *mockStringWriter) WriteString(_ string) (int, error) {
 	return 0, m.err
 }
 

--- a/syncwriter_test.go
+++ b/syncwriter_test.go
@@ -74,11 +74,57 @@ func TestSyncWriter_WriteString_fallback(t *testing.T) {
 }
 
 type mockWriter struct {
-	sb strings.Builder
+	sb  strings.Builder
+	err error
 }
 
 func (m *mockWriter) Write(p []byte) (int, error) {
+	if m.err != nil {
+		return 0, m.err
+	}
 	return m.sb.Write(p)
+}
+
+func TestSyncWriter_Write_Error(t *testing.T) {
+	mw := &mockWriter{err: fmt.Errorf("error")}
+	sw := goyek.Sync(mw)
+
+	_, err := sw.Write([]byte("hello"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestSyncWriter_WriteString_Error(t *testing.T) {
+	mw := &mockWriter{err: fmt.Errorf("error")}
+	sw := goyek.Sync(mw)
+
+	_, err := sw.WriteString("hello")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestSyncWriter_WriteString_StringWriter_Error(t *testing.T) {
+	mw := &mockStringWriter{err: fmt.Errorf("error")}
+	sw := goyek.Sync(mw)
+
+	_, err := sw.WriteString("hello")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+type mockStringWriter struct {
+	err error
+}
+
+func (m *mockStringWriter) Write(p []byte) (int, error) {
+	return 0, nil
+}
+
+func (m *mockStringWriter) WriteString(s string) (int, error) {
+	return 0, m.err
 }
 
 func TestSync_Reuse(t *testing.T) {


### PR DESCRIPTION
Identified and fixed a potential data race in the `BufferParallel` middleware by ensuring its internal output buffer is thread-safe. This was achieved by exporting the internal synchronization logic as `SyncWriter` and `Sync`, and implementing `io.StringWriter` for better performance. All internal uses of output synchronization were updated to use the new public API, and new tests were added to verify thread-safety and correctness.

---
*PR created automatically by Jules for task [4080266208887079118](https://jules.google.com/task/4080266208887079118) started by @pellared*