### PR TITLE
Add support for SIGTERM and improve signal handling in Main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 
 ### Added
 
+- Add support for graceful shutdown via `SIGTERM` and other termination signals.
 - Add safety checks to `A.Setenv` and `A.Chdir` to prevent their usage
   in parallel tasks.
 

--- a/flow.go
+++ b/flow.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 	"strings"
 	"text/tabwriter"
+
+	"github.com/goyek/goyek/v3/internal"
 )
 
 // Flow is the root type of the package.
@@ -374,10 +376,14 @@ const (
 	exitCodeInvalid = 2
 )
 
+var osExit = os.Exit
+
+var trapSignalsHook = func() {}
+
 // Main runs provided tasks and all their dependencies.
 // Each task is executed at most once.
 // It exits the current program when after the run is finished
-// or SIGINT interrupted the execution.
+// or a termination signal interrupted the execution.
 //   - 0 exit code means that non of the tasks failed.
 //   - 1 exit code means that a task has failed or the execution was interrupted.
 //   - 2 exit code means that the input was invalid.
@@ -390,40 +396,56 @@ func Main(args []string, opts ...Option) {
 // Main runs provided tasks and all their dependencies.
 // Each task is executed at most once.
 // It exits the current program when after the run is finished
-// or SIGINT interrupted the execution.
+// or a termination signal interrupted the execution.
 //   - 0 exit code means that non of the tasks failed.
 //   - 1 exit code means that a task has failed or the execution was interrupted.
 //   - 2 exit code means that the input was invalid.
 //
 // Calls [Usage] when invalid args are provided.
 func (f *Flow) Main(args []string, opts ...Option) {
-	out := f.Output()
+	out := internal.SyncWriter(f.Output())
 
 	// trap Ctrl+C and call cancel on the context
 	ctx, cancel := context.WithCancel(context.Background())
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
+	signal.Notify(c, internal.TerminationSignals()...)
+	trapSignalsHook()
+	done := make(chan struct{})
+	handlerDone := make(chan struct{})
 	go func() {
-		<-c // first signal, cancel context
-		fmt.Fprintln(out, "first interrupt, graceful stop")
-		cancel()
+		defer close(handlerDone)
+		defer signal.Stop(c)
 
-		<-c // second signal, hard exit
-		fmt.Fprintln(out, "second interrupt, exit")
-		os.Exit(exitCodeFail)
+		select {
+		case <-c: // first signal, cancel context
+			fmt.Fprintln(out, "first interrupt, graceful stop")
+			cancel()
+		case <-done:
+			return
+		}
+
+		select {
+		case <-c: // second signal, hard exit
+			fmt.Fprintln(out, "second interrupt, exit")
+			osExit(exitCodeFail)
+		case <-done:
+			return
+		}
 	}()
 
 	exitCode := f.main(ctx, args, opts...)
-	os.Exit(exitCode)
+	close(done)
+	<-handlerDone
+	osExit(exitCode)
 }
 
 func (f *Flow) main(ctx context.Context, args []string, opts ...Option) int {
 	err := f.Execute(ctx, args, opts...)
-	var ferr *FailError
-	if errors.As(err, &ferr) {
+	if ctx.Err() != nil {
 		return exitCodeFail
 	}
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+	var ferr *FailError
+	if errors.As(err, &ferr) {
 		return exitCodeFail
 	}
 	if err != nil {

--- a/internal/signals_default.go
+++ b/internal/signals_default.go
@@ -1,0 +1,13 @@
+//go:build windows || plan9
+// +build windows plan9
+
+package internal
+
+import (
+	"os"
+)
+
+// TerminationSignals returns the signals that should cause the program to terminate.
+func TerminationSignals() []os.Signal {
+	return []os.Signal{os.Interrupt}
+}

--- a/internal/signals_test.go
+++ b/internal/signals_test.go
@@ -1,0 +1,26 @@
+package internal_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/goyek/goyek/v3/internal"
+)
+
+func TestTerminationSignals(t *testing.T) {
+	sigs := internal.TerminationSignals()
+	if len(sigs) == 0 {
+		t.Fatal("no signals returned")
+	}
+
+	foundInterrupt := false
+	for _, sig := range sigs {
+		if sig == os.Interrupt {
+			foundInterrupt = true
+			break
+		}
+	}
+	if !foundInterrupt {
+		t.Error("os.Interrupt not found in termination signals")
+	}
+}

--- a/internal/signals_unix.go
+++ b/internal/signals_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows && !plan9
+// +build !windows,!plan9
+
+package internal
+
+import (
+	"os"
+	"syscall"
+)
+
+// TerminationSignals returns the signals that should cause the program to terminate.
+func TerminationSignals() []os.Signal {
+	return []os.Signal{os.Interrupt, syscall.SIGTERM}
+}

--- a/trap_signals_test.go
+++ b/trap_signals_test.go
@@ -9,8 +9,10 @@ import (
 	"time"
 )
 
+const windows = "windows"
+
 func TestFlow_Main_signal_graceful(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == windows {
 		t.Skip("skipping signal test on windows")
 	}
 
@@ -72,7 +74,7 @@ func TestFlow_Main_signal_graceful(t *testing.T) {
 }
 
 func TestFlow_Main_signal_hard(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == windows {
 		t.Skip("skipping signal test on windows")
 	}
 
@@ -97,7 +99,7 @@ func TestFlow_Main_signal_hard(t *testing.T) {
 	f.SetOutput(io.Discard)
 	f.Define(Task{
 		Name: "task",
-		Action: func(a *A) {
+		Action: func(_ *A) {
 			select {} // block forever
 		},
 	})
@@ -134,7 +136,7 @@ func TestFlow_Main_signal_hard(t *testing.T) {
 }
 
 func TestMain_signal_graceful(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == windows {
 		t.Skip("skipping signal test on windows")
 	}
 

--- a/trap_signals_test.go
+++ b/trap_signals_test.go
@@ -1,0 +1,218 @@
+package goyek
+
+import (
+	"io"
+	"os"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestFlow_Main_signal_graceful(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping signal test on windows")
+	}
+
+	origOsExit := osExit
+	defer func() { osExit = origOsExit }()
+	var exitCode int
+	var mu sync.Mutex
+	osExit = func(code int) {
+		mu.Lock()
+		exitCode = code
+		mu.Unlock()
+	}
+
+	origTrapSignalsHook := trapSignalsHook
+	defer func() { trapSignalsHook = origTrapSignalsHook }()
+	trapSignalsHookCalled := make(chan struct{})
+	trapSignalsHook = func() {
+		close(trapSignalsHookCalled)
+	}
+
+	f := &Flow{}
+	f.SetOutput(io.Discard)
+	var actionCalled bool
+	f.Define(Task{
+		Name: "task",
+		Action: func(a *A) {
+			actionCalled = true
+			<-a.Context().Done()
+		},
+	})
+
+	doneCh := make(chan struct{})
+	go func() {
+		f.Main([]string{"task"})
+		close(doneCh)
+	}()
+
+	<-trapSignalsHookCalled
+	p, _ := os.FindProcess(os.Getpid())
+	if err := p.Signal(os.Interrupt); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-doneCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for Main to finish")
+	}
+
+	if !actionCalled {
+		t.Error("action was not called")
+	}
+	mu.Lock()
+	gotExitCode := exitCode
+	mu.Unlock()
+	if gotExitCode != exitCodeFail {
+		t.Errorf("got exit code %d, want %d", gotExitCode, exitCodeFail)
+	}
+}
+
+func TestFlow_Main_signal_hard(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping signal test on windows")
+	}
+
+	origOsExit := osExit
+	defer func() { osExit = origOsExit }()
+	var exitCode int
+	var mu sync.Mutex
+	osExit = func(code int) {
+		mu.Lock()
+		exitCode = code
+		mu.Unlock()
+	}
+
+	origTrapSignalsHook := trapSignalsHook
+	defer func() { trapSignalsHook = origTrapSignalsHook }()
+	trapSignalsHookCalled := make(chan struct{})
+	trapSignalsHook = func() {
+		close(trapSignalsHookCalled)
+	}
+
+	f := &Flow{}
+	f.SetOutput(io.Discard)
+	f.Define(Task{
+		Name: "task",
+		Action: func(a *A) {
+			select {} // block forever
+		},
+	})
+
+	go func() {
+		f.Main([]string{"task"})
+	}()
+
+	<-trapSignalsHookCalled
+	p, _ := os.FindProcess(os.Getpid())
+	if err := p.Signal(os.Interrupt); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait a bit and send second signal
+	time.Sleep(100 * time.Millisecond)
+
+	// We need to loop because we want to make sure the second signal is caught
+	// by the second select in the signal handler.
+	for i := 0; i < 10; i++ {
+		mu.Lock()
+		gotExitCode := exitCode
+		mu.Unlock()
+		if gotExitCode == exitCodeFail {
+			return
+		}
+		if err := p.Signal(os.Interrupt); err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	t.Fatal("Main did not exit with failure after two interrupts")
+}
+
+func TestMain_signal_graceful(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping signal test on windows")
+	}
+
+	origOsExit := osExit
+	defer func() { osExit = origOsExit }()
+	var exitCode int
+	var mu sync.Mutex
+	osExit = func(code int) {
+		mu.Lock()
+		exitCode = code
+		mu.Unlock()
+	}
+
+	origTrapSignalsHook := trapSignalsHook
+	defer func() { trapSignalsHook = origTrapSignalsHook }()
+	trapSignalsHookCalled := make(chan struct{})
+	trapSignalsHook = func() {
+		close(trapSignalsHookCalled)
+	}
+
+	origDefaultFlow := DefaultFlow
+	defer func() { DefaultFlow = origDefaultFlow }()
+	DefaultFlow = &Flow{}
+	DefaultFlow.SetOutput(io.Discard)
+	DefaultFlow.Define(Task{
+		Name: "task",
+		Action: func(a *A) {
+			<-a.Context().Done()
+		},
+	})
+
+	doneCh := make(chan struct{})
+	go func() {
+		Main([]string{"task"})
+		close(doneCh)
+	}()
+
+	<-trapSignalsHookCalled
+	p, _ := os.FindProcess(os.Getpid())
+	if err := p.Signal(os.Interrupt); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-doneCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for Main to finish")
+	}
+
+	mu.Lock()
+	gotExitCode := exitCode
+	mu.Unlock()
+	if gotExitCode != exitCodeFail {
+		t.Errorf("got exit code %d, want %d", gotExitCode, exitCodeFail)
+	}
+}
+
+func TestFlow_Main_pass(t *testing.T) {
+	origOsExit := osExit
+	defer func() { osExit = origOsExit }()
+	var exitCode int
+	var mu sync.Mutex
+	osExit = func(code int) {
+		mu.Lock()
+		exitCode = code
+		mu.Unlock()
+	}
+
+	f := &Flow{}
+	f.SetOutput(io.Discard)
+	f.Define(Task{Name: "task"})
+
+	f.Main([]string{"task"})
+
+	mu.Lock()
+	gotExitCode := exitCode
+	mu.Unlock()
+	if gotExitCode != exitCodePass {
+		t.Errorf("got exit code %d, want %d", gotExitCode, exitCodePass)
+	}
+}


### PR DESCRIPTION
The `Main` function in `goyek` previously only trapped `os.Interrupt` (SIGINT). This enhancement adds support for `SIGTERM`, which is crucial for graceful shutdowns in containerized environments like Docker and Kubernetes.

The signal handling logic was refactored to:
1. Support portable termination signals (SIGINT and SIGTERM on Unix, SIGINT on Windows/Plan9).
2. Implement a two-stage signal handler: the first signal cancels the context (graceful stop), and the second signal forces an immediate exit.
3. Ensure thread-safety of the output writer in `Main` using `internal.SyncWriter`.
4. Improve testability by abstracting `os.Exit` and adding a synchronization hook for tests.
5. Provide comprehensive integration tests in `trap_signals_test.go`.

These changes make `goyek` more robust and better suited for modern deployment pipelines.

---
*PR created automatically by Jules for task [8874954911626005952](https://jules.google.com/task/8874954911626005952) started by @pellared*