### PR TITLE
Add SIGTERM support for graceful shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 
 - Add safety checks to `A.Setenv` and `A.Chdir` to prevent their usage
   in parallel tasks.
+- `Flow.Main` now handles `SIGTERM` on Unix-like systems for graceful
+  shutdown.
 
 ### Fixed
 

--- a/build/tools.go
+++ b/build/tools.go
@@ -1,5 +1,4 @@
 //go:build tools
-// +build tools
 
 package main
 

--- a/build/tools.go
+++ b/build/tools.go
@@ -1,4 +1,5 @@
 //go:build tools
+// +build tools
 
 package main
 

--- a/flow.go
+++ b/flow.go
@@ -405,18 +405,20 @@ func (f *Flow) Main(args []string, opts ...Option) {
 	ctx, cancel := context.WithCancel(context.Background())
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, internal.TerminationSignals()...)
-	go func() {
-		<-c // first signal, cancel context
-		fmt.Fprintln(out, "first interrupt, graceful stop")
-		cancel()
-
-		<-c // second signal, hard exit
-		fmt.Fprintln(out, "second interrupt, exit")
-		os.Exit(exitCodeFail)
-	}()
+	go f.handleSignals(c, out, cancel, os.Exit)
 
 	exitCode := f.main(ctx, args, opts...)
 	os.Exit(exitCode)
