### PR TITLE
Fix UTF-8 safe truncation in A.TempDir

### DIFF
--- a/a.go
+++ b/a.go
@@ -291,6 +291,9 @@ func (a *A) TempDir() string {
 	name := strings.Map(mapper, a.Name())
 	if len(name) > maxTempDirTaskNameLen {
 		name = name[:maxTempDirTaskNameLen]
+		for len(name) > 0 && !utf8.ValidString(name) {
+			name = name[:len(name)-1]
+		}
 	}
 
 	dir, err := os.MkdirTemp("", "goyek-"+name+"-*")

--- a/a.go
+++ b/a.go
@@ -269,6 +269,9 @@ func (a *A) Setenv(key, value string) {
 // if the directory creation fails, TempDir terminates the action by calling Fatal.
 func (a *A) TempDir() string {
 	a.Helper()
+	// Drop unusual characters (such as path separators or
+	// characters interacting with globs) from the directory name to
+	// avoid surprising os.MkdirTemp behavior.
 	name := strings.Map(tempDirMapper, a.Name())
 	if len(name) > maxTempDirTaskNameLen {
 		name = truncateUTF8(name[:maxTempDirTaskNameLen])
@@ -349,9 +352,6 @@ func (a *A) run(action func(a *A)) (finished bool, panicVal interface{}, panicSt
 	return finished, panicVal, panicStack
 }
 
-// Drop unusual characters (such as path separators or
-// characters interacting with globs) from the directory name to
-// avoid surprising os.MkdirTemp behavior.
 func tempDirMapper(r rune) rune {
 	if r < utf8.RuneSelf {
 		const allowed = "!#$%&()+,-.=@^_{}~ "

--- a/a.go
+++ b/a.go
@@ -269,31 +269,9 @@ func (a *A) Setenv(key, value string) {
 // if the directory creation fails, TempDir terminates the action by calling Fatal.
 func (a *A) TempDir() string {
 	a.Helper()
-	// Drop unusual characters (such as path separators or
-	// characters interacting with globs) from the directory name to
-	// avoid surprising os.MkdirTemp behavior.
-	mapper := func(r rune) rune {
-		if r < utf8.RuneSelf {
-			const allowed = "!#$%&()+,-.=@^_{}~ "
-			if '0' <= r && r <= '9' ||
-				'a' <= r && r <= 'z' ||
-				'A' <= r && r <= 'Z' {
-				return r
-			}
-			if strings.ContainsRune(allowed, r) {
-				return r
-			}
-		} else if unicode.IsLetter(r) || unicode.IsNumber(r) {
-			return r
-		}
-		return -1
-	}
-	name := strings.Map(mapper, a.Name())
+	name := strings.Map(tempDirMapper, a.Name())
 	if len(name) > maxTempDirTaskNameLen {
-		name = name[:maxTempDirTaskNameLen]
-		for len(name) > 0 && !utf8.ValidString(name) {
-			name = name[:len(name)-1]
-		}
+		name = truncateUTF8(name[:maxTempDirTaskNameLen])
 	}
 
 	dir, err := os.MkdirTemp("", "goyek-"+name+"-*")
@@ -369,6 +347,33 @@ func (a *A) run(action func(a *A)) (finished bool, panicVal interface{}, panicSt
 	}()
 	<-ch
 	return finished, panicVal, panicStack
+}
+
+// Drop unusual characters (such as path separators or
+// characters interacting with globs) from the directory name to
+// avoid surprising os.MkdirTemp behavior.
+func tempDirMapper(r rune) rune {
+	if r < utf8.RuneSelf {
+		const allowed = "!#$%&()+,-.=@^_{}~ "
+		if '0' <= r && r <= '9' ||
+			'a' <= r && r <= 'z' ||
+			'A' <= r && r <= 'Z' {
+			return r
+		}
+		if strings.ContainsRune(allowed, r) {
+			return r
+		}
+	} else if unicode.IsLetter(r) || unicode.IsNumber(r) {
+		return r
+	}
+	return -1
+}
+
+func truncateUTF8(s string) string {
+	for len(s) > 0 && !utf8.ValidString(s) {
+		s = s[:len(s)-1]
+	}
+	return s
 }
 
 func (a *A) runCleanups(finished *bool, panicVal *interface{}, panicStack *[]byte) {

--- a/a_test.go
+++ b/a_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"unicode/utf8"
 	"testing"
 	"time"
 
@@ -390,6 +391,39 @@ func TestA_TempDir(t *testing.T) {
 	assertEqual(t, res.Status, goyek.StatusPassed, "should return proper status")
 	_, err := os.Lstat(dir)
 	assertTrue(t, os.IsNotExist(err), "should remove the dir after the action")
+}
+
+func TestA_TempDir_UTF8SafeTruncation(t *testing.T) {
+	testCases := []struct {
+		name     string
+		taskName string
+	}{
+		{
+			name:     "2-byte truncation",
+			taskName: strings.Repeat("a", 63) + "ą",
+		},
+		{
+			name:     "4-byte truncation",
+			taskName: strings.Repeat("a", 63) + "💩",
+		},
+		{
+			name:     "4-byte truncation middle",
+			taskName: strings.Repeat("a", 61) + "💩",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var dir string
+			res := goyek.NewRunner(func(a *goyek.A) {
+				dir = a.TempDir()
+			})(goyek.Input{TaskName: tc.taskName})
+
+			assertEqual(t, res.Status, goyek.StatusPassed, "should return proper status")
+			if !utf8.ValidString(dir) {
+				t.Errorf("TempDir path is not valid UTF-8: %s", dir)
+			}
+		})
+	}
 }
 
 func TestA_TempDir_long_name(t *testing.T) {

--- a/a_test.go
+++ b/a_test.go
@@ -7,9 +7,9 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"unicode/utf8"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/goyek/goyek/v3"
 )

--- a/a_test.go
+++ b/a_test.go
@@ -419,8 +419,9 @@ func TestA_TempDir_UTF8SafeTruncation(t *testing.T) {
 			})(goyek.Input{TaskName: tc.taskName})
 
 			assertEqual(t, res.Status, goyek.StatusPassed, "should return proper status")
-			if !utf8.ValidString(dir) {
-				t.Errorf("TempDir path is not valid UTF-8: %s", dir)
+			base := filepath.Base(dir)
+			if !utf8.ValidString(base) {
+				t.Errorf("TempDir name is not valid UTF-8: %q", base)
 			}
 		})
 	}


### PR DESCRIPTION
This PR fixes a small security/robustness issue in `A.TempDir` where task name truncation could lead to invalid UTF-8 strings. 

While `A.TempDir` sanitizes the task name, it allows non-ASCII letters and numbers (e.g., 'ą'). If the resulting name exceeds 64 bytes, it was previously truncated using a simple byte slice, which could break a multi-byte UTF-8 character.

The fix ensures that if truncation is necessary, trailing bytes are removed until the string is valid UTF-8.

Additional test cases were added to `a_test.go` to verify this behavior for both 2-byte and 4-byte UTF-8 characters.

---
*PR created automatically by Jules for task [7111852482793708174](https://jules.google.com/task/7111852482793708174) started by @pellared*