### PR TITLE
Enhance graceful shutdown with SIGTERM support and thread-safe output

### DIFF
--- a/flow.go
+++ b/flow.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 	"strings"
 	"text/tabwriter"
+
+	"github.com/goyek/goyek/v3/internal"
 )
 
 // Flow is the root type of the package.
@@ -321,6 +323,8 @@ func (err *FailError) Error() string {
 	return "task failed: " + err.Task
 }
 
+var osExit = os.Exit
+
 // Execute runs provided tasks and all their dependencies.
 // Each task is executed at most once.
 // Returns nil if no task has failed,
@@ -377,7 +381,7 @@ const (
 // Main runs provided tasks and all their dependencies.
 // Each task is executed at most once.
 // It exits the current program when after the run is finished
-// or SIGINT interrupted the execution.
+// or termination signals interrupted the execution.
 //   - 0 exit code means that non of the tasks failed.
 //   - 1 exit code means that a task has failed or the execution was interrupted.
 //   - 2 exit code means that the input was invalid.
@@ -390,31 +394,48 @@ func Main(args []string, opts ...Option) {
 // Main runs provided tasks and all their dependencies.
 // Each task is executed at most once.
 // It exits the current program when after the run is finished
-// or SIGINT interrupted the execution.
+// or termination signals interrupted the execution.
 //   - 0 exit code means that non of the tasks failed.
 //   - 1 exit code means that a task has failed or the execution was interrupted.
 //   - 2 exit code means that the input was invalid.
 //
 // Calls [Usage] when invalid args are provided.
 func (f *Flow) Main(args []string, opts ...Option) {
-	out := f.Output()
+	out := internal.SyncWriter(f.Output())
 
-	// trap Ctrl+C and call cancel on the context
+	// trap signals and call cancel on the context
 	ctx, cancel := context.WithCancel(context.Background())
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
-	go func() {
-		<-c // first signal, cancel context
-		fmt.Fprintln(out, "first interrupt, graceful stop")
-		cancel()
-
-		<-c // second signal, hard exit
-		fmt.Fprintln(out, "second interrupt, exit")
-		os.Exit(exitCodeFail)
-	}()
+	done := make(chan struct{})
+	f.trapSignals(ctx, cancel, out, done)
 
 	exitCode := f.main(ctx, args, opts...)
-	os.Exit(exitCode)
+	close(done)
+	osExit(exitCode)
+}
+
+func (f *Flow) trapSignals(ctx context.Context, cancel context.CancelFunc, out io.Writer, done <-chan struct{}) {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, internal.TerminationSignals()...)
+	go func() {
+		defer signal.Stop(c)
+		select {
+		case <-done:
+			return
+		case <-ctx.Done():
+			return
+		case <-c: // first signal, cancel context
+			fmt.Fprintln(out, "first interrupt, graceful stop")
+			cancel()
+		}
+
+		select {
+		case <-done:
+			return
+		case <-c: // second signal, hard exit
+			fmt.Fprintln(out, "second interrupt, exit")
+			osExit(exitCodeFail)
+		}
+	}()
 }
 
 func (f *Flow) main(ctx context.Context, args []string, opts ...Option) int {

--- a/flow.go
+++ b/flow.go
@@ -413,7 +413,7 @@ func (f *Flow) Main(args []string, opts ...Option) {
 	osExit(exitCode)
 }
 
-func (f *Flow) trapSignals(ctx context.Context, cancel context.CancelFunc, out io.Writer, done <-chan struct{}) {
+func (f *Flow) trapSignals(_ context.Context, cancel context.CancelFunc, out io.Writer, done <-chan struct{}) {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, internal.TerminationSignals()...)
 	go func() {

--- a/flow.go
+++ b/flow.go
@@ -381,7 +381,7 @@ const (
 // Main runs provided tasks and all their dependencies.
 // Each task is executed at most once.
 // It exits the current program when after the run is finished
-// or termination signals interrupted the execution.
+// or SIGINT interrupted the execution.
 //   - 0 exit code means that non of the tasks failed.
 //   - 1 exit code means that a task has failed or the execution was interrupted.
 //   - 2 exit code means that the input was invalid.
@@ -420,8 +420,6 @@ func (f *Flow) trapSignals(ctx context.Context, cancel context.CancelFunc, out i
 		defer signal.Stop(c)
 		select {
 		case <-done:
-			return
-		case <-ctx.Done():
 			return
 		case <-c: // first signal, cancel context
 			fmt.Fprintln(out, "first interrupt, graceful stop")

--- a/internal/signals_default.go
+++ b/internal/signals_default.go
@@ -1,3 +1,4 @@
+//go:build windows || plan9
 // +build windows plan9
 
 package internal

--- a/internal/signals_default.go
+++ b/internal/signals_default.go
@@ -1,0 +1,12 @@
+// +build windows plan9
+
+package internal
+
+import (
+	"os"
+)
+
+// TerminationSignals returns the signals that should cause a graceful shutdown.
+func TerminationSignals() []os.Signal {
+	return []os.Signal{os.Interrupt}
+}

--- a/internal/signals_test.go
+++ b/internal/signals_test.go
@@ -1,0 +1,24 @@
+package internal_test
+
+import (
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/goyek/goyek/v3/internal"
+)
+
+func TestTerminationSignals(t *testing.T) {
+	sigs := internal.TerminationSignals()
+	if len(sigs) == 0 {
+		t.Fatal("no termination signals returned")
+	}
+	if sigs[0] != os.Interrupt {
+		t.Errorf("expected first signal to be os.Interrupt, got %v", sigs[0])
+	}
+	if runtime.GOOS != "windows" && runtime.GOOS != "plan9" {
+		if len(sigs) < 2 {
+			t.Fatal("expected at least 2 termination signals on Unix")
+		}
+	}
+}

--- a/internal/signals_unix.go
+++ b/internal/signals_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows && !plan9
 // +build !windows,!plan9
 
 package internal

--- a/internal/signals_unix.go
+++ b/internal/signals_unix.go
@@ -1,0 +1,13 @@
+// +build !windows,!plan9
+
+package internal
+
+import (
+	"os"
+	"syscall"
+)
+
+// TerminationSignals returns the signals that should cause a graceful shutdown.
+func TerminationSignals() []os.Signal {
+	return []os.Signal{os.Interrupt, syscall.SIGTERM}
+}

--- a/trap_signals_test.go
+++ b/trap_signals_test.go
@@ -36,7 +36,9 @@ func TestFlow_trapSignals(t *testing.T) {
 	p, _ := os.FindProcess(os.Getpid())
 
 	// first signal
-	p.Signal(os.Interrupt)
+	if err := p.Signal(os.Interrupt); err != nil {
+		t.Fatal(err)
+	}
 
 	// wait for context cancellation
 	select {
@@ -47,7 +49,9 @@ func TestFlow_trapSignals(t *testing.T) {
 	}
 
 	// second signal
-	p.Signal(os.Interrupt)
+	if err := p.Signal(os.Interrupt); err != nil {
+		t.Fatal(err)
+	}
 
 	// wait for osExit call
 	start := time.Now()

--- a/trap_signals_test.go
+++ b/trap_signals_test.go
@@ -85,3 +85,71 @@ func TestFlow_Main(t *testing.T) {
 		t.Errorf("expected exitCodeInvalid, got %d", exitCode)
 	}
 }
+
+func TestMain_topLevel(t *testing.T) {
+	origOsExit := osExit
+	defer func() { osExit = origOsExit }()
+
+	var exitCode int
+	osExit = func(code int) {
+		exitCode = code
+	}
+
+	Main(nil)
+
+	if exitCode != exitCodeInvalid {
+		t.Errorf("expected exitCodeInvalid, got %d", exitCode)
+	}
+}
+
+func TestFailError_Error(t *testing.T) {
+	err := &FailError{Task: "task1"}
+	got := err.Error()
+	want := "task failed: task1"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFlow_trapSignals_done(t *testing.T) {
+	f := &Flow{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	close(done)
+	f.trapSignals(ctx, cancel, io.Discard, done)
+}
+
+func TestFlow_trapSignals_ctxDone(t *testing.T) {
+	f := &Flow{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	done := make(chan struct{})
+	defer close(done)
+	f.trapSignals(ctx, cancel, io.Discard, done)
+}
+
+func TestFlow_trapSignals_done_second(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+	f := &Flow{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	f.trapSignals(ctx, cancel, io.Discard, done)
+
+	p, _ := os.FindProcess(os.Getpid())
+	if err := p.Signal(os.Interrupt); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-ctx.Done():
+		// ok
+	case <-time.After(time.Second):
+		t.Fatal("context should be canceled")
+	}
+
+	close(done)
+}

--- a/trap_signals_test.go
+++ b/trap_signals_test.go
@@ -10,9 +10,11 @@ import (
 	"time"
 )
 
+const windows = "windows"
+
 func TestFlow_trapSignals(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping on windows")
+	if runtime.GOOS == windows {
+		t.Skip("skipping on " + windows)
 	}
 
 	origOsExit := osExit
@@ -111,7 +113,7 @@ func TestFailError_Error(t *testing.T) {
 	}
 }
 
-func TestFlow_trapSignals_done(t *testing.T) {
+func TestFlow_trapSignals_done(_ *testing.T) {
 	f := &Flow{}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -120,7 +122,7 @@ func TestFlow_trapSignals_done(t *testing.T) {
 	f.trapSignals(ctx, cancel, io.Discard, done)
 }
 
-func TestFlow_trapSignals_ctxDone(t *testing.T) {
+func TestFlow_trapSignals_ctxDone(_ *testing.T) {
 	f := &Flow{}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -130,8 +132,8 @@ func TestFlow_trapSignals_ctxDone(t *testing.T) {
 }
 
 func TestFlow_trapSignals_done_second(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping on windows")
+	if runtime.GOOS == windows {
+		t.Skip("skipping on " + windows)
 	}
 	f := &Flow{}
 	ctx, cancel := context.WithCancel(context.Background())

--- a/trap_signals_test.go
+++ b/trap_signals_test.go
@@ -1,0 +1,83 @@
+package goyek
+
+import (
+	"context"
+	"io"
+	"os"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestFlow_trapSignals(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+
+	origOsExit := osExit
+	defer func() { osExit = origOsExit }()
+
+	var exitCode int
+	var mu sync.Mutex
+	osExit = func(code int) {
+		mu.Lock()
+		defer mu.Unlock()
+		exitCode = code
+	}
+
+	f := &Flow{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	defer close(done)
+	f.trapSignals(ctx, cancel, io.Discard, done)
+
+	p, _ := os.FindProcess(os.Getpid())
+
+	// first signal
+	p.Signal(os.Interrupt)
+
+	// wait for context cancellation
+	select {
+	case <-ctx.Done():
+		// ok
+	case <-time.After(time.Second):
+		t.Fatal("context should be canceled")
+	}
+
+	// second signal
+	p.Signal(os.Interrupt)
+
+	// wait for osExit call
+	start := time.Now()
+	for {
+		mu.Lock()
+		code := exitCode
+		mu.Unlock()
+		if code == exitCodeFail {
+			break
+		}
+		if time.Since(start) > time.Second {
+			t.Fatal("osExit should be called with exitCodeFail")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestFlow_Main(t *testing.T) {
+	origOsExit := osExit
+	defer func() { osExit = origOsExit }()
+
+	var exitCode int
+	osExit = func(code int) {
+		exitCode = code
+	}
+
+	f := &Flow{}
+	f.Main(nil)
+
+	if exitCode != exitCodeInvalid {
+		t.Errorf("expected exitCodeInvalid, got %d", exitCode)
+	}
+}


### PR DESCRIPTION
Added SIGTERM support for graceful shutdown on Unix-like systems, refactored signal handling for better testability and thread-safety, and added comprehensive unit tests.

---
*PR created automatically by Jules for task [2897341360607697059](https://jules.google.com/task/2897341360607697059) started by @pellared*