### PR TITLE
Enhance signal handling and output synchronization in Flow.Main

### DIFF
--- a/flow.go
+++ b/flow.go
@@ -16,6 +16,8 @@ import (
 
 var osExit = os.Exit
 
+var trapSignalsHook = func(ready <-chan struct{}) {}
+
 // Flow is the root type of the package.
 // Use Register methods to register all tasks
 // and Run or Main method to execute provided tasks.
@@ -407,10 +409,14 @@ func (f *Flow) Main(args []string, opts ...Option) {
 	// trap Ctrl+C and call cancel on the context
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
+	handlerDone := make(chan struct{})
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, internal.TerminationSignals()...)
+	ready := make(chan struct{})
 	go func() {
+		defer close(handlerDone)
 		defer signal.Stop(c)
+		close(ready)
 		select {
 		case <-c: // first signal, cancel context
 			fmt.Fprintln(out, "first interrupt, graceful stop")
@@ -426,9 +432,11 @@ func (f *Flow) Main(args []string, opts ...Option) {
 		case <-done:
 		}
 	}()
+	trapSignalsHook(ready)
 
 	exitCode := f.main(ctx, args, opts...)
 	close(done)
+	<-handlerDone
 	osExit(exitCode)
 }
 

--- a/flow.go
+++ b/flow.go
@@ -8,11 +8,13 @@ import (
 	"os"
 	"os/signal"
 	"sort"
-
-	"github.com/goyek/goyek/v3/internal"
 	"strings"
 	"text/tabwriter"
+
+	"github.com/goyek/goyek/v3/internal"
 )
+
+var osExit = os.Exit
 
 // Flow is the root type of the package.
 // Use Register methods to register all tasks
@@ -420,14 +422,14 @@ func (f *Flow) Main(args []string, opts ...Option) {
 		select {
 		case <-c: // second signal, hard exit
 			fmt.Fprintln(out, "second interrupt, exit")
-			os.Exit(exitCodeFail)
+			osExit(exitCodeFail)
 		case <-done:
 		}
 	}()
 
 	exitCode := f.main(ctx, args, opts...)
 	close(done)
-	os.Exit(exitCode)
+	osExit(exitCode)
 }
 
 func (f *Flow) main(ctx context.Context, args []string, opts ...Option) int {
@@ -435,6 +437,9 @@ func (f *Flow) main(ctx context.Context, args []string, opts ...Option) int {
 	var ferr *FailError
 	if errors.As(err, &ferr) {
 		return exitCodeFail
+	}
+	if err == nil {
+		err = ctx.Err()
 	}
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return exitCodeFail

--- a/flow.go
+++ b/flow.go
@@ -16,7 +16,7 @@ import (
 
 var osExit = os.Exit
 
-var trapSignalsHook = func(ready <-chan struct{}) {}
+var trapSignalsHook = func(_ <-chan struct{}) {}
 
 // Flow is the root type of the package.
 // Use Register methods to register all tasks

--- a/flow.go
+++ b/flow.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"os/signal"
 	"sort"
+
+	"github.com/goyek/goyek/v3/internal"
 	"strings"
 	"text/tabwriter"
 )
@@ -377,7 +379,7 @@ const (
 // Main runs provided tasks and all their dependencies.
 // Each task is executed at most once.
 // It exits the current program when after the run is finished
-// or SIGINT interrupted the execution.
+// or termination signal interrupted the execution.
 //   - 0 exit code means that non of the tasks failed.
 //   - 1 exit code means that a task has failed or the execution was interrupted.
 //   - 2 exit code means that the input was invalid.
@@ -390,30 +392,41 @@ func Main(args []string, opts ...Option) {
 // Main runs provided tasks and all their dependencies.
 // Each task is executed at most once.
 // It exits the current program when after the run is finished
-// or SIGINT interrupted the execution.
+// or termination signal interrupted the execution.
 //   - 0 exit code means that non of the tasks failed.
 //   - 1 exit code means that a task has failed or the execution was interrupted.
 //   - 2 exit code means that the input was invalid.
 //
 // Calls [Usage] when invalid args are provided.
 func (f *Flow) Main(args []string, opts ...Option) {
-	out := f.Output()
+	out := internal.SyncWriter(f.Output())
+	f.SetOutput(out)
 
 	// trap Ctrl+C and call cancel on the context
 	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
+	signal.Notify(c, internal.TerminationSignals()...)
 	go func() {
-		<-c // first signal, cancel context
-		fmt.Fprintln(out, "first interrupt, graceful stop")
-		cancel()
+		defer signal.Stop(c)
+		select {
+		case <-c: // first signal, cancel context
+			fmt.Fprintln(out, "first interrupt, graceful stop")
+			cancel()
+		case <-done:
+			return
+		}
 
-		<-c // second signal, hard exit
-		fmt.Fprintln(out, "second interrupt, exit")
-		os.Exit(exitCodeFail)
+		select {
+		case <-c: // second signal, hard exit
+			fmt.Fprintln(out, "second interrupt, exit")
+			os.Exit(exitCodeFail)
+		case <-done:
+		}
 	}()
 
 	exitCode := f.main(ctx, args, opts...)
+	close(done)
 	os.Exit(exitCode)
 }
 

--- a/internal/signals.go
+++ b/internal/signals.go
@@ -1,0 +1,8 @@
+package internal
+
+import "os"
+
+// TerminationSignals returns the signals that should cause a graceful termination.
+func TerminationSignals() []os.Signal {
+	return terminationSignals()
+}

--- a/internal/signals_default.go
+++ b/internal/signals_default.go
@@ -1,0 +1,10 @@
+//go:build windows || plan9
+// +build windows plan9
+
+package internal
+
+import "os"
+
+func terminationSignals() []os.Signal {
+	return []os.Signal{os.Interrupt}
+}

--- a/internal/signals_test.go
+++ b/internal/signals_test.go
@@ -1,0 +1,39 @@
+package internal_test
+
+import (
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/goyek/goyek/v3/internal"
+)
+
+func TestTerminationSignals(t *testing.T) {
+	sigs := internal.TerminationSignals()
+
+	if len(sigs) == 0 {
+		t.Fatal("no termination signals returned")
+	}
+
+	hasInterrupt := false
+	for _, sig := range sigs {
+		if sig == os.Interrupt {
+			hasInterrupt = true
+			break
+		}
+	}
+	if !hasInterrupt {
+		t.Error("os.Interrupt missing from termination signals")
+	}
+
+	switch runtime.GOOS {
+	case "windows", "plan9":
+		if len(sigs) != 1 {
+			t.Errorf("expected 1 signal on %s, got %d", runtime.GOOS, len(sigs))
+		}
+	default:
+		if len(sigs) < 2 {
+			t.Errorf("expected at least 2 signals on %s, got %d", runtime.GOOS, len(sigs))
+		}
+	}
+}

--- a/internal/signals_unix.go
+++ b/internal/signals_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows && !plan9
+// +build !windows,!plan9
+
+package internal
+
+import (
+	"os"
+	"syscall"
+)
+
+func terminationSignals() []os.Signal {
+	return []os.Signal{os.Interrupt, syscall.SIGTERM}
+}

--- a/trap_signals_test.go
+++ b/trap_signals_test.go
@@ -1,0 +1,109 @@
+package goyek
+
+import (
+	"io"
+	"os"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+const windows = "windows"
+
+func TestFlow_Main_signal_graceful(t *testing.T) {
+	if runtime.GOOS == windows {
+		t.Skip("skipping signal test on windows")
+	}
+
+	oldOsExit := osExit
+	var exitCode int32 = -1
+	osExit = func(code int) {
+		atomic.StoreInt32(&exitCode, int32(code))
+	}
+	defer func() { osExit = oldOsExit }()
+
+	f := &Flow{}
+	f.SetOutput(io.Discard)
+
+	f.Define(Task{
+		Name: "sleep",
+		Action: func(a *A) {
+			p, _ := os.FindProcess(os.Getpid())
+			if err := p.Signal(os.Interrupt); err != nil {
+				t.Fatal(err)
+			}
+
+			select {
+			case <-a.Context().Done():
+			case <-time.After(5 * time.Second):
+				a.Error("should have been canceled")
+			}
+		},
+	})
+
+	f.Main([]string{"sleep"})
+
+	if got := atomic.LoadInt32(&exitCode); got != 1 {
+		t.Errorf("expected exit code 1, got %d", got)
+	}
+}
+
+func TestFlow_Main_signal_hard(t *testing.T) {
+	if runtime.GOOS == windows {
+		t.Skip("skipping signal test on windows")
+	}
+
+	oldOsExit := osExit
+	var exitCode int32 = -1
+	osExit = func(code int) {
+		atomic.StoreInt32(&exitCode, int32(code))
+	}
+	defer func() { osExit = oldOsExit }()
+
+	f := &Flow{}
+	f.SetOutput(io.Discard)
+
+	f.Define(Task{
+		Name: "sleep",
+		Action: func(a *A) {
+			p, _ := os.FindProcess(os.Getpid())
+			if err := p.Signal(os.Interrupt); err != nil {
+				t.Fatal(err)
+			}
+			time.Sleep(100 * time.Millisecond)
+			if err := p.Signal(os.Interrupt); err != nil {
+				t.Fatal(err)
+			}
+
+			select {
+			case <-a.Context().Done():
+			case <-time.After(5 * time.Second):
+				a.Error("should have been canceled")
+			}
+		},
+	})
+
+	f.Main([]string{"sleep"})
+
+	if got := atomic.LoadInt32(&exitCode); got != 1 {
+		t.Errorf("expected exit code 1, got %d", got)
+	}
+}
+
+func TestMain_topLevel(t *testing.T) {
+	// Just to cover the top-level Main wrapper
+	oldOsExit := osExit
+	osExit = func(code int) {}
+	defer func() { osExit = oldOsExit }()
+
+	Main(nil)
+}
+
+func TestFailError_Error(t *testing.T) {
+	err := &FailError{Task: "foo"}
+	want := "task failed: foo"
+	if got := err.Error(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/trap_signals_test.go
+++ b/trap_signals_test.go
@@ -19,9 +19,15 @@ func TestFlow_Main_signal_graceful(t *testing.T) {
 	oldOsExit := osExit
 	var exitCode int32 = -1
 	osExit = func(code int) {
-		atomic.StoreInt32(&exitCode, int32(code))
+		atomic.StoreInt32(&exitCode, int32(code)) //nolint:gosec // G115: exit code is a small integer
 	}
 	defer func() { osExit = oldOsExit }()
+
+	oldTrapSignalsHook := trapSignalsHook
+	trapSignalsHook = func(ready <-chan struct{}) {
+		<-ready
+	}
+	defer func() { trapSignalsHook = oldTrapSignalsHook }()
 
 	f := &Flow{}
 	f.SetOutput(io.Discard)
@@ -57,9 +63,15 @@ func TestFlow_Main_signal_hard(t *testing.T) {
 	oldOsExit := osExit
 	var exitCode int32 = -1
 	osExit = func(code int) {
-		atomic.StoreInt32(&exitCode, int32(code))
+		atomic.StoreInt32(&exitCode, int32(code)) //nolint:gosec // G115: exit code is a small integer
 	}
 	defer func() { osExit = oldOsExit }()
+
+	oldTrapSignalsHook := trapSignalsHook
+	trapSignalsHook = func(ready <-chan struct{}) {
+		<-ready
+	}
+	defer func() { trapSignalsHook = oldTrapSignalsHook }()
 
 	f := &Flow{}
 	f.SetOutput(io.Discard)
@@ -91,10 +103,10 @@ func TestFlow_Main_signal_hard(t *testing.T) {
 	}
 }
 
-func TestMain_topLevel(t *testing.T) {
+func TestMain_topLevel(_ *testing.T) {
 	// Just to cover the top-level Main wrapper
 	oldOsExit := osExit
-	osExit = func(code int) {}
+	osExit = func(_ int) {}
 	defer func() { osExit = oldOsExit }()
 
 	Main(nil)


### PR DESCRIPTION
I have enhanced the signal handling in `Flow.Main` to be more robust and secure. 

Key improvements:
- **Graceful Shutdown**: Added support for `SIGTERM` on Unix systems, ensuring tasks can be gracefully canceled by container orchestrators.
- **Data Race Prevention**: The output writer is now wrapped with `internal.SyncWriter` at the start of `Main`, preventing interleaved logs and potential data races when the signal handler goroutine writes to the output simultaneously with running tasks.
- **Resource Management**: Implemented a `done` channel and used `signal.Stop` to ensure the signal-handling goroutine is cleaned up after `Main` finishes, preventing goroutine and signal handler leaks.
- **Portability**: Introduced `internal.TerminationSignals()` to handle platform-specific termination signals correctly (including `SIGTERM` on Unix and `os.Interrupt` everywhere).

All tests passed, and I've added unit tests for the new internal signal utilities.

---
*PR created automatically by Jules for task [872961093149468893](https://jules.google.com/task/872961093149468893) started by @pellared*