### PR TITLE
Improve signal handling and fix output race in Main

### DIFF
--- a/flow.go
+++ b/flow.go
@@ -7,10 +7,14 @@ import (
 	"io"
 	"os"
 	"os/signal"
+
+	"github.com/goyek/goyek/v3/internal"
 	"sort"
 	"strings"
 	"text/tabwriter"
 )
+
+var osExit = os.Exit
 
 // Flow is the root type of the package.
 // Use Register methods to register all tasks
@@ -377,7 +381,7 @@ const (
 // Main runs provided tasks and all their dependencies.
 // Each task is executed at most once.
 // It exits the current program when after the run is finished
-// or SIGINT interrupted the execution.
+// or a termination signal interrupted the execution.
 //   - 0 exit code means that non of the tasks failed.
 //   - 1 exit code means that a task has failed or the execution was interrupted.
 //   - 2 exit code means that the input was invalid.
@@ -397,33 +401,52 @@ func Main(args []string, opts ...Option) {
 //
 // Calls [Usage] when invalid args are provided.
 func (f *Flow) Main(args []string, opts ...Option) {
-	out := f.Output()
+	out := internal.SyncWriter(f.Output())
+	f.SetOutput(out)
 
-	// trap Ctrl+C and call cancel on the context
+	// trap signals and call cancel on the context
 	ctx, cancel := context.WithCancel(context.Background())
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
-	go func() {
-		<-c // first signal, cancel context
-		fmt.Fprintln(out, "first interrupt, graceful stop")
-		cancel()
-
-		<-c // second signal, hard exit
-		fmt.Fprintln(out, "second interrupt, exit")
-		os.Exit(exitCodeFail)
-	}()
+	defer cancel()
+	done := make(chan struct{})
+	go f.trapSignals(ctx, cancel, out, done)
 
 	exitCode := f.main(ctx, args, opts...)
-	os.Exit(exitCode)
+	close(done)
+	osExit(exitCode)
+}
+
+func (f *Flow) trapSignals(ctx context.Context, cancel context.CancelFunc, out io.Writer, done chan struct{}) {
+	c := make(chan os.Signal, 1)
+	sigs := internal.TerminationSignals()
+	signal.Notify(c, sigs...)
+	defer signal.Stop(c)
+
+	select {
+	case <-c: // first signal, cancel context
+		fmt.Fprintln(out, "first interrupt, graceful stop")
+		cancel()
+	case <-done:
+		return
+	}
+
+	select {
+	case <-c: // second signal, hard exit
+		fmt.Fprintln(out, "second interrupt, exit")
+		osExit(exitCodeFail)
+	case <-done:
+	}
 }
 
 func (f *Flow) main(ctx context.Context, args []string, opts ...Option) int {
 	err := f.Execute(ctx, args, opts...)
-	var ferr *FailError
-	if errors.As(err, &ferr) {
+	if ctx.Err() != nil {
 		return exitCodeFail
 	}
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return exitCodeFail
+	}
+	var ferr *FailError
+	if errors.As(err, &ferr) {
 		return exitCodeFail
 	}
 	if err != nil {

--- a/flow.go
+++ b/flow.go
@@ -15,6 +15,7 @@ import (
 )
 
 var osExit = os.Exit
+var trapSignalsHook func()
 
 // Flow is the root type of the package.
 // Use Register methods to register all tasks
@@ -415,10 +416,13 @@ func (f *Flow) Main(args []string, opts ...Option) {
 	osExit(exitCode)
 }
 
-func (f *Flow) trapSignals(ctx context.Context, cancel context.CancelFunc, out io.Writer, done chan struct{}) {
+func (f *Flow) trapSignals(_ context.Context, cancel context.CancelFunc, out io.Writer, done chan struct{}) {
 	c := make(chan os.Signal, 1)
 	sigs := internal.TerminationSignals()
 	signal.Notify(c, sigs...)
+	if trapSignalsHook != nil {
+		trapSignalsHook()
+	}
 	defer signal.Stop(c)
 
 	select {

--- a/internal/signals_default.go
+++ b/internal/signals_default.go
@@ -1,0 +1,13 @@
+//go:build windows || plan9
+// +build windows plan9
+
+package internal
+
+import (
+	"os"
+)
+
+// TerminationSignals returns the signals that should trigger a graceful shutdown.
+func TerminationSignals() []os.Signal {
+	return []os.Signal{os.Interrupt}
+}

--- a/internal/signals_test.go
+++ b/internal/signals_test.go
@@ -1,0 +1,12 @@
+package internal
+
+import (
+	"testing"
+)
+
+func TestTerminationSignals(t *testing.T) {
+	sigs := TerminationSignals()
+	if len(sigs) == 0 {
+		t.Fatal("TerminationSignals returned no signals")
+	}
+}

--- a/internal/signals_unix.go
+++ b/internal/signals_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows && !plan9
+// +build !windows,!plan9
+
+package internal
+
+import (
+	"os"
+	"syscall"
+)
+
+// TerminationSignals returns the signals that should trigger a graceful shutdown.
+func TerminationSignals() []os.Signal {
+	return []os.Signal{os.Interrupt, syscall.SIGTERM}
+}

--- a/trap_signals_test.go
+++ b/trap_signals_test.go
@@ -1,0 +1,129 @@
+package goyek
+
+import (
+	"context"
+	"io"
+	"os"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestFlow_Main(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping signal test on windows")
+	}
+
+	origOsExit := osExit
+	defer func() { osExit = origOsExit }()
+
+	var exitCode int32 = -1
+	osExit = func(code int) {
+		atomic.StoreInt32(&exitCode, int32(code))
+	}
+
+	f := &Flow{}
+	f.Define(Task{
+		Name: "test",
+		Action: func(a *A) {
+			// wait for signal
+			select {
+			case <-a.Context().Done():
+			case <-time.After(time.Second):
+				t.Error("timeout waiting for context cancellation")
+			}
+		},
+	})
+
+	go func() {
+		// wait for Main to start and register signal handler
+		time.Sleep(100 * time.Millisecond)
+		p, _ := os.FindProcess(os.Getpid())
+		if err := p.Signal(os.Interrupt); err != nil {
+			t.Errorf("failed to send signal: %v", err)
+		}
+	}()
+
+	f.Main([]string{"test"})
+
+	if atomic.LoadInt32(&exitCode) != 1 {
+		t.Errorf("expected exit code 1, got %d", atomic.LoadInt32(&exitCode))
+	}
+}
+
+func TestFlow_trapSignals(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping signal test on windows")
+	}
+
+	origOsExit := osExit
+	defer func() { osExit = origOsExit }()
+
+	var exitCode int32 = -1
+	osExit = func(code int) {
+		atomic.StoreInt32(&exitCode, int32(code))
+	}
+
+	f := &Flow{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+
+	go f.trapSignals(ctx, cancel, io.Discard, done)
+
+	p, _ := os.FindProcess(os.Getpid())
+
+	// first signal
+	if err := p.Signal(os.Interrupt); err != nil {
+		t.Fatalf("failed to send first signal: %v", err)
+	}
+
+	// wait for context cancellation
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for context cancellation")
+	}
+
+	// second signal
+	if err := p.Signal(os.Interrupt); err != nil {
+		t.Fatalf("failed to send second signal: %v", err)
+	}
+
+	// wait for hard exit
+	for i := 0; i < 10; i++ {
+		if atomic.LoadInt32(&exitCode) == 1 {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	if atomic.LoadInt32(&exitCode) != 1 {
+		t.Errorf("expected exit code 1, got %d", atomic.LoadInt32(&exitCode))
+	}
+
+	close(done)
+}
+
+func TestMain_topLevel(t *testing.T) {
+	// Just to cover the top-level Main function
+	origOsExit := osExit
+	defer func() { osExit = origOsExit }()
+	osExit = func(code int) {}
+
+	// Define a task in DefaultFlow
+	f := DefaultFlow
+	if f.tasks == nil {
+		f.tasks = make(map[string]*DefinedTask)
+	}
+	f.Define(Task{Name: "top", Action: func(a *A) {}})
+	Main([]string{"top"})
+}
+
+func TestFailError_Error(t *testing.T) {
+	err := &FailError{Task: "test"}
+	if err.Error() != "task failed: test" {
+		t.Errorf("unexpected error message: %s", err.Error())
+	}
+}

--- a/trap_signals_test.go
+++ b/trap_signals_test.go
@@ -10,8 +10,10 @@ import (
 	"time"
 )
 
+const windows = "windows"
+
 func TestFlow_Main(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == windows {
 		t.Skip("skipping signal test on windows")
 	}
 
@@ -20,8 +22,14 @@ func TestFlow_Main(t *testing.T) {
 
 	var exitCode int32 = -1
 	osExit = func(code int) {
-		atomic.StoreInt32(&exitCode, int32(code))
+		atomic.StoreInt32(&exitCode, int32(code)) //nolint:gosec // G115: exit code is a small integer
 	}
+
+	ready := make(chan struct{})
+	trapSignalsHook = func() {
+		close(ready)
+	}
+	defer func() { trapSignalsHook = nil }()
 
 	f := &Flow{}
 	f.Define(Task{
@@ -37,8 +45,7 @@ func TestFlow_Main(t *testing.T) {
 	})
 
 	go func() {
-		// wait for Main to start and register signal handler
-		time.Sleep(100 * time.Millisecond)
+		<-ready
 		p, _ := os.FindProcess(os.Getpid())
 		if err := p.Signal(os.Interrupt); err != nil {
 			t.Errorf("failed to send signal: %v", err)
@@ -53,7 +60,7 @@ func TestFlow_Main(t *testing.T) {
 }
 
 func TestFlow_trapSignals(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == windows {
 		t.Skip("skipping signal test on windows")
 	}
 
@@ -62,7 +69,7 @@ func TestFlow_trapSignals(t *testing.T) {
 
 	var exitCode int32 = -1
 	osExit = func(code int) {
-		atomic.StoreInt32(&exitCode, int32(code))
+		atomic.StoreInt32(&exitCode, int32(code)) //nolint:gosec // G115: exit code is a small integer
 	}
 
 	f := &Flow{}
@@ -70,8 +77,15 @@ func TestFlow_trapSignals(t *testing.T) {
 	defer cancel()
 	done := make(chan struct{})
 
+	ready := make(chan struct{})
+	trapSignalsHook = func() {
+		close(ready)
+	}
+	defer func() { trapSignalsHook = nil }()
+
 	go f.trapSignals(ctx, cancel, io.Discard, done)
 
+	<-ready
 	p, _ := os.FindProcess(os.Getpid())
 
 	// first signal
@@ -106,18 +120,18 @@ func TestFlow_trapSignals(t *testing.T) {
 	close(done)
 }
 
-func TestMain_topLevel(t *testing.T) {
+func TestMain_topLevel(_ *testing.T) {
 	// Just to cover the top-level Main function
 	origOsExit := osExit
 	defer func() { osExit = origOsExit }()
-	osExit = func(code int) {}
+	osExit = func(_ int) {}
 
 	// Define a task in DefaultFlow
 	f := DefaultFlow
 	if f.tasks == nil {
 		f.tasks = make(map[string]*DefinedTask)
 	}
-	f.Define(Task{Name: "top", Action: func(a *A) {}})
+	f.Define(Task{Name: "top", Action: func(_ *A) {}})
 	Main([]string{"top"})
 }
 


### PR DESCRIPTION
This change enhances the security and reliability of the `goyek` task runner by improving how it handles termination signals and concurrent output logging in the `Main` function.

Key improvements:
- **Portable Termination Signals:** Added support for `SIGTERM` on Unix-like systems, ensuring graceful shutdown in containerized environments (e.g., Kubernetes/Docker).
- **Concurrency Safety:** Fixed a data race where the signal-handling goroutine and running tasks could concurrently write to the same output. `Main` now automatically wraps the output with a thread-safe `SyncWriter`.
- **Resource Management:** Fixed a potential goroutine and signal notification leak. The signal-trapping goroutine now correctly terminates when the task run is complete, and `signal.Stop` is called to release resources.
- **Improved Testing:** Abstracted `os.Exit` and refactored signal handling into a testable method, allowing robust verification of graceful shutdown and hard-exit paths.
- **Correct Exit Codes:** Fixed a bug where `Main` would return a success exit code (0) even if it was interrupted by a signal during a task's execution. It now correctly returns 1 (fail) as intended.

---
*PR created automatically by Jules for task [5822612279795887382](https://jules.google.com/task/5822612279795887382) started by @pellared*