### PR TITLE
Enhance signal handling and reliability in Flow.Main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 ## [Unreleased](https://github.com/goyek/goyek/compare/v3.0.1...HEAD)
 
 ### Added
+- Enhance signal handling in `Flow.Main` by adding `SIGTERM` support (CWE-730) and implementing a two-signal termination pattern for graceful shutdown.
 
 - Add safety checks to `A.Setenv` and `A.Chdir` to prevent their usage
   in parallel tasks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 ## [Unreleased](https://github.com/goyek/goyek/compare/v3.0.1...HEAD)
 
 ### Added
-- Enhance signal handling in `Flow.Main` by adding `SIGTERM` support (CWE-730) and implementing a two-signal termination pattern for graceful shutdown.
+
+- Enhance signal handling in `Flow.Main` by adding `SIGTERM` support
+  (CWE-730) and implementing a two-signal termination pattern for graceful
+  shutdown.
 
 - Add safety checks to `A.Setenv` and `A.Chdir` to prevent their usage
   in parallel tasks.

--- a/flow.go
+++ b/flow.go
@@ -10,6 +10,13 @@ import (
 	"sort"
 	"strings"
 	"text/tabwriter"
+
+	"github.com/goyek/goyek/v3/internal"
+)
+
+var (
+	osExit          = os.Exit
+	trapSignalsHook = func() {}
 )
 
 // Flow is the root type of the package.
