### PR TITLE
Fix potential panic in Exec helper on empty command

### DIFF
--- a/build/exec.go
+++ b/build/exec.go
@@ -19,6 +19,10 @@ func Exec(a *goyek.A, workDir, cmdLine string) bool {
 		a.Errorf("parse command line: %v", err)
 		return false
 	}
+	if len(args) == 0 {
+		a.Error("empty command line")
+		return false
+	}
 	cmd := exec.CommandContext(a.Context(), args[0], args[1:]...) //nolint:gosec // it is a convenient function to run programs
 	cmd.Dir = workDir
 	cmd.Stdin = os.Stdin

--- a/build/exec_test.go
+++ b/build/exec_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/goyek/goyek/v3"
+)
+
+func TestExec_EmptyCommand(t *testing.T) {
+	runner := goyek.NewRunner(func(a *goyek.A) {
+		if Exec(a, ".", "") {
+			a.Error("Exec should return false for empty command")
+		}
+	})
+	result := runner(goyek.Input{TaskName: "test"})
+	if result.Status != goyek.StatusFailed {
+		t.Errorf("Expected status Failed, got %v", result.Status)
+	}
+}
+
+func TestExec_WhitespaceCommand(t *testing.T) {
+	runner := goyek.NewRunner(func(a *goyek.A) {
+		if Exec(a, ".", "   ") {
+			a.Error("Exec should return false for whitespace-only command")
+		}
+	})
+	result := runner(goyek.Input{TaskName: "test"})
+	if result.Status != goyek.StatusFailed {
+		t.Errorf("Expected status Failed, got %v", result.Status)
+	}
+}
+
+func TestExec_ValidCommand(t *testing.T) {
+	runner := goyek.NewRunner(func(a *goyek.A) {
+		if !Exec(a, ".", "go version") {
+			a.Error("Exec should return true for valid command")
+		}
+	})
+	result := runner(goyek.Input{TaskName: "test"})
+	if result.Status != goyek.StatusPassed {
+		t.Errorf("Expected status Passed, got %v", result.Status)
+	}
+}


### PR DESCRIPTION
This PR fixes a potential runtime panic in the `Exec` helper function used in the build pipeline. When an empty or whitespace-only string was passed to `Exec`, `shellwords.Parse` would return an empty slice, and the subsequent access to `args[0]` would cause a panic.

Changes:
- Added a check in `build/exec.go` to ensure `args` is not empty.
- Created `build/exec_test.go` with regression tests for empty, whitespace-only, and valid commands.
- Verified that all tests pass.

---
*PR created automatically by Jules for task [1670438219473979012](https://jules.google.com/task/1670438219473979012) started by @pellared*