+}
+
+func (f *Flow) handleSignals(c <-chan os.Signal, out io.Writer, cancel context.CancelFunc, exit func(int)) {
+	<-c // first signal, cancel context
+	fmt.Fprintln(out, "first interrupt, graceful stop")
+	cancel()
+
+	<-c // second signal, hard exit
+	fmt.Fprintln(out, "second interrupt, exit")
+	exit(exitCodeFail)
 }
 
 func (f *Flow) main(ctx context.Context, args []string, opts ...Option) int {

--- a/flow.go
+++ b/flow.go
@@ -404,7 +404,7 @@ func (f *Flow) Main(args []string, opts ...Option) {
 	// trap termination signals and call cancel on the context
 	ctx, cancel := context.WithCancel(context.Background())
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, internal.TerminationSignals...)
+	signal.Notify(c, internal.TerminationSignals()...)
 	go func() {
 		<-c // first signal, cancel context
 		fmt.Fprintln(out, "first interrupt, graceful stop")

--- a/flow.go
+++ b/flow.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 	"strings"
 	"text/tabwriter"
+
+	"github.com/goyek/goyek/v3/internal"
 )
 
 // Flow is the root type of the package.
@@ -399,10 +401,10 @@ func Main(args []string, opts ...Option) {
 func (f *Flow) Main(args []string, opts ...Option) {
 	out := f.Output()
 
-	// trap Ctrl+C and call cancel on the context
+	// trap termination signals and call cancel on the context
 	ctx, cancel := context.WithCancel(context.Background())
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
+	signal.Notify(c, internal.TerminationSignals...)
 	go func() {
 		<-c // first signal, cancel context
 		fmt.Fprintln(out, "first interrupt, graceful stop")

--- a/flow.go
+++ b/flow.go
@@ -34,6 +34,8 @@ type Flow struct {
 // The top-level functions such as Define, Main, and so on are wrappers for the methods of Flow.
 var DefaultFlow = &Flow{}
 
+var osExit = os.Exit
+
 // Tasks returns all tasks sorted in lexicographical order.
 func Tasks() []*DefinedTask {
 	return DefaultFlow.Tasks()
@@ -399,25 +401,37 @@ func Main(args []string, opts ...Option) {
 //
 // Calls [Usage] when invalid args are provided.
 func (f *Flow) Main(args []string, opts ...Option) {
+	f.mainWithExit(args, osExit, opts...)
+}
+
+func (f *Flow) mainWithExit(args []string, exit func(int), opts ...Option) {
 	out := f.Output()
 
 	// trap termination signals and call cancel on the context
 	ctx, cancel := context.WithCancel(context.Background())
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, internal.TerminationSignals()...)
-	go f.handleSignals(c, out, cancel, os.Exit)
+	go f.handleSignals(c, out, cancel, exit)
 
 	exitCode := f.main(ctx, args, opts...)
-	os.Exit(exitCode)
+	exit(exitCode)
 }
 
 func (f *Flow) handleSignals(c <-chan os.Signal, out io.Writer, cancel context.CancelFunc, exit func(int)) {
-	<-c // first signal, cancel context
-	fmt.Fprintln(out, "first interrupt, graceful stop")
+	sig := <-c // first signal, cancel context
+	msg := "first interrupt"
+	if sig != os.Interrupt {
+		msg = fmt.Sprintf("signal received: %v", sig)
+	}
+	fmt.Fprintf(out, "%s, graceful stop\n", msg)
 	cancel()
 
-	<-c // second signal, hard exit
-	fmt.Fprintln(out, "second interrupt, exit")
+	sig = <-c // second signal, hard exit
+	msg = "second interrupt"
+	if sig != os.Interrupt {
+		msg = fmt.Sprintf("signal received: %v", sig)
+	}
+	fmt.Fprintf(out, "%s, exit\n", msg)
 	exit(exitCodeFail)
 }
 

--- a/flow_main_unix_test.go
+++ b/flow_main_unix_test.go
@@ -28,7 +28,7 @@ func TestFlow_handleSignals(t *testing.T) {
 
 	go flow.handleSignals(c, out, cancel, exitFunc)
 
-	// First signal
+	// First signal (not Interrupt)
 	c <- syscall.SIGTERM
 
 	select {
@@ -48,6 +48,81 @@ func TestFlow_handleSignals(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("exit not called after second signal")
+	}
+}
+
+func TestFlow_handleSignals_interrupt(t *testing.T) {
+	flow := &Flow{}
+	out := &stringsBuilder{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c := make(chan os.Signal, 2)
+
+	exitCalled := make(chan int, 1)
+	exitFunc := func(code int) {
+		exitCalled <- code
+	}
+
+	go flow.handleSignals(c, out, cancel, exitFunc)
+
+	// First signal (Interrupt)
+	c <- os.Interrupt
+
+	select {
+	case <-ctx.Done():
+		// Success: context canceled
+	case <-time.After(time.Second):
+		t.Fatal("context not canceled after first signal")
+	}
+
+	// Second signal
+	c <- os.Interrupt
+
+	select {
+	case code := <-exitCalled:
+		if code != 1 {
+			t.Errorf("expected exit code 1, got %d", code)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("exit not called after second signal")
+	}
+}
+
+func TestFlow_Main_exported(t *testing.T) {
+	oldOsExit := osExit
+	defer func() { osExit = oldOsExit }()
+
+	exitCalled := make(chan int, 1)
+	osExit = func(code int) {
+		exitCalled <- code
+	}
+
+	flow := &Flow{}
+	flow.SetOutput(io.Discard)
+	flow.Define(Task{Name: "task"})
+
+	// Test (f *Flow).Main
+	flow.Main([]string{"task"})
+	if got := <-exitCalled; got != 0 {
+		t.Errorf("expected exit code 0, got %d", got)
+	}
+
+	// Test Main
+	flowBackup := DefaultFlow
+	DefaultFlow = flow
+	defer func() { DefaultFlow = flowBackup }()
+
+	Main([]string{"task"})
+	if got := <-exitCalled; got != 0 {
+		t.Errorf("expected exit code 0, got %d", got)
+	}
+
+	// Test Main with invalid args
+	Main([]string{"invalid"})
+	if got := <-exitCalled; got != 2 {
+		t.Errorf("expected exit code 2, got %d", got)
 	}
 }
 

--- a/flow_main_unix_test.go
+++ b/flow_main_unix_test.go
@@ -7,68 +7,47 @@ import (
 	"context"
 	"io"
 	"os"
-	"os/signal"
 	"syscall"
 	"testing"
 	"time"
-
-	"github.com/goyek/goyek/v3/internal"
 )
 
-func TestFlow_Main_SIGTERM(t *testing.T) {
+func TestFlow_handleSignals(t *testing.T) {
 	flow := &Flow{}
 	out := &stringsBuilder{}
-	flow.SetOutput(out)
-
-	taskStarted := make(chan struct{})
-	taskFinished := make(chan struct{})
-
-	flow.Define(Task{
-		Name: "test",
-		Action: func(a *A) {
-			close(taskStarted)
-			select {
-			case <-a.Context().Done():
-			case <-time.After(5 * time.Second):
-				// This should not happen if SIGTERM is handled correctly
-			}
-			close(taskFinished)
-		},
-	})
-
-	// We can't call flow.Main because it calls os.Exit.
-	// But we can simulate the signal handling logic.
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, internal.TerminationSignals()...)
-	defer signal.Stop(c)
+	c := make(chan os.Signal, 2)
 
-	go func() {
-		// Wait for task to start
-		<-taskStarted
-		// Send SIGTERM to ourselves
-		process, _ := os.FindProcess(os.Getpid())
-		_ = process.Signal(syscall.SIGTERM)
-	}()
+	exitCalled := make(chan int, 1)
+	exitFunc := func(code int) {
+		exitCalled <- code
+	}
 
-	go func() {
-		select {
-		case <-c:
-			cancel()
-		case <-taskFinished:
-		}
-	}()
+	go flow.handleSignals(c, out, cancel, exitFunc)
 
-	flow.main(ctx, []string{"test"})
+	// First signal
+	c <- syscall.SIGTERM
 
 	select {
-	case <-taskFinished:
-		// Success
+	case <-ctx.Done():
+		// Success: context canceled
 	case <-time.After(time.Second):
-		t.Error("task was not canceled by SIGTERM")
+		t.Fatal("context not canceled after first signal")
+	}
+
+	// Second signal
+	c <- syscall.SIGTERM
+
+	select {
+	case code := <-exitCalled:
+		if code != 1 {
+			t.Errorf("expected exit code 1, got %d", code)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("exit not called after second signal")
 	}
 }
 

--- a/flow_main_unix_test.go
+++ b/flow_main_unix_test.go
@@ -1,0 +1,81 @@
+//go:build !windows && !plan9
+// +build !windows,!plan9
+
+package goyek
+
+import (
+	"context"
+	"io"
+	"os"
+	"os/signal"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/goyek/goyek/v3/internal"
+)
+
+func TestFlow_Main_SIGTERM(t *testing.T) {
+	flow := &Flow{}
+	out := &strings_builder{}
+	flow.SetOutput(out)
+
+	taskStarted := make(chan struct{})
+	taskFinished := make(chan struct{})
+
+	flow.Define(Task{
+		Name: "test",
+		Action: func(a *A) {
+			close(taskStarted)
+			select {
+			case <-a.Context().Done():
+			case <-time.After(5 * time.Second):
+				// This should not happen if SIGTERM is handled correctly
+			}
+			close(taskFinished)
+		},
+	})
+
+	// We can't call flow.Main because it calls os.Exit.
+	// But we can simulate the signal handling logic.
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, internal.TerminationSignals...)
+	defer signal.Stop(c)
+
+	go func() {
+		// Wait for task to start
+		<-taskStarted
+		// Send SIGTERM to ourselves
+		process, _ := os.FindProcess(os.Getpid())
+		process.Signal(syscall.SIGTERM)
+	}()
+
+	go func() {
+		select {
+		case <-c:
+			cancel()
+		case <-taskFinished:
+		}
+	}()
+
+	flow.main(ctx, []string{"test"})
+
+	select {
+	case <-taskFinished:
+		// Success
+	case <-time.After(time.Second):
+		t.Error("task was not canceled by SIGTERM")
+	}
+}
+
+type strings_builder struct {
+	io.Writer
+}
+
+func (b *strings_builder) Write(p []byte) (n int, err error) {
+	return len(p), nil
+}

--- a/flow_main_unix_test.go
+++ b/flow_main_unix_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestFlow_Main_SIGTERM(t *testing.T) {
 	flow := &Flow{}
-	out := &strings_builder{}
+	out := &stringsBuilder{}
 	flow.SetOutput(out)
 
 	taskStarted := make(chan struct{})
@@ -43,7 +43,7 @@ func TestFlow_Main_SIGTERM(t *testing.T) {
 	defer cancel()
 
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, internal.TerminationSignals...)
+	signal.Notify(c, internal.TerminationSignals()...)
 	defer signal.Stop(c)
 
 	go func() {
@@ -51,7 +51,7 @@ func TestFlow_Main_SIGTERM(t *testing.T) {
 		<-taskStarted
 		// Send SIGTERM to ourselves
 		process, _ := os.FindProcess(os.Getpid())
-		process.Signal(syscall.SIGTERM)
+		_ = process.Signal(syscall.SIGTERM)
 	}()
 
 	go func() {
@@ -72,10 +72,10 @@ func TestFlow_Main_SIGTERM(t *testing.T) {
 	}
 }
 
-type strings_builder struct {
+type stringsBuilder struct {
 	io.Writer
 }
 
-func (b *strings_builder) Write(p []byte) (n int, err error) {
+func (b *stringsBuilder) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }

--- a/internal/signals.go
+++ b/internal/signals.go
@@ -1,0 +1,14 @@
+package internal
+
+import (
+	"os"
+)
+
+// TerminationSignals returns the signals that cause the program to terminate.
+func TerminationSignals() []os.Signal {
+	signals := []os.Signal{os.Interrupt}
+	for _, s := range platformSignals() {
+		signals = append(signals, s)
+	}
+	return signals
+}

--- a/internal/signals_test.go
+++ b/internal/signals_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestTerminationSignals(t *testing.T) {
-	signals := internal.TerminationSignals
+	signals := internal.TerminationSignals()
 	if len(signals) == 0 {
 		t.Fatal("TerminationSignals should not be empty")
 	}

--- a/internal/signals_test.go
+++ b/internal/signals_test.go
@@ -1,0 +1,38 @@
+package internal_test
+
+import (
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/goyek/goyek/v3/internal"
+)
+
+func TestTerminationSignals(t *testing.T) {
+	signals := internal.TerminationSignals
+	if len(signals) == 0 {
+		t.Fatal("TerminationSignals should not be empty")
+	}
+
+	foundInterrupt := false
+	for _, s := range signals {
+		if s == os.Interrupt {
+			foundInterrupt = true
+			break
+		}
+	}
+	if !foundInterrupt {
+		t.Error("os.Interrupt not found in TerminationSignals")
+	}
+
+	switch runtime.GOOS {
+	case "windows", "plan9":
+		if len(signals) != 1 {
+			t.Errorf("expected 1 signal on %s, got %d", runtime.GOOS, len(signals))
+		}
+	default:
+		if len(signals) < 2 {
+			t.Errorf("expected at least 2 signals on %s, got %d", runtime.GOOS, len(signals))
+		}
+	}
+}

--- a/internal/signals_unix.go
+++ b/internal/signals_unix.go
@@ -1,0 +1,11 @@
+//go:build !windows && !plan9
+
+package internal
+
+import (
+	"os"
+	"syscall"
+)
+
+// TerminationSignals are signals that cause the program to terminate.
+var TerminationSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}

--- a/internal/signals_unix.go
+++ b/internal/signals_unix.go
@@ -1,4 +1,5 @@
 //go:build !windows && !plan9
+// +build !windows,!plan9
 
 package internal
 

--- a/internal/signals_unix.go
+++ b/internal/signals_unix.go
@@ -8,5 +8,7 @@ import (
 	"syscall"
 )
 
-// TerminationSignals are signals that cause the program to terminate.
-var TerminationSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}
+// TerminationSignals returns the signals that cause the program to terminate.
+func TerminationSignals() []os.Signal {
+	return []os.Signal{os.Interrupt, syscall.SIGTERM}
+}

--- a/internal/signals_unix.go
+++ b/internal/signals_unix.go
@@ -8,7 +8,6 @@ import (
 	"syscall"
 )
 
-// TerminationSignals returns the signals that cause the program to terminate.
-func TerminationSignals() []os.Signal {
-	return []os.Signal{os.Interrupt, syscall.SIGTERM}
+func platformSignals() []os.Signal {
+	return []os.Signal{syscall.SIGTERM}
 }

--- a/internal/signals_windows.go
+++ b/internal/signals_windows.go
@@ -7,5 +7,7 @@ import (
 	"os"
 )
 
-// TerminationSignals are signals that cause the program to terminate.
-var TerminationSignals = []os.Signal{os.Interrupt}
+// TerminationSignals returns the signals that cause the program to terminate.
+func TerminationSignals() []os.Signal {
+	return []os.Signal{os.Interrupt}
+}

--- a/internal/signals_windows.go
+++ b/internal/signals_windows.go
@@ -7,7 +7,6 @@ import (
 	"os"
 )
 
-// TerminationSignals returns the signals that cause the program to terminate.
-func TerminationSignals() []os.Signal {
-	return []os.Signal{os.Interrupt}
+func platformSignals() []os.Signal {
+	return nil
 }

--- a/internal/signals_windows.go
+++ b/internal/signals_windows.go
@@ -1,0 +1,10 @@
+//go:build windows || plan9
+
+package internal
+
+import (
+	"os"
+)
+
+// TerminationSignals are signals that cause the program to terminate.
+var TerminationSignals = []os.Signal{os.Interrupt}

--- a/internal/signals_windows.go
+++ b/internal/signals_windows.go
@@ -1,4 +1,5 @@
 //go:build windows || plan9
+// +build windows plan9
 
 package internal
 


### PR DESCRIPTION
Added `SIGTERM` support to `Flow.Main` for graceful shutdown on Unix systems.
Introduced `internal/signals_unix.go` and `internal/signals_windows.go` to handle signals portably.
Updated `CHANGELOG.md` and added unit tests in `internal/signals_test.go`.

---
*PR created automatically by Jules for task [3154667468421634806](https://jules.google.com/task/3154667468421634806) started by @pellared*