### PR TITLE
build: switch to safer command execution and remove shellwords dependency

### DIFF
--- a/build/diff.go
+++ b/build/diff.go
@@ -12,7 +12,7 @@ var diff = goyek.Define(goyek.Task{
 	Name:  "diff",
 	Usage: "git diff",
 	Action: func(a *goyek.A) {
-		ExecArgs(a, dirRoot, "git", "diff", "--exit-code")
+		Exec(a, dirRoot, "git", "diff", "--exit-code")
 
 		a.Log("Cmd: git status --porcelain")
 

--- a/build/diff.go
+++ b/build/diff.go
@@ -12,7 +12,7 @@ var diff = goyek.Define(goyek.Task{
 	Name:  "diff",
 	Usage: "git diff",
 	Action: func(a *goyek.A) {
-		Exec(a, dirRoot, "git diff --exit-code")
+		ExecArgs(a, dirRoot, "git", "diff", "--exit-code")
 
 		a.Log("Cmd: git status --porcelain")
 

--- a/build/exec.go
+++ b/build/exec.go
@@ -4,26 +4,8 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/mattn/go-shellwords"
-
 	"github.com/goyek/goyek/v3"
 )
-
-// Exec runs the command in given directory.
-// It calls a.Error[f] and returns false in case of any problems.
-func Exec(a *goyek.A, workDir, cmdLine string) bool {
-	a.Helper()
-	args, err := shellwords.Parse(cmdLine)
-	if err != nil {
-		a.Errorf("parse command line: %v", err)
-		return false
-	}
-	if len(args) == 0 {
-		a.Error("empty command line")
-		return false
-	}
-	return ExecArgs(a, workDir, args[0], args[1:]...)
-}
 
 // ExecArgs runs the command in given directory.
 // It calls a.Error[f] and returns false in case of any problems.

--- a/build/exec.go
+++ b/build/exec.go
@@ -7,9 +7,9 @@ import (
 	"github.com/goyek/goyek/v3"
 )
 
-// ExecArgs runs the command in given directory.
+// Exec runs the command in given directory.
 // It calls a.Error[f] and returns false in case of any problems.
-func ExecArgs(a *goyek.A, workDir, name string, args ...string) bool {
+func Exec(a *goyek.A, workDir, name string, args ...string) bool {
 	a.Helper()
 	a.Logf("Run %v in %s", append([]string{name}, args...), workDir)
 	cmd := exec.CommandContext(a.Context(), name, args...) //nolint:gosec // it is a convenient function to run programs

--- a/build/exec.go
+++ b/build/exec.go
@@ -13,7 +13,6 @@ import (
 // It calls a.Error[f] and returns false in case of any problems.
 func Exec(a *goyek.A, workDir, cmdLine string) bool {
 	a.Helper()
-	a.Logf("Run %q in %s", cmdLine, workDir)
 	args, err := shellwords.Parse(cmdLine)
 	if err != nil {
 		a.Errorf("parse command line: %v", err)
@@ -23,7 +22,15 @@ func Exec(a *goyek.A, workDir, cmdLine string) bool {
 		a.Error("empty command line")
 		return false
 	}
-	cmd := exec.CommandContext(a.Context(), args[0], args[1:]...) //nolint:gosec // it is a convenient function to run programs
+	return ExecArgs(a, workDir, args[0], args[1:]...)
+}
+
+// ExecArgs runs the command in given directory.
+// It calls a.Error[f] and returns false in case of any problems.
+func ExecArgs(a *goyek.A, workDir, name string, args ...string) bool {
+	a.Helper()
+	a.Logf("Run %v in %s", append([]string{name}, args...), workDir)
+	cmd := exec.CommandContext(a.Context(), name, args...) //nolint:gosec // it is a convenient function to run programs
 	cmd.Dir = workDir
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = a.Output()

--- a/build/exec_test.go
+++ b/build/exec_test.go
@@ -41,3 +41,27 @@ func TestExec_ValidCommand(t *testing.T) {
 		t.Errorf("Expected status Passed, got %v", result.Status)
 	}
 }
+
+func TestExecArgs_InvalidCommand(t *testing.T) {
+	runner := goyek.NewRunner(func(a *goyek.A) {
+		if ExecArgs(a, ".", "non-existing-command") {
+			a.Error("ExecArgs should return false for non-existing command")
+		}
+	})
+	result := runner(goyek.Input{TaskName: "test"})
+	if result.Status != goyek.StatusFailed {
+		t.Errorf("Expected status Failed, got %v", result.Status)
+	}
+}
+
+func TestExecArgs_ValidCommand(t *testing.T) {
+	runner := goyek.NewRunner(func(a *goyek.A) {
+		if !ExecArgs(a, ".", "go", "version") {
+			a.Error("ExecArgs should return true for valid command")
+		}
+	})
+	result := runner(goyek.Input{TaskName: "test"})
+	if result.Status != goyek.StatusPassed {
+		t.Errorf("Expected status Passed, got %v", result.Status)
+	}
+}

--- a/build/exec_test.go
+++ b/build/exec_test.go
@@ -6,42 +6,6 @@ import (
 	"github.com/goyek/goyek/v3"
 )
 
-func TestExec_EmptyCommand(t *testing.T) {
-	runner := goyek.NewRunner(func(a *goyek.A) {
-		if Exec(a, ".", "") {
-			a.Error("Exec should return false for empty command")
-		}
-	})
-	result := runner(goyek.Input{TaskName: "test"})
-	if result.Status != goyek.StatusFailed {
-		t.Errorf("Expected status Failed, got %v", result.Status)
-	}
-}
-
-func TestExec_WhitespaceCommand(t *testing.T) {
-	runner := goyek.NewRunner(func(a *goyek.A) {
-		if Exec(a, ".", "   ") {
-			a.Error("Exec should return false for whitespace-only command")
-		}
-	})
-	result := runner(goyek.Input{TaskName: "test"})
-	if result.Status != goyek.StatusFailed {
-		t.Errorf("Expected status Failed, got %v", result.Status)
-	}
-}
-
-func TestExec_ValidCommand(t *testing.T) {
-	runner := goyek.NewRunner(func(a *goyek.A) {
-		if !Exec(a, ".", "go version") {
-			a.Error("Exec should return true for valid command")
-		}
-	})
-	result := runner(goyek.Input{TaskName: "test"})
-	if result.Status != goyek.StatusPassed {
-		t.Errorf("Expected status Passed, got %v", result.Status)
-	}
-}
-
 func TestExecArgs_InvalidCommand(t *testing.T) {
 	runner := goyek.NewRunner(func(a *goyek.A) {
 		if ExecArgs(a, ".", "non-existing-command") {

--- a/build/exec_test.go
+++ b/build/exec_test.go
@@ -6,10 +6,10 @@ import (
 	"github.com/goyek/goyek/v3"
 )
 
-func TestExecArgs_InvalidCommand(t *testing.T) {
+func TestExec_InvalidCommand(t *testing.T) {
 	runner := goyek.NewRunner(func(a *goyek.A) {
-		if ExecArgs(a, ".", "non-existing-command") {
-			a.Error("ExecArgs should return false for non-existing command")
+		if Exec(a, ".", "non-existing-command") {
+			a.Error("Exec should return false for non-existing command")
 		}
 	})
 	result := runner(goyek.Input{TaskName: "test"})
@@ -18,10 +18,10 @@ func TestExecArgs_InvalidCommand(t *testing.T) {
 	}
 }
 
-func TestExecArgs_ValidCommand(t *testing.T) {
+func TestExec_ValidCommand(t *testing.T) {
 	runner := goyek.NewRunner(func(a *goyek.A) {
-		if !ExecArgs(a, ".", "go", "version") {
-			a.Error("ExecArgs should return true for valid command")
+		if !Exec(a, ".", "go", "version") {
+			a.Error("Exec should return true for valid command")
 		}
 	})
 	result := runner(goyek.Input{TaskName: "test"})

--- a/build/go.mod
+++ b/build/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/client9/misspell v0.3.4
 	github.com/golangci/golangci-lint/v2 v2.11.4
 	github.com/goyek/goyek/v3 v3.0.0-00010101000000-000000000000
-	github.com/mattn/go-shellwords v1.0.13
 )
 
 replace github.com/goyek/goyek/v3 => ../

--- a/build/go.sum
+++ b/build/go.sum
@@ -422,8 +422,6 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
-github.com/mattn/go-shellwords v1.0.13 h1:DC0OMEpGjm6LfNFU4ckYcvbQKyp2vE8atyFGXNtDcf4=
-github.com/mattn/go-shellwords v1.0.13/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mgechev/revive v1.15.0 h1:vJ0HzSBzfNyPbHKolgiFjHxLek9KUijhqh42yGoqZ8Q=

--- a/build/golint.go
+++ b/build/golint.go
@@ -6,10 +6,10 @@ var golint = goyek.Define(goyek.Task{
 	Name:  "golint",
 	Usage: "golangci-lint run --fix",
 	Action: func(a *goyek.A) {
-		if !ExecArgs(a, dirBuild, "go", "install", "github.com/golangci/golangci-lint/v2/cmd/golangci-lint") {
+		if !Exec(a, dirBuild, "go", "install", "github.com/golangci/golangci-lint/v2/cmd/golangci-lint") {
 			return
 		}
-		ExecArgs(a, dirRoot, "golangci-lint", "run", "--fix")
-		ExecArgs(a, dirBuild, "golangci-lint", "run", "--fix")
+		Exec(a, dirRoot, "golangci-lint", "run", "--fix")
+		Exec(a, dirBuild, "golangci-lint", "run", "--fix")
 	},
 })

--- a/build/golint.go
+++ b/build/golint.go
@@ -6,10 +6,10 @@ var golint = goyek.Define(goyek.Task{
 	Name:  "golint",
 	Usage: "golangci-lint run --fix",
 	Action: func(a *goyek.A) {
-		if !Exec(a, dirBuild, "go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint") {
+		if !ExecArgs(a, dirBuild, "go", "install", "github.com/golangci/golangci-lint/v2/cmd/golangci-lint") {
 			return
 		}
-		Exec(a, dirRoot, "golangci-lint run --fix")
-		Exec(a, dirBuild, "golangci-lint run --fix")
+		ExecArgs(a, dirRoot, "golangci-lint", "run", "--fix")
+		ExecArgs(a, dirBuild, "golangci-lint", "run", "--fix")
 	},
 })

--- a/build/mdlint.go
+++ b/build/mdlint.go
@@ -25,6 +25,6 @@ var mdlint = goyek.Define(goyek.Task{
 		dockerImage := "ghcr.io/igorshubovych/markdownlint-cli:v0.41.0"
 		args := []string{"run", "--rm", "-v", curDir + ":/workdir", dockerImage}
 		args = append(args, mdFiles...)
-		ExecArgs(a, dirRoot, "docker", args...)
+		Exec(a, dirRoot, "docker", args...)
 	},
 })

--- a/build/mdlint.go
+++ b/build/mdlint.go
@@ -3,7 +3,6 @@ package main
 import (
 	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/goyek/goyek/v3"
 )
@@ -24,6 +23,8 @@ var mdlint = goyek.Define(goyek.Task{
 			a.Skip("no .md files")
 		}
 		dockerImage := "ghcr.io/igorshubovych/markdownlint-cli:v0.41.0"
-		Exec(a, dirRoot, "docker run --rm -v '"+curDir+":/workdir' "+dockerImage+" "+strings.Join(mdFiles, " "))
+		args := []string{"run", "--rm", "-v", curDir + ":/workdir", dockerImage}
+		args = append(args, mdFiles...)
+		ExecArgs(a, dirRoot, "docker", args...)
 	},
 })

--- a/build/mod.go
+++ b/build/mod.go
@@ -6,7 +6,7 @@ var mod = goyek.Define(goyek.Task{
 	Name:  "mod",
 	Usage: "go mod tidy",
 	Action: func(a *goyek.A) {
-		ExecArgs(a, dirRoot, "go", "mod", "tidy")
-		ExecArgs(a, dirBuild, "go", "mod", "tidy")
+		Exec(a, dirRoot, "go", "mod", "tidy")
+		Exec(a, dirBuild, "go", "mod", "tidy")
 	},
 })

--- a/build/mod.go
+++ b/build/mod.go
@@ -6,7 +6,7 @@ var mod = goyek.Define(goyek.Task{
 	Name:  "mod",
 	Usage: "go mod tidy",
 	Action: func(a *goyek.A) {
-		Exec(a, dirRoot, "go mod tidy")
-		Exec(a, dirBuild, "go mod tidy")
+		ExecArgs(a, dirRoot, "go", "mod", "tidy")
+		ExecArgs(a, dirBuild, "go", "mod", "tidy")
 	},
 })

--- a/build/spell.go
+++ b/build/spell.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"strings"
-
 	"github.com/goyek/goyek/v3"
 )
 
@@ -17,6 +15,8 @@ var spell = goyek.Define(goyek.Task{
 		if len(mdFiles) == 0 {
 			a.Skip("no .md files")
 		}
-		Exec(a, dirRoot, "misspell -error -locale=US -w "+strings.Join(mdFiles, " "))
+		args := []string{"-error", "-locale=US", "-w"}
+		args = append(args, mdFiles...)
+		ExecArgs(a, dirRoot, "misspell", args...)
 	},
 })

--- a/build/spell.go
+++ b/build/spell.go
@@ -8,7 +8,7 @@ var spell = goyek.Define(goyek.Task{
 	Name:  "spell",
 	Usage: "misspell",
 	Action: func(a *goyek.A) {
-		if !ExecArgs(a, dirBuild, "go", "install", "github.com/client9/misspell/cmd/misspell") {
+		if !Exec(a, dirBuild, "go", "install", "github.com/client9/misspell/cmd/misspell") {
 			return
 		}
 		mdFiles := find(a, ".md")
@@ -17,6 +17,6 @@ var spell = goyek.Define(goyek.Task{
 		}
 		args := []string{"-error", "-locale=US", "-w"}
 		args = append(args, mdFiles...)
-		ExecArgs(a, dirRoot, "misspell", args...)
+		Exec(a, dirRoot, "misspell", args...)
 	},
 })

--- a/build/spell.go
+++ b/build/spell.go
@@ -8,7 +8,7 @@ var spell = goyek.Define(goyek.Task{
 	Name:  "spell",
 	Usage: "misspell",
 	Action: func(a *goyek.A) {
-		if !Exec(a, dirBuild, "go install github.com/client9/misspell/cmd/misspell") {
+		if !ExecArgs(a, dirBuild, "go", "install", "github.com/client9/misspell/cmd/misspell") {
 			return
 		}
 		mdFiles := find(a, ".md")

--- a/build/test.go
+++ b/build/test.go
@@ -6,13 +6,14 @@ var test = goyek.Define(goyek.Task{
 	Name:  "test",
 	Usage: "go test",
 	Action: func(a *goyek.A) {
-		verbose := ""
+		args := []string{"test"}
 		if *v {
-			verbose = "-v"
+			args = append(args, "-v")
 		}
-		if !Exec(a, dirRoot, "go test "+verbose+" -race -covermode=atomic -coverprofile=coverage.out -coverpkg=./... ./...") {
+		args = append(args, "-race", "-covermode=atomic", "-coverprofile=coverage.out", "-coverpkg=./...", "./...")
+		if !ExecArgs(a, dirRoot, "go", args...) {
 			return
 		}
-		Exec(a, dirRoot, "go tool cover -html=coverage.out -o coverage.html")
+		ExecArgs(a, dirRoot, "go", "tool", "cover", "-html=coverage.out", "-o", "coverage.html")
 	},
 })

--- a/build/test.go
+++ b/build/test.go
@@ -11,9 +11,9 @@ var test = goyek.Define(goyek.Task{
 			args = append(args, "-v")
 		}
 		args = append(args, "-race", "-covermode=atomic", "-coverprofile=coverage.out", "-coverpkg=./...", "./...")
-		if !ExecArgs(a, dirRoot, "go", args...) {
+		if !Exec(a, dirRoot, "go", args...) {
 			return
 		}
-		ExecArgs(a, dirRoot, "go", "tool", "cover", "-html=coverage.out", "-o", "coverage.html")
+		Exec(a, dirRoot, "go", "tool", "cover", "-html=coverage.out", "-o", "coverage.html")
 	},
 })


### PR DESCRIPTION
Enhance the security and robustness of the build pipeline by switching from string-based command execution to a safer argument-slice-based approach.