### PR TITLE
Add graceful shutdown on SIGTERM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 
 ### Added
 
+- `Flow.Main` now handles graceful shutdown on `SIGTERM` (on Unix systems)
+  in addition to `os.Interrupt`, ensuring task cleanups are executed.
 - Add safety checks to `A.Setenv` and `A.Chdir` to prevent their usage
   in parallel tasks.
 

--- a/a.go
+++ b/a.go
@@ -13,7 +13,12 @@ import (
 	"unicode/utf8"
 )
 
-const maxTempDirTaskNameLen = 64
+const (
+	maxTempDirTaskNameLen = 64
+
+	goosWindows = "windows"
+	goosPlan9   = "plan9"
+)
 
 // A is a type passed to [Task.Action] functions to manage task state
 // and support formatted task logs.
@@ -320,7 +325,7 @@ func (a *A) Chdir(dir string) {
 	// current working directory.” Since we are changing the working
 	// directory, we should also set or update PWD to reflect that.
 	switch runtime.GOOS {
-	case "windows", "plan9":
+	case goosWindows, goosPlan9:
 		// Windows and Plan 9 do not use the PWD variable.
 	default:
 		if !filepath.IsAbs(dir) {

--- a/flow.go
+++ b/flow.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"sort"
+	"sync"
 	"strings"
 	"text/tabwriter"
 
@@ -376,6 +377,11 @@ const (
 	exitCodeInvalid = 2
 )
 
+var (
+	mainExiter   = os.Exit
+	mainExiterMu sync.RWMutex
+)
+
 // Main runs provided tasks and all their dependencies.
 // Each task is executed at most once.
 // It exits the current program when after the run is finished
@@ -399,7 +405,7 @@ func Main(args []string, opts ...Option) {
 //
 // Calls [Usage] when invalid args are provided.
 func (f *Flow) Main(args []string, opts ...Option) {
-	out := f.Output()
+	out := internal.SyncWriter(f.Output())
 
 	// trap Ctrl+C and call cancel on the context
 	ctx, cancel := context.WithCancel(context.Background())
@@ -412,11 +418,19 @@ func (f *Flow) Main(args []string, opts ...Option) {
 
 		<-c // second signal, hard exit
 		fmt.Fprintln(out, "second interrupt, exit")
-		os.Exit(exitCodeFail)
+		mainExiterMu.RLock()
+		exiter := mainExiter
+		mainExiterMu.RUnlock()
+		exiter(exitCodeFail)
+		// block forever to ensure os.Exit equivalent finishes the process
+		select {}
 	}()
 
 	exitCode := f.main(ctx, args, opts...)
-	os.Exit(exitCode)
+	mainExiterMu.RLock()
+	exiter := mainExiter
+	mainExiterMu.RUnlock()
+	exiter(exitCode)
 }
 
 func (f *Flow) main(ctx context.Context, args []string, opts ...Option) int {
@@ -431,6 +445,9 @@ func (f *Flow) main(ctx context.Context, args []string, opts ...Option) int {
 	if err != nil {
 		f.Usage()()
 		return exitCodeInvalid
+	}
+	if err := ctx.Err(); err != nil {
+		return exitCodeFail
 	}
 	return exitCodePass
 }

--- a/flow.go
+++ b/flow.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 	"strings"
 	"text/tabwriter"
+
+	"github.com/goyek/goyek/v3/internal"
 )
 
 // Flow is the root type of the package.
@@ -402,7 +404,7 @@ func (f *Flow) Main(args []string, opts ...Option) {
 	// trap Ctrl+C and call cancel on the context
 	ctx, cancel := context.WithCancel(context.Background())
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
+	signal.Notify(c, internal.TerminationSignals...)
 	go func() {
 		<-c // first signal, cancel context
 		fmt.Fprintln(out, "first interrupt, graceful stop")

--- a/flow_main_test.go
+++ b/flow_main_test.go
@@ -105,7 +105,7 @@ func TestFlow_Main(t *testing.T) {
 	})
 
 	t.Run("interrupt", func(t *testing.T) {
-		if runtime.GOOS == "windows" || runtime.GOOS == "plan9" {
+		if runtime.GOOS == goosWindows || runtime.GOOS == goosPlan9 {
 			t.Skip("skipping on " + runtime.GOOS)
 		}
 
@@ -125,10 +125,10 @@ func TestFlow_Main(t *testing.T) {
 	})
 }
 
-func TestMain_wrapper(t *testing.T) {
+func TestMain_wrapper(_ *testing.T) {
 	mainExiterMu.Lock()
 	origExiter := mainExiter
-	mainExiter = func(code int) {}
+	mainExiter = func(_ int) {}
 	mainExiterMu.Unlock()
 	defer func() {
 		mainExiterMu.Lock()
@@ -165,7 +165,7 @@ func TestFailError_Error(t *testing.T) {
 }
 
 func TestFlow_Main_second_interrupt(t *testing.T) {
-	if runtime.GOOS == "windows" || runtime.GOOS == "plan9" {
+	if runtime.GOOS == goosWindows || runtime.GOOS == goosPlan9 {
 		t.Skip("skipping on " + runtime.GOOS)
 	}
 

--- a/flow_main_test.go
+++ b/flow_main_test.go
@@ -3,8 +3,14 @@ package goyek
 import (
 	"context"
 	"io"
+	"runtime"
 	"strings"
+	"sync"
+	"syscall"
 	"testing"
+	"time"
+
+	"github.com/goyek/goyek/v3/internal"
 )
 
 func TestFlow_main(t *testing.T) {
@@ -62,5 +68,149 @@ func Test_main_usage(t *testing.T) {
 
 	if !called {
 		t.Error("usage should be called for invalid input")
+	}
+}
+
+func TestFlow_Main(t *testing.T) {
+	flow := &Flow{}
+	sb := &safeBuffer{}
+	flow.SetOutput(sb)
+	flow.Define(Task{Name: "task"})
+	flow.Define(Task{Name: "wait", Action: func(a *A) {
+		<-a.Context().Done()
+	}})
+
+	exitCh := make(chan int, 1)
+	mainExiterMu.Lock()
+	origExiter := mainExiter
+	mainExiter = func(code int) {
+		select {
+		case exitCh <- code:
+		default:
+		}
+	}
+	mainExiterMu.Unlock()
+	defer func() {
+		mainExiterMu.Lock()
+		mainExiter = origExiter
+		mainExiterMu.Unlock()
+	}()
+
+	t.Run("pass", func(t *testing.T) {
+		flow.Main([]string{"task"})
+		gotExitCode := <-exitCh
+		if gotExitCode != 0 {
+			t.Errorf("got exit code %d, want 0", gotExitCode)
+		}
+	})
+
+	t.Run("interrupt", func(t *testing.T) {
+		if runtime.GOOS == "windows" || runtime.GOOS == "plan9" {
+			t.Skip("skipping on " + runtime.GOOS)
+		}
+
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+			_ = syscall.Kill(syscall.Getpid(), internal.TerminationSignals[0].(syscall.Signal))
+		}()
+
+		flow.Main([]string{"wait"})
+		gotExitCode := <-exitCh
+		if gotExitCode != 1 {
+			t.Errorf("got exit code %d, want 1", gotExitCode)
+		}
+		if !strings.Contains(sb.String(), "first interrupt") {
+			t.Error("missing first interrupt message")
+		}
+	})
+}
+
+func TestMain_wrapper(t *testing.T) {
+	mainExiterMu.Lock()
+	origExiter := mainExiter
+	mainExiter = func(code int) {}
+	mainExiterMu.Unlock()
+	defer func() {
+		mainExiterMu.Lock()
+		mainExiter = origExiter
+		mainExiterMu.Unlock()
+	}()
+
+	Main(nil)
+}
+
+type safeBuffer struct {
+	mu sync.Mutex
+	sb strings.Builder
+}
+
+func (b *safeBuffer) Write(p []byte) (n int, err error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.sb.Write(p)
+}
+
+func (b *safeBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.sb.String()
+}
+
+func TestFailError_Error(t *testing.T) {
+	err := &FailError{Task: "test"}
+	want := "task failed: test"
+	if got := err.Error(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFlow_Main_second_interrupt(t *testing.T) {
+	if runtime.GOOS == "windows" || runtime.GOOS == "plan9" {
+		t.Skip("skipping on " + runtime.GOOS)
+	}
+
+	flow := &Flow{}
+	sb := &safeBuffer{}
+	flow.SetOutput(sb)
+	flow.Define(Task{Name: "wait", Action: func(a *A) {
+		<-a.Context().Done()
+		time.Sleep(1 * time.Second)
+	}})
+
+	exitCh := make(chan int, 1)
+	mainExiterMu.Lock()
+	origExiter := mainExiter
+	mainExiter = func(code int) {
+		select {
+		case exitCh <- code:
+		default:
+		}
+	}
+	mainExiterMu.Unlock()
+	defer func() {
+		mainExiterMu.Lock()
+		mainExiter = origExiter
+		mainExiterMu.Unlock()
+	}()
+
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		_ = syscall.Kill(syscall.Getpid(), syscall.SIGINT)
+
+		for i := 0; i < 20; i++ {
+			if strings.Contains(sb.String(), "first interrupt") {
+				break
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+
+		_ = syscall.Kill(syscall.Getpid(), syscall.SIGINT)
+	}()
+
+	flow.Main([]string{"wait"})
+
+	gotExitCode := <-exitCh
+	if gotExitCode != 1 {
+		t.Errorf("got exit code %d, want 1", gotExitCode)
 	}
 }

--- a/internal/signals.go
+++ b/internal/signals.go
@@ -1,0 +1,6 @@
+package internal
+
+import "os"
+
+// TerminationSignals are the signals that should cause the flow to stop gracefully.
+var TerminationSignals []os.Signal

--- a/internal/signals_test.go
+++ b/internal/signals_test.go
@@ -1,0 +1,33 @@
+package internal
+
+import (
+	"os"
+	"runtime"
+	"syscall"
+	"testing"
+)
+
+func TestTerminationSignals(t *testing.T) {
+	signals := make(map[os.Signal]bool)
+	for _, s := range TerminationSignals {
+		signals[s] = true
+	}
+
+	if !signals[os.Interrupt] {
+		t.Error("os.Interrupt missing from TerminationSignals")
+	}
+
+	switch runtime.GOOS {
+	case "windows", "plan9":
+		if len(TerminationSignals) != 1 {
+			t.Errorf("expected 1 signal on %s, got %d", runtime.GOOS, len(TerminationSignals))
+		}
+	default:
+		if !signals[syscall.SIGTERM] {
+			t.Error("syscall.SIGTERM missing from TerminationSignals")
+		}
+		if len(TerminationSignals) != 2 {
+			t.Errorf("expected 2 signals on %s, got %d", runtime.GOOS, len(TerminationSignals))
+		}
+	}
+}

--- a/internal/signals_unix.go
+++ b/internal/signals_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows && !plan9
+// +build !windows,!plan9
+
+package internal
+
+import (
+	"os"
+	"syscall"
+)
+
+func init() {
+	TerminationSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}
+}

--- a/internal/signals_windows.go
+++ b/internal/signals_windows.go
@@ -1,0 +1,10 @@
+//go:build windows || plan9
+// +build windows plan9
+
+package internal
+
+import "os"
+
+func init() {
+	TerminationSignals = []os.Signal{os.Interrupt}
+}


### PR DESCRIPTION
Implemented graceful shutdown handling for `SIGTERM` in `Flow.Main`. This ensures that when the process receives a `SIGTERM` signal (e.g., from Docker or Kubernetes), it will attempt to stop gracefully, allowing task cleanups (like deleting temporary directories or stopping subprocesses) to run.

Key changes:
- Created `internal/signals.go`, `internal/signals_unix.go`, and `internal/signals_windows.go` to define `TerminationSignals` portably.
- Updated `Flow.Main` in `flow.go` to use `internal.TerminationSignals` for signal notification.
- Added unit tests in `internal/signals_test.go` to verify signal definition across platforms.
- Updated `CHANGELOG.md` to document the enhancement.

---
*PR created automatically by Jules for task [7147043316169423008](https://jules.google.com/task/7147043316169423008) started by @pellared*