@@ -377,8 +384,8 @@ const (
 // Main runs provided tasks and all their dependencies.
 // Each task is executed at most once.
 // It exits the current program when after the run is finished
-// or SIGINT interrupted the execution.
-//   - 0 exit code means that non of the tasks failed.
+// or a termination signal interrupted the execution.
+//   - 0 exit code means that none of the tasks failed.
 //   - 1 exit code means that a task has failed or the execution was interrupted.
 //   - 2 exit code means that the input was invalid.
 //
@@ -390,31 +397,49 @@ func Main(args []string, opts ...Option) {
 // Main runs provided tasks and all their dependencies.
 // Each task is executed at most once.
 // It exits the current program when after the run is finished
-// or SIGINT interrupted the execution.
-//   - 0 exit code means that non of the tasks failed.
+// or a termination signal interrupted the execution.
+//   - 0 exit code means that none of the tasks failed.
 //   - 1 exit code means that a task has failed or the execution was interrupted.
 //   - 2 exit code means that the input was invalid.
 //
 // Calls [Usage] when invalid args are provided.
 func (f *Flow) Main(args []string, opts ...Option) {
-	out := f.Output()
+	out := internal.SyncWriter(f.Output())
 
-	// trap Ctrl+C and call cancel on the context
+	// trap termination signals and call cancel on the context
 	ctx, cancel := context.WithCancel(context.Background())
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
+	signal.Notify(c, internal.TerminationSignals()...)
+	done := make(chan struct{})
+	handlerDone := make(chan struct{})
 	go func() {
-		<-c // first signal, cancel context
-		fmt.Fprintln(out, "first interrupt, graceful stop")
-		cancel()
+		defer close(handlerDone)
+		defer signal.Stop(c)
+		select {
+		case <-c: // first signal, cancel context
+			fmt.Fprintln(out, "first interrupt, graceful stop")
+			cancel()
+		case <-done:
+			return
+		}
 
-		<-c // second signal, hard exit
-		fmt.Fprintln(out, "second interrupt, exit")
-		os.Exit(exitCodeFail)
+		select {
+		case <-c: // second signal, hard exit
+			fmt.Fprintln(out, "second interrupt, exit")
+			osExit(exitCodeFail)
+		case <-done:
+		}
 	}()
+	trapSignalsHook()
 
 	exitCode := f.main(ctx, args, opts...)
-	os.Exit(exitCode)
+	close(done)
+	<-handlerDone
+
+	if ctx.Err() != nil {
+		exitCode = exitCodeFail
+	}
+	osExit(exitCode)
 }
 
 func (f *Flow) main(ctx context.Context, args []string, opts ...Option) int {

--- a/internal/signals_default.go
+++ b/internal/signals_default.go
@@ -1,0 +1,13 @@
+//go:build windows || plan9
+// +build windows plan9
+
+package internal
+
+import (
+	"os"
+)
+
+// TerminationSignals returns the signals that should cause a graceful termination.
+func TerminationSignals() []os.Signal {
+	return []os.Signal{os.Interrupt}
+}

--- a/internal/signals_test.go
+++ b/internal/signals_test.go
@@ -1,0 +1,25 @@
+package internal_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/goyek/goyek/v3/internal"
+)
+
+func TestTerminationSignals(t *testing.T) {
+	sigs := internal.TerminationSignals()
+	if len(sigs) == 0 {
+		t.Error("expected at least one signal")
+	}
+	foundInterrupt := false
+	for _, sig := range sigs {
+		if sig == os.Interrupt {
+			foundInterrupt = true
+			break
+		}
+	}
+	if !foundInterrupt {
+		t.Error("expected os.Interrupt in termination signals")
+	}
+}

--- a/internal/signals_unix.go
+++ b/internal/signals_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows && !plan9
+// +build !windows,!plan9
+
+package internal
+
+import (
+	"os"
+	"syscall"
+)
+
+// TerminationSignals returns the signals that should cause a graceful termination.
+func TerminationSignals() []os.Signal {
+	return []os.Signal{os.Interrupt, syscall.SIGTERM}
+}

--- a/trap_signals_test.go
+++ b/trap_signals_test.go
@@ -1,0 +1,132 @@
+package goyek
+
+import (
+	"io"
+	"os"
+	"runtime"
+	"sync"
+	"testing"
+)
+
+const windows = "windows"
+
+func TestFlow_Main_signal_graceful(t *testing.T) {
+	if runtime.GOOS == windows {
+		t.Skip("skipping on windows")
+	}
+
+	origOsExit := osExit
+	origTrapSignalsHook := trapSignalsHook
+	hookCalled := make(chan struct{})
+	trapSignalsHook = func() {
+		close(hookCalled)
+	}
+	defer func() {
+		osExit = origOsExit
+		trapSignalsHook = origTrapSignalsHook
+	}()
+
+	var mu sync.Mutex
+	var exitCode int
+	osExit = func(code int) {
+		mu.Lock()
+		defer mu.Unlock()
+		exitCode = code
+	}
+
+	f := &Flow{}
+	f.SetOutput(io.Discard)
+	f.Define(Task{
+		Name: "task",
+		Action: func(a *A) {
+			p, _ := os.FindProcess(os.Getpid())
+			if err := p.Signal(os.Interrupt); err != nil {
+				t.Error(err)
+			}
+			<-a.Context().Done()
+		},
+	})
+
+	doneCh := make(chan struct{})
+	go func() {
+		defer close(doneCh)
+		f.Main([]string{"task"})
+	}()
+	<-hookCalled
+
+	<-doneCh
+
+	mu.Lock()
+	defer mu.Unlock()
+	if exitCode != exitCodeFail {
+		t.Errorf("got exit code %d, want %d", exitCode, exitCodeFail)
+	}
+}
+
+func TestFlow_Main_signal_hard(t *testing.T) {
+	if runtime.GOOS == windows {
+		t.Skip("skipping on windows")
+	}
+
+	origOsExit := osExit
+	origTrapSignalsHook := trapSignalsHook
+	hookCalled := make(chan struct{})
+	trapSignalsHook = func() {
+		close(hookCalled)
+	}
+	defer func() {
+		osExit = origOsExit
+		trapSignalsHook = origTrapSignalsHook
+	}()
+
+	var mu sync.Mutex
+	var exitCode int
+	osExit = func(code int) {
+		mu.Lock()
+		defer mu.Unlock()
+		exitCode = code
+	}
+
+	f := &Flow{}
+	f.SetOutput(io.Discard)
+	f.Define(Task{
+		Name: "task",
+		Action: func(a *A) {
+			p, _ := os.FindProcess(os.Getpid())
+			if err := p.Signal(os.Interrupt); err != nil {
+				t.Error(err)
+			}
+			// Wait for the first signal to be handled
+			<-a.Context().Done()
+
+			// Send second signal for hard exit
+			if err := p.Signal(os.Interrupt); err != nil {
+				t.Error(err)
+			}
+			// The second signal should trigger osExit(1) in the goroutine
+		},
+	})
+
+	doneCh := make(chan struct{})
+	go func() {
+		defer close(doneCh)
+		f.Main([]string{"task"})
+	}()
+	<-hookCalled
+
+	<-doneCh
+
+	mu.Lock()
+	defer mu.Unlock()
+	if exitCode != exitCodeFail {
+		t.Errorf("got exit code %d, want %d", exitCode, exitCodeFail)
+	}
+}
+
+func TestFailError_Error(t *testing.T) {
+	err := &FailError{Task: "task"}
+	want := "task failed: task"
+	if got := err.Error(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/trap_signals_test.go
+++ b/trap_signals_test.go
@@ -63,6 +63,66 @@ func TestFlow_Main_signal_graceful(t *testing.T) {
 	}
 }
 
+func TestMain_signal_graceful(t *testing.T) {
+	if runtime.GOOS == windows {
+		t.Skip("skipping on windows")
+	}
+
+	origOsExit := osExit
+	origTrapSignalsHook := trapSignalsHook
+	hookCalled := make(chan struct{})
+	trapSignalsHook = func() {
+		close(hookCalled)
+	}
+	defer func() {
+		osExit = origOsExit
+		trapSignalsHook = origTrapSignalsHook
+	}()
+
+	var mu sync.Mutex
+	var exitCode int
+	osExit = func(code int) {
+		mu.Lock()
+		defer mu.Unlock()
+		exitCode = code
+	}
+
+	f := &Flow{}
+	f.SetOutput(io.Discard)
+	task := f.Define(Task{
+		Name: "task",
+		Action: func(a *A) {
+			p, _ := os.FindProcess(os.Getpid())
+			if err := p.Signal(os.Interrupt); err != nil {
+				t.Error(err)
+			}
+			<-a.Context().Done()
+		},
+	})
+	f.SetDefault(task)
+
+	origDefaultFlow := DefaultFlow
+	DefaultFlow = f
+	defer func() {
+		DefaultFlow = origDefaultFlow
+	}()
+
+	doneCh := make(chan struct{})
+	go func() {
+		defer close(doneCh)
+		Main(nil)
+	}()
+	<-hookCalled
+
+	<-doneCh
+
+	mu.Lock()
+	defer mu.Unlock()
+	if exitCode != exitCodeFail {
+		t.Errorf("got exit code %d, want %d", exitCode, exitCodeFail)
+	}
+}
+
 func TestFlow_Main_signal_hard(t *testing.T) {
 	if runtime.GOOS == windows {
 		t.Skip("skipping on windows")
@@ -93,6 +153,7 @@ func TestFlow_Main_signal_hard(t *testing.T) {
 		Name: "task",
 		Action: func(a *A) {
 			p, _ := os.FindProcess(os.Getpid())
+			// Send first signal
 			if err := p.Signal(os.Interrupt); err != nil {
 				t.Error(err)
 			}
@@ -100,8 +161,10 @@ func TestFlow_Main_signal_hard(t *testing.T) {
 			<-a.Context().Done()
 
 			// Send second signal for hard exit
-			if err := p.Signal(os.Interrupt); err != nil {
-				t.Error(err)
+			// Use a loop to increase the chance of it being caught by the second select
+			for i := 0; i < 10; i++ {
+				_ = p.Signal(os.Interrupt)
+				runtime.Gosched()
 			}
 			// The second signal should trigger osExit(1) in the goroutine
 		},
@@ -120,6 +183,48 @@ func TestFlow_Main_signal_hard(t *testing.T) {
 	defer mu.Unlock()
 	if exitCode != exitCodeFail {
 		t.Errorf("got exit code %d, want %d", exitCode, exitCodeFail)
+	}
+}
+
+func TestFlow_Main_pass(t *testing.T) {
+	origOsExit := osExit
+	origTrapSignalsHook := trapSignalsHook
+	hookCalled := make(chan struct{})
+	trapSignalsHook = func() {
+		close(hookCalled)
+	}
+	defer func() {
+		osExit = origOsExit
+		trapSignalsHook = origTrapSignalsHook
+	}()
+
+	var mu sync.Mutex
+	var exitCode int
+	osExit = func(code int) {
+		mu.Lock()
+		defer mu.Unlock()
+		exitCode = code
+	}
+
+	f := &Flow{}
+	f.SetOutput(io.Discard)
+	f.Define(Task{
+		Name: "task",
+	})
+
+	doneCh := make(chan struct{})
+	go func() {
+		defer close(doneCh)
+		f.Main([]string{"task"})
+	}()
+	<-hookCalled
+
+	<-doneCh
+
+	mu.Lock()
+	defer mu.Unlock()
+	if exitCode != exitCodePass {
+		t.Errorf("got exit code %d, want %d", exitCode, exitCodePass)
 	}
 }
 

--- a/trap_signals_test.go
+++ b/trap_signals_test.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"sync"
 	"testing"
+	"time"
 )
 
 const windows = "windows"
@@ -162,15 +163,15 @@ func TestFlow_Main_signal_hard(t *testing.T) {
 
 			// Send second signal for hard exit
 			// Use a loop to increase the chance of it being caught by the second select
-			for i := 0; i < 10; i++ {
+			for i := 0; i < 100; i++ {
+				_ = p.Signal(os.Interrupt)
+				time.Sleep(10 * time.Millisecond)
 				mu.Lock()
 				done := exitCode != 0
 				mu.Unlock()
 				if done {
-					break
+					return
 				}
-				_ = p.Signal(os.Interrupt)
-				runtime.Gosched()
 			}
 		},
 	})

--- a/trap_signals_test.go
+++ b/trap_signals_test.go
@@ -163,10 +163,15 @@ func TestFlow_Main_signal_hard(t *testing.T) {
 			// Send second signal for hard exit
 			// Use a loop to increase the chance of it being caught by the second select
 			for i := 0; i < 10; i++ {
+				mu.Lock()
+				done := exitCode != 0
+				mu.Unlock()
+				if done {
+					break
+				}
 				_ = p.Signal(os.Interrupt)
 				runtime.Gosched()
 			}
-			// The second signal should trigger osExit(1) in the goroutine
 		},
 	})
 


### PR DESCRIPTION
This change enhances the security and reliability of goyek by improving its signal handling logic. 

Key improvements:
- **SIGTERM Support**: On Unix systems, `SIGTERM` is now handled in addition to `SIGINT`. This is crucial for graceful shutdowns in orchestrated environments like Kubernetes.
- **Graceful Shutdown**: The first termination signal cancels the execution context, allowing tasks to perform cleanups. A second signal triggers an immediate exit.
- **Thread-Safety**: The output writer is now synchronized during signal handling to prevent data races and interleaved logs when the signal handler prints to the console while tasks are still running.
- **Testability**: `os.Exit` is abstracted, and a synchronization hook is added, enabling robust unit testing of signal trapping without terminating the test process.
- **Cross-Platform**: Portable signal definitions are provided via build tags, maintaining compatibility with Go 1.16.

Comprehensive tests and race detector verification ensure the stability of these changes.

---
*PR created automatically by Jules for task [3026578541577458404](https://jules.google.com/task/3026578541577458404) started by @pellared*