### PR TITLE
Add SIGTERM support for graceful shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 
 - Add safety checks to `A.Setenv` and `A.Chdir` to prevent their usage
   in parallel tasks.
+- `Flow.Main` now handles `SIGTERM` (on Unix-like systems) for graceful
+  shutdown.
 
 ### Fixed
 

--- a/flow.go
+++ b/flow.go
@@ -392,19 +392,24 @@ func Main(args []string, opts ...Option) {
 // Main runs provided tasks and all their dependencies.
 // Each task is executed at most once.
 // It exits the current program when after the run is finished
-// or SIGINT interrupted the execution.
+// or SIGINT or SIGTERM (on Unix) interrupted the execution.
 //   - 0 exit code means that non of the tasks failed.
 //   - 1 exit code means that a task has failed or the execution was interrupted.
 //   - 2 exit code means that the input was invalid.
 //
 // Calls [Usage] when invalid args are provided.
 func (f *Flow) Main(args []string, opts ...Option) {
-	out := f.Output()
-
-	// trap Ctrl+C and call cancel on the context
 	ctx, cancel := context.WithCancel(context.Background())
+	f.trapSignals(cancel)
+
+	exitCode := f.main(ctx, args, opts...)
+	os.Exit(exitCode)
+}
+
+func (f *Flow) trapSignals(cancel context.CancelFunc) {
+	out := f.Output()
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, internal.TerminationSignals...)
+	signal.Notify(c, internal.TerminationSignals()...)
 	go func() {
 		<-c // first signal, cancel context
 		fmt.Fprintln(out, "first interrupt, graceful stop")
@@ -414,9 +419,6 @@ func (f *Flow) Main(args []string, opts ...Option) {
 		fmt.Fprintln(out, "second interrupt, exit")
 		os.Exit(exitCodeFail)
 	}()
-
-	exitCode := f.main(ctx, args, opts...)
-	os.Exit(exitCode)
 }
 
 func (f *Flow) main(ctx context.Context, args []string, opts ...Option) int {

--- a/flow.go
+++ b/flow.go
@@ -14,6 +14,8 @@ import (
 	"github.com/goyek/goyek/v3/internal"
 )
 
+var osExit = os.Exit
+
 // Flow is the root type of the package.
 // Use Register methods to register all tasks
 // and Run or Main method to execute provided tasks.
@@ -403,7 +405,7 @@ func (f *Flow) Main(args []string, opts ...Option) {
 	f.trapSignals(cancel)
 
 	exitCode := f.main(ctx, args, opts...)
-	os.Exit(exitCode)
+	osExit(exitCode)
 }
 
 func (f *Flow) trapSignals(cancel context.CancelFunc) {
@@ -417,7 +419,7 @@ func (f *Flow) trapSignals(cancel context.CancelFunc) {
 
 		<-c // second signal, hard exit
 		fmt.Fprintln(out, "second interrupt, exit")
-		os.Exit(exitCodeFail)
+		osExit(exitCodeFail)
 	}()
 }
 

--- a/flow.go
+++ b/flow.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 	"strings"
 	"text/tabwriter"
+
+	"github.com/goyek/goyek/v3/internal"
 )
 
 // Flow is the root type of the package.
@@ -402,7 +404,7 @@ func (f *Flow) Main(args []string, opts ...Option) {
 	// trap Ctrl+C and call cancel on the context
 	ctx, cancel := context.WithCancel(context.Background())
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
+	signal.Notify(c, internal.TerminationSignals...)
 	go func() {
 		<-c // first signal, cancel context
 		fmt.Fprintln(out, "first interrupt, graceful stop")

--- a/internal/signals_default.go
+++ b/internal/signals_default.go
@@ -1,0 +1,10 @@
+// +build !aix,!darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd,!solaris
+
+package internal
+
+import (
+	"os"
+)
+
+// TerminationSignals are the signals that should cause a graceful shutdown.
+var TerminationSignals = []os.Signal{os.Interrupt}

--- a/internal/signals_default.go
+++ b/internal/signals_default.go
@@ -6,5 +6,7 @@ import (
 	"os"
 )
 
-// TerminationSignals are the signals that should cause a graceful shutdown.
-var TerminationSignals = []os.Signal{os.Interrupt}
+// TerminationSignals returns the signals that should cause a graceful shutdown.
+func TerminationSignals() []os.Signal {
+	return []os.Signal{os.Interrupt}
+}

--- a/internal/signals_test.go
+++ b/internal/signals_test.go
@@ -12,7 +12,7 @@ import (
 func TestTerminationSignals(t *testing.T) {
 	hasInterrupt := false
 	hasSIGTERM := false
-	for _, s := range internal.TerminationSignals {
+	for _, s := range internal.TerminationSignals() {
 		if s == os.Interrupt {
 			hasInterrupt = true
 		}

--- a/internal/signals_test.go
+++ b/internal/signals_test.go
@@ -1,0 +1,40 @@
+package internal_test
+
+import (
+	"os"
+	"runtime"
+	"syscall"
+	"testing"
+
+	"github.com/goyek/goyek/v3/internal"
+)
+
+func TestTerminationSignals(t *testing.T) {
+	hasInterrupt := false
+	hasSIGTERM := false
+	for _, s := range internal.TerminationSignals {
+		if s == os.Interrupt {
+			hasInterrupt = true
+		}
+		if s == syscall.SIGTERM {
+			hasSIGTERM = true
+		}
+	}
+
+	if !hasInterrupt {
+		t.Error("TerminationSignals should contain os.Interrupt")
+	}
+
+	isUnix := false
+	switch runtime.GOOS {
+	case "aix", "darwin", "dragonfly", "freebsd", "linux", "netbsd", "openbsd", "solaris":
+		isUnix = true
+	}
+
+	if isUnix && !hasSIGTERM {
+		t.Error("TerminationSignals should contain syscall.SIGTERM on Unix")
+	}
+	if !isUnix && hasSIGTERM {
+		t.Error("TerminationSignals should not contain syscall.SIGTERM on non-Unix")
+	}
+}

--- a/internal/signals_unix.go
+++ b/internal/signals_unix.go
@@ -1,3 +1,4 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
 // +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package internal

--- a/internal/signals_unix.go
+++ b/internal/signals_unix.go
@@ -7,5 +7,7 @@ import (
 	"syscall"
 )
 
-// TerminationSignals are the signals that should cause a graceful shutdown.
-var TerminationSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}
+// TerminationSignals returns the signals that should cause a graceful shutdown.
+func TerminationSignals() []os.Signal {
+	return []os.Signal{os.Interrupt, syscall.SIGTERM}
+}

--- a/internal/signals_unix.go
+++ b/internal/signals_unix.go
@@ -1,0 +1,11 @@
+// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
+
+package internal
+
+import (
+	"os"
+	"syscall"
+)
+
+// TerminationSignals are the signals that should cause a graceful shutdown.
+var TerminationSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}

--- a/trap_signals_test.go
+++ b/trap_signals_test.go
@@ -1,0 +1,40 @@
+package goyek
+
+import (
+	"context"
+	"io"
+	"os"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestFlow_trapSignals(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows because os.Process.Signal(os.Interrupt) is not supported")
+	}
+	f := &Flow{}
+	f.SetOutput(io.Discard)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	f.trapSignals(cancel)
+
+	p, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		t.Fatalf("could not find process: %v", err)
+	}
+
+	// Send signal to ourselves.
+	// Since we are using a buffered channel of size 1 in trapSignals,
+	// and we only care about the first signal for this test.
+	if err := p.Signal(os.Interrupt); err != nil {
+		t.Fatalf("could not send signal: %v", err)
+	}
+
+	select {
+	case <-ctx.Done():
+		// Success
+	case <-time.After(time.Second):
+		t.Error("context should have been canceled")
+	}
+}

--- a/trap_signals_test.go
+++ b/trap_signals_test.go
@@ -21,7 +21,7 @@ func TestFlow_trapSignals(t *testing.T) {
 	var exitCode int32 = -1
 	origOsExit := osExit
 	osExit = func(code int) {
-		atomic.StoreInt32(&exitCode, int32(code))
+		atomic.StoreInt32(&exitCode, int32(code)) //nolint:gosec // G115: exit code is a small integer
 	}
 	defer func() { osExit = origOsExit }()
 
@@ -71,7 +71,7 @@ func TestFlow_Main(t *testing.T) {
 	var exitCode int32 = -1
 	origOsExit := osExit
 	osExit = func(code int) {
-		atomic.StoreInt32(&exitCode, int32(code))
+		atomic.StoreInt32(&exitCode, int32(code)) //nolint:gosec // G115: exit code is a small integer
 	}
 	defer func() { osExit = origOsExit }()
 
@@ -88,7 +88,7 @@ func TestMain_topLevel(t *testing.T) {
 	var exitCode int32 = -1
 	origOsExit := osExit
 	osExit = func(code int) {
-		atomic.StoreInt32(&exitCode, int32(code))
+		atomic.StoreInt32(&exitCode, int32(code)) //nolint:gosec // G115: exit code is a small integer
 	}
 	defer func() { osExit = origOsExit }()
 

--- a/trap_signals_test.go
+++ b/trap_signals_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"runtime"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -17,16 +18,21 @@ func TestFlow_trapSignals(t *testing.T) {
 	f.SetOutput(io.Discard)
 	ctx, cancel := context.WithCancel(context.Background())
 
+	var exitCode int32 = -1
+	origOsExit := osExit
+	osExit = func(code int) {
+		atomic.StoreInt32(&exitCode, int32(code))
+	}
+	defer func() { osExit = origOsExit }()
+
 	f.trapSignals(cancel)
 
 	p, err := os.FindProcess(os.Getpid())
 	if err != nil {
-		t.Fatalf("could not find process: %v", err)
+		t.Fatalf("could find process: %v", err)
 	}
 
-	// Send signal to ourselves.
-	// Since we are using a buffered channel of size 1 in trapSignals,
-	// and we only care about the first signal for this test.
+	// Send first signal.
 	if err := p.Signal(os.Interrupt); err != nil {
 		t.Fatalf("could not send signal: %v", err)
 	}
@@ -36,5 +42,59 @@ func TestFlow_trapSignals(t *testing.T) {
 		// Success
 	case <-time.After(time.Second):
 		t.Error("context should have been canceled")
+	}
+
+	// Send second signal.
+	if err := p.Signal(os.Interrupt); err != nil {
+		t.Fatalf("could not send signal: %v", err)
+	}
+
+	// Wait for osExit to be called.
+	start := time.Now()
+	for time.Since(start) < time.Second {
+		if atomic.LoadInt32(&exitCode) != -1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if got := atomic.LoadInt32(&exitCode); got != exitCodeFail {
+		t.Errorf("got exit code: %d; want: %d", got, exitCodeFail)
+	}
+}
+
+func TestFlow_Main(t *testing.T) {
+	f := &Flow{}
+	f.SetOutput(io.Discard)
+	f.Define(Task{Name: "task"})
+
+	var exitCode int32 = -1
+	origOsExit := osExit
+	osExit = func(code int) {
+		atomic.StoreInt32(&exitCode, int32(code))
+	}
+	defer func() { osExit = origOsExit }()
+
+	f.Main([]string{"task"})
+
+	if got := atomic.LoadInt32(&exitCode); got != exitCodePass {
+		t.Errorf("got exit code: %d; want: %d", got, exitCodePass)
+	}
+}
+
+func TestMain_topLevel(t *testing.T) {
+	Define(Task{Name: "top-level-task"})
+
+	var exitCode int32 = -1
+	origOsExit := osExit
+	osExit = func(code int) {
+		atomic.StoreInt32(&exitCode, int32(code))
+	}
+	defer func() { osExit = origOsExit }()
+
+	Main([]string{"top-level-task"})
+
+	if got := atomic.LoadInt32(&exitCode); got != exitCodePass {
+		t.Errorf("got exit code: %d; want: %d", got, exitCodePass)
 	}
 }


### PR DESCRIPTION
This enhancement improves the reliability and security of goyek by ensuring that tasks can gracefully shut down when receiving a SIGTERM signal, which is commonly used in containerized environments like Kubernetes.

Key changes:
- Created `internal/signals_unix.go` and `internal/signals_default.go` to portably define `TerminationSignals`.
- Added `internal/signals_test.go` to verify the platform-specific signal definitions.
- Updated `Flow.Main` in `flow.go` to use `internal.TerminationSignals` in its signal notification logic.
- Updated `CHANGELOG.md` to reflect the addition of SIGTERM support.

All tests passed, including race detector tests.

---
*PR created automatically by Jules for task [448205802981549814](https://jules.google.com/task/448205802981549814) started by @pellared*