### PR TITLE
Add SIGTERM support and improve signal handling robustness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 
 ### Added
 
+- Add support for SIGTERM as a termination signal in `Flow.Main`.
 - Add safety checks to `A.Setenv` and `A.Chdir` to prevent their usage
   in parallel tasks.
 

--- a/flow.go
+++ b/flow.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 	"strings"
 	"text/tabwriter"
+
+	"github.com/goyek/goyek/v3/internal"
 )
 
 // Flow is the root type of the package.
@@ -374,10 +376,15 @@ const (
 	exitCodeInvalid = 2
 )
 
+var (
+	osExit          = os.Exit
+	trapSignalsHook func() // used for testing
+)
+
 // Main runs provided tasks and all their dependencies.
 // Each task is executed at most once.
 // It exits the current program when after the run is finished
-// or SIGINT interrupted the execution.
+// or termination signals interrupted the execution.
 //   - 0 exit code means that non of the tasks failed.
 //   - 1 exit code means that a task has failed or the execution was interrupted.
 //   - 2 exit code means that the input was invalid.
@@ -390,31 +397,51 @@ func Main(args []string, opts ...Option) {
 // Main runs provided tasks and all their dependencies.
 // Each task is executed at most once.
 // It exits the current program when after the run is finished
-// or SIGINT interrupted the execution.
+// or termination signals interrupted the execution.
 //   - 0 exit code means that non of the tasks failed.
 //   - 1 exit code means that a task has failed or the execution was interrupted.
 //   - 2 exit code means that the input was invalid.
 //
 // Calls [Usage] when invalid args are provided.
 func (f *Flow) Main(args []string, opts ...Option) {
-	out := f.Output()
+	out := internal.SyncWriter(f.Output())
 
-	// trap Ctrl+C and call cancel on the context
+	// trap termination signals and call cancel on the context
 	ctx, cancel := context.WithCancel(context.Background())
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
+	signal.Notify(c, internal.TerminationSignals()...)
+	done := make(chan struct{})
+	handlerDone := make(chan struct{})
 	go func() {
-		<-c // first signal, cancel context
-		fmt.Fprintln(out, "first interrupt, graceful stop")
-		cancel()
+		defer close(handlerDone)
+		defer signal.Stop(c)
 
-		<-c // second signal, hard exit
-		fmt.Fprintln(out, "second interrupt, exit")
-		os.Exit(exitCodeFail)
+		if trapSignalsHook != nil {
+			trapSignalsHook()
+		}
+
+		select {
+		case <-c:
+			// first signal, cancel context
+			fmt.Fprintln(out, "first termination signal, graceful stop")
+			cancel()
+		case <-done:
+			return
+		}
+
+		select {
+		case <-c:
+			// second signal, hard exit
+			fmt.Fprintln(out, "second termination signal, exit")
+			osExit(exitCodeFail)
+		case <-done:
+		}
 	}()
 
 	exitCode := f.main(ctx, args, opts...)
-	os.Exit(exitCode)
+	close(done)
+	<-handlerDone
+	osExit(exitCode)
 }
 
 func (f *Flow) main(ctx context.Context, args []string, opts ...Option) int {
@@ -423,7 +450,7 @@ func (f *Flow) main(ctx context.Context, args []string, opts ...Option) int {
 	if errors.As(err, &ferr) {
 		return exitCodeFail
 	}
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || ctx.Err() != nil {
 		return exitCodeFail
 	}
 	if err != nil {

--- a/flow.go
+++ b/flow.go
@@ -435,6 +435,16 @@ func (f *Flow) Main(args []string, opts ...Option) {
 			fmt.Fprintln(out, "second termination signal, exit")
 			osExit(exitCodeFail)
 		case <-done:
+			return
+		}
+
+		// consume any extra signals during tests
+		for {
+			select {
+			case <-c:
+			case <-done:
+				return
+			}
 		}
 	}()
 

--- a/flow_main_test.go
+++ b/flow_main_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestFlow_main(t *testing.T) {
@@ -63,4 +64,124 @@ func Test_main_usage(t *testing.T) {
 	if !called {
 		t.Error("usage should be called for invalid input")
 	}
+}
+
+func Test_main_deadline(t *testing.T) {
+	flow := &Flow{}
+	flow.SetOutput(io.Discard)
+	flow.Define(Task{Name: "task", Action: func(a *A) {
+		<-a.Context().Done()
+	}})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	got := flow.main(ctx, []string{"task"})
+	if got != 1 {
+		t.Errorf("expected exit code 1 for deadline exceeded, got %d", got)
+	}
+}
+
+func TestFailError_Error(t *testing.T) {
+	err := &FailError{Task: "my-task"}
+	got := err.Error()
+	want := "task failed: my-task"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestExecute_package(t *testing.T) {
+	orig := DefaultFlow
+	defer func() { DefaultFlow = orig }()
+	DefaultFlow = &Flow{}
+	Define(Task{Name: "task"})
+	err := Execute(context.Background(), []string{"task"})
+	if err != nil {
+		t.Errorf("expected nil err, got %v", err)
+	}
+}
+
+func TestMain_package(t *testing.T) {
+	orig := DefaultFlow
+	defer func() { DefaultFlow = orig }()
+	DefaultFlow = &Flow{}
+	Define(Task{Name: "task"})
+
+	restoreOsExit := osExit
+	defer func() { osExit = restoreOsExit }()
+	osExit = func(code int) {}
+
+	Main([]string{"task"})
+}
+
+func TestPrint_package(t *testing.T) {
+	orig := DefaultFlow
+	defer func() { DefaultFlow = orig }()
+	DefaultFlow = &Flow{}
+	Define(Task{Name: "task", Usage: "usage"})
+	Print()
+}
+
+func TestTasks_package(t *testing.T) {
+	orig := DefaultFlow
+	defer func() { DefaultFlow = orig }()
+	DefaultFlow = &Flow{}
+	Define(Task{Name: "task"})
+	tasks := Tasks()
+	if len(tasks) != 1 {
+		t.Errorf("expected 1 task, got %d", len(tasks))
+	}
+}
+
+func TestOutput_package(t *testing.T) {
+	orig := DefaultFlow
+	defer func() { DefaultFlow = orig }()
+	DefaultFlow = &Flow{}
+	SetOutput(io.Discard)
+	if Output() != io.Discard {
+		t.Error("Output() should return io.Discard")
+	}
+}
+
+func TestLogger_package(t *testing.T) {
+	orig := DefaultFlow
+	defer func() { DefaultFlow = orig }()
+	DefaultFlow = &Flow{}
+	l := &FmtLogger{}
+	SetLogger(l)
+	if GetLogger() != l {
+		t.Error("GetLogger() should return l")
+	}
+}
+
+func TestUsage_package(t *testing.T) {
+	orig := DefaultFlow
+	defer func() { DefaultFlow = orig }()
+	DefaultFlow = &Flow{}
+	called := false
+	SetUsage(func() { called = true })
+	Usage()()
+	if !called {
+		t.Error("Usage should be called")
+	}
+}
+
+func TestDefault_package(t *testing.T) {
+	orig := DefaultFlow
+	defer func() { DefaultFlow = orig }()
+	DefaultFlow = &Flow{}
+	task := Define(Task{Name: "task"})
+	SetDefault(task)
+	if Default() != task {
+		t.Error("Default() should return task")
+	}
+}
+
+func TestUse_package(t *testing.T) {
+	orig := DefaultFlow
+	defer func() { DefaultFlow = orig }()
+	DefaultFlow = &Flow{}
+	Use(func(r Runner) Runner { return r })
+	UseExecutor(func(e Executor) Executor { return e })
 }

--- a/flow_main_test.go
+++ b/flow_main_test.go
@@ -102,7 +102,7 @@ func TestExecute_package(t *testing.T) {
 	}
 }
 
-func TestMain_package(t *testing.T) {
+func TestMain_package(_ *testing.T) {
 	orig := DefaultFlow
 	defer func() { DefaultFlow = orig }()
 	DefaultFlow = &Flow{}
@@ -110,12 +110,12 @@ func TestMain_package(t *testing.T) {
 
 	restoreOsExit := osExit
 	defer func() { osExit = restoreOsExit }()
-	osExit = func(code int) {}
+	osExit = func(_ int) {}
 
 	Main([]string{"task"})
 }
 
-func TestPrint_package(t *testing.T) {
+func TestPrint_package(_ *testing.T) {
 	orig := DefaultFlow
 	defer func() { DefaultFlow = orig }()
 	DefaultFlow = &Flow{}
@@ -178,7 +178,7 @@ func TestDefault_package(t *testing.T) {
 	}
 }
 
-func TestUse_package(t *testing.T) {
+func TestUse_package(_ *testing.T) {
 	orig := DefaultFlow
 	defer func() { DefaultFlow = orig }()
 	DefaultFlow = &Flow{}

--- a/internal/signals.go
+++ b/internal/signals.go
@@ -1,0 +1,8 @@
+package internal
+
+import "os"
+
+// TerminationSignals returns the signals that should trigger a graceful shutdown.
+func TerminationSignals() []os.Signal {
+	return terminationSignals()
+}

--- a/internal/signals_default.go
+++ b/internal/signals_default.go
@@ -1,0 +1,10 @@
+//go:build windows || plan9
+// +build windows plan9
+
+package internal
+
+import "os"
+
+func terminationSignals() []os.Signal {
+	return []os.Signal{os.Interrupt}
+}

--- a/internal/signals_test.go
+++ b/internal/signals_test.go
@@ -1,0 +1,37 @@
+package internal
+
+import (
+	"os"
+	"runtime"
+	"testing"
+)
+
+func TestTerminationSignals(t *testing.T) {
+	sigs := TerminationSignals()
+
+	if len(sigs) == 0 {
+		t.Fatal("TerminationSignals() returned no signals")
+	}
+
+	hasInterrupt := false
+	for _, sig := range sigs {
+		if sig == os.Interrupt {
+			hasInterrupt = true
+			break
+		}
+	}
+	if !hasInterrupt {
+		t.Error("TerminationSignals() should include os.Interrupt")
+	}
+
+	switch runtime.GOOS {
+	case "windows", "plan9":
+		if len(sigs) != 1 {
+			t.Errorf("expected 1 signal on %s, got %d", runtime.GOOS, len(sigs))
+		}
+	default:
+		if len(sigs) < 2 {
+			t.Errorf("expected at least 2 signals on %s, got %d", runtime.GOOS, len(sigs))
+		}
+	}
+}

--- a/internal/signals_unix.go
+++ b/internal/signals_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows && !plan9
+// +build !windows,!plan9
+
+package internal
+
+import (
+	"os"
+	"syscall"
+)
+
+func terminationSignals() []os.Signal {
+	return []os.Signal{os.Interrupt, syscall.SIGTERM}
+}

--- a/trap_signals_test.go
+++ b/trap_signals_test.go
@@ -81,14 +81,16 @@ func TestFlow_Main_signal_hard(t *testing.T) {
 	hookCalled := make(chan struct{})
 	trapSignalsHook = func() { close(hookCalled) }
 
+	taskFinished := make(chan struct{})
 	f := &Flow{}
 	f.SetOutput(io.Discard)
 	f.Define(Task{
 		Name: "task",
 		Action: func(a *A) {
 			<-a.Context().Done()
-			// Hang to allow second signal
-			select {}
+			// Return after a short delay to allow second signal to be caught
+			time.Sleep(100 * time.Millisecond)
+			close(taskFinished)
 		},
 	})
 
@@ -100,25 +102,31 @@ func TestFlow_Main_signal_hard(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Wait for the hard exit
+	// Wait a bit for the first signal to be processed
+	time.Sleep(20 * time.Millisecond)
+
+	if err := p.Signal(os.Interrupt); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for the hard exit to be recorded
 	var got int
 	for i := 0; i < 100; i++ {
-		runtime.Gosched()
-		time.Sleep(10 * time.Millisecond)
-		if err := p.Signal(os.Interrupt); err != nil {
-			t.Fatal(err)
-		}
 		mu.Lock()
 		got = exitCode
 		mu.Unlock()
 		if got == 1 {
 			break
 		}
+		time.Sleep(10 * time.Millisecond)
 	}
 
 	if got != 1 {
 		t.Errorf("expected exit code 1, got %d", got)
 	}
+
+	// Ensure the task finished and Main can return
+	<-taskFinished
 }
 
 func TestFlow_Main_pass(t *testing.T) {
@@ -178,6 +186,69 @@ func TestMain_signal_graceful(t *testing.T) {
 	p, _ := os.FindProcess(os.Getpid())
 	if err := p.Signal(os.Interrupt); err != nil {
 		t.Fatal(err)
+	}
+
+	<-doneCh
+	mu.Lock()
+	got := exitCode
+	mu.Unlock()
+	if got != 1 {
+		t.Errorf("expected exit code 1, got %d", got)
+	}
+}
+
+func TestFlow_Main_extra_signals(t *testing.T) {
+	if runtime.GOOS == windows {
+		t.Skip("skipping on windows")
+	}
+
+	restoreOsExit := osExit
+	defer func() { osExit = restoreOsExit }()
+	var mu sync.Mutex
+	var exitCode int
+	osExit = func(code int) {
+		mu.Lock()
+		defer mu.Unlock()
+		exitCode = code
+	}
+
+	restoreTrapSignalsHook := trapSignalsHook
+	defer func() { trapSignalsHook = restoreTrapSignalsHook }()
+	hookCalled := make(chan struct{})
+	trapSignalsHook = func() { close(hookCalled) }
+
+	f := &Flow{}
+	f.SetOutput(io.Discard)
+	f.Define(Task{
+		Name: "task",
+		Action: func(a *A) {
+			<-a.Context().Done()
+			// Hang to allow extra signals
+			time.Sleep(150 * time.Millisecond)
+		},
+	})
+
+	doneCh := make(chan struct{})
+	go func() {
+		f.Main([]string{"task"})
+		close(doneCh)
+	}()
+
+	<-hookCalled
+	p, _ := os.FindProcess(os.Getpid())
+
+	// First signal: graceful stop
+	_ = p.Signal(os.Interrupt)
+	time.Sleep(20 * time.Millisecond)
+
+	// Second signal: hard exit
+	_ = p.Signal(os.Interrupt)
+	time.Sleep(20 * time.Millisecond)
+
+	// Extra signals: should be consumed by the loop
+	for i := 0; i < 5; i++ {
+		_ = p.Signal(os.Interrupt)
+		time.Sleep(10 * time.Millisecond)
 	}
 
 	<-doneCh

--- a/trap_signals_test.go
+++ b/trap_signals_test.go
@@ -94,7 +94,11 @@ func TestFlow_Main_signal_hard(t *testing.T) {
 		},
 	})
 
-	go f.Main([]string{"task"})
+	doneCh := make(chan struct{})
+	go func() {
+		f.Main([]string{"task"})
+		close(doneCh)
+	}()
 
 	<-hookCalled
 	p, _ := os.FindProcess(os.Getpid())
@@ -127,13 +131,19 @@ func TestFlow_Main_signal_hard(t *testing.T) {
 
 	// Ensure the task finished and Main can return
 	<-taskFinished
+	<-doneCh
 }
 
 func TestFlow_Main_pass(t *testing.T) {
 	restoreOsExit := osExit
 	defer func() { osExit = restoreOsExit }()
+	var mu sync.Mutex
 	var exitCode int
-	osExit = func(code int) { exitCode = code }
+	osExit = func(code int) {
+		mu.Lock()
+		defer mu.Unlock()
+		exitCode = code
+	}
 
 	f := &Flow{}
 	f.SetOutput(io.Discard)
@@ -141,8 +151,11 @@ func TestFlow_Main_pass(t *testing.T) {
 
 	f.Main([]string{"task"})
 
-	if exitCode != 0 {
-		t.Errorf("expected exit code 0, got %d", exitCode)
+	mu.Lock()
+	got := exitCode
+	mu.Unlock()
+	if got != 0 {
+		t.Errorf("expected exit code 0, got %d", got)
 	}
 }
 

--- a/trap_signals_test.go
+++ b/trap_signals_test.go
@@ -9,8 +9,10 @@ import (
 	"time"
 )
 
+const windows = "windows"
+
 func TestFlow_Main_signal_graceful(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == windows {
 		t.Skip("skipping on windows")
 	}
 
@@ -56,7 +58,7 @@ func TestFlow_Main_signal_graceful(t *testing.T) {
 }
 
 func TestFlow_Main_signal_hard(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == windows {
 		t.Skip("skipping on windows")
 	}
 
@@ -98,19 +100,22 @@ func TestFlow_Main_signal_hard(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Wait for the first signal to be processed
-	time.Sleep(100 * time.Millisecond)
-
-	if err := p.Signal(os.Interrupt); err != nil {
-		t.Fatal(err)
+	// Wait for the first signal to be processed and then send the second one repeatedly
+	var got int
+	for i := 0; i < 100; i++ {
+		time.Sleep(10 * time.Millisecond)
+		if err := p.Signal(os.Interrupt); err != nil {
+			t.Fatal(err)
+		}
+		mu.Lock()
+		got = exitCode
+		mu.Unlock()
+		if got == 1 {
+			break
+		}
+		runtime.Gosched()
 	}
 
-	// Give it some time to call osExit
-	time.Sleep(100 * time.Millisecond)
-
-	mu.Lock()
-	got := exitCode
-	mu.Unlock()
 	if got != 1 {
 		t.Errorf("expected exit code 1, got %d", got)
 	}
@@ -134,7 +139,7 @@ func TestFlow_Main_pass(t *testing.T) {
 }
 
 func TestMain_signal_graceful(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == windows {
 		t.Skip("skipping on windows")
 	}
 

--- a/trap_signals_test.go
+++ b/trap_signals_test.go
@@ -18,8 +18,13 @@ func TestFlow_Main_signal_graceful(t *testing.T) {
 
 	restoreOsExit := osExit
 	defer func() { osExit = restoreOsExit }()
+	var mu sync.Mutex
 	var exitCode int
-	osExit = func(code int) { exitCode = code }
+	osExit = func(code int) {
+		mu.Lock()
+		defer mu.Unlock()
+		exitCode = code
+	}
 
 	restoreTrapSignalsHook := trapSignalsHook
 	defer func() { trapSignalsHook = restoreTrapSignalsHook }()
@@ -31,11 +36,7 @@ func TestFlow_Main_signal_graceful(t *testing.T) {
 	f.Define(Task{
 		Name: "task",
 		Action: func(a *A) {
-			select {
-			case <-a.Context().Done():
-			case <-time.After(time.Second):
-				a.Error("timeout")
-			}
+			<-a.Context().Done()
 		},
 	})
 
@@ -52,8 +53,11 @@ func TestFlow_Main_signal_graceful(t *testing.T) {
 	}
 
 	<-doneCh
-	if exitCode != 1 {
-		t.Errorf("expected exit code 1, got %d", exitCode)
+	mu.Lock()
+	got := exitCode
+	mu.Unlock()
+	if got != 1 {
+		t.Errorf("expected exit code 1, got %d", got)
 	}
 }
 
@@ -82,13 +86,9 @@ func TestFlow_Main_signal_hard(t *testing.T) {
 	f.Define(Task{
 		Name: "task",
 		Action: func(a *A) {
-			select {
-			case <-a.Context().Done():
-				// hang to allow second signal
-				select {}
-			case <-time.After(time.Second):
-				a.Error("timeout")
-			}
+			<-a.Context().Done()
+			// Hang to allow second signal
+			select {}
 		},
 	})
 
@@ -100,9 +100,10 @@ func TestFlow_Main_signal_hard(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Wait for the first signal to be processed and then send the second one repeatedly
+	// Wait for the hard exit
 	var got int
 	for i := 0; i < 100; i++ {
+		runtime.Gosched()
 		time.Sleep(10 * time.Millisecond)
 		if err := p.Signal(os.Interrupt); err != nil {
 			t.Fatal(err)
@@ -113,7 +114,6 @@ func TestFlow_Main_signal_hard(t *testing.T) {
 		if got == 1 {
 			break
 		}
-		runtime.Gosched()
 	}
 
 	if got != 1 {
@@ -145,23 +145,26 @@ func TestMain_signal_graceful(t *testing.T) {
 
 	restoreOsExit := osExit
 	defer func() { osExit = restoreOsExit }()
+	var mu sync.Mutex
 	var exitCode int
-	osExit = func(code int) { exitCode = code }
+	osExit = func(code int) {
+		mu.Lock()
+		defer mu.Unlock()
+		exitCode = code
+	}
 
 	restoreTrapSignalsHook := trapSignalsHook
 	defer func() { trapSignalsHook = restoreTrapSignalsHook }()
 	hookCalled := make(chan struct{})
 	trapSignalsHook = func() { close(hookCalled) }
 
+	origDefaultFlow := DefaultFlow
+	defer func() { DefaultFlow = origDefaultFlow }()
 	DefaultFlow = &Flow{}
 	Define(Task{
 		Name: "task",
 		Action: func(a *A) {
-			select {
-			case <-a.Context().Done():
-			case <-time.After(time.Second):
-				a.Error("timeout")
-			}
+			<-a.Context().Done()
 		},
 	})
 
@@ -178,7 +181,10 @@ func TestMain_signal_graceful(t *testing.T) {
 	}
 
 	<-doneCh
-	if exitCode != 1 {
-		t.Errorf("expected exit code 1, got %d", exitCode)
+	mu.Lock()
+	got := exitCode
+	mu.Unlock()
+	if got != 1 {
+		t.Errorf("expected exit code 1, got %d", got)
 	}
 }

--- a/trap_signals_test.go
+++ b/trap_signals_test.go
@@ -1,0 +1,179 @@
+package goyek
+
+import (
+	"io"
+	"os"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestFlow_Main_signal_graceful(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+
+	restoreOsExit := osExit
+	defer func() { osExit = restoreOsExit }()
+	var exitCode int
+	osExit = func(code int) { exitCode = code }
+
+	restoreTrapSignalsHook := trapSignalsHook
+	defer func() { trapSignalsHook = restoreTrapSignalsHook }()
+	hookCalled := make(chan struct{})
+	trapSignalsHook = func() { close(hookCalled) }
+
+	f := &Flow{}
+	f.SetOutput(io.Discard)
+	f.Define(Task{
+		Name: "task",
+		Action: func(a *A) {
+			select {
+			case <-a.Context().Done():
+			case <-time.After(time.Second):
+				a.Error("timeout")
+			}
+		},
+	})
+
+	doneCh := make(chan struct{})
+	go func() {
+		f.Main([]string{"task"})
+		close(doneCh)
+	}()
+
+	<-hookCalled
+	p, _ := os.FindProcess(os.Getpid())
+	if err := p.Signal(os.Interrupt); err != nil {
+		t.Fatal(err)
+	}
+
+	<-doneCh
+	if exitCode != 1 {
+		t.Errorf("expected exit code 1, got %d", exitCode)
+	}
+}
+
+func TestFlow_Main_signal_hard(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+
+	restoreOsExit := osExit
+	defer func() { osExit = restoreOsExit }()
+	var mu sync.Mutex
+	var exitCode int
+	osExit = func(code int) {
+		mu.Lock()
+		defer mu.Unlock()
+		exitCode = code
+	}
+
+	restoreTrapSignalsHook := trapSignalsHook
+	defer func() { trapSignalsHook = restoreTrapSignalsHook }()
+	hookCalled := make(chan struct{})
+	trapSignalsHook = func() { close(hookCalled) }
+
+	f := &Flow{}
+	f.SetOutput(io.Discard)
+	f.Define(Task{
+		Name: "task",
+		Action: func(a *A) {
+			select {
+			case <-a.Context().Done():
+				// hang to allow second signal
+				select {}
+			case <-time.After(time.Second):
+				a.Error("timeout")
+			}
+		},
+	})
+
+	go f.Main([]string{"task"})
+
+	<-hookCalled
+	p, _ := os.FindProcess(os.Getpid())
+	if err := p.Signal(os.Interrupt); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for the first signal to be processed
+	time.Sleep(100 * time.Millisecond)
+
+	if err := p.Signal(os.Interrupt); err != nil {
+		t.Fatal(err)
+	}
+
+	// Give it some time to call osExit
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	got := exitCode
+	mu.Unlock()
+	if got != 1 {
+		t.Errorf("expected exit code 1, got %d", got)
+	}
+}
+
+func TestFlow_Main_pass(t *testing.T) {
+	restoreOsExit := osExit
+	defer func() { osExit = restoreOsExit }()
+	var exitCode int
+	osExit = func(code int) { exitCode = code }
+
+	f := &Flow{}
+	f.SetOutput(io.Discard)
+	f.Define(Task{Name: "task"})
+
+	f.Main([]string{"task"})
+
+	if exitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", exitCode)
+	}
+}
+
+func TestMain_signal_graceful(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+
+	restoreOsExit := osExit
+	defer func() { osExit = restoreOsExit }()
+	var exitCode int
+	osExit = func(code int) { exitCode = code }
+
+	restoreTrapSignalsHook := trapSignalsHook
+	defer func() { trapSignalsHook = restoreTrapSignalsHook }()
+	hookCalled := make(chan struct{})
+	trapSignalsHook = func() { close(hookCalled) }
+
+	DefaultFlow = &Flow{}
+	Define(Task{
+		Name: "task",
+		Action: func(a *A) {
+			select {
+			case <-a.Context().Done():
+			case <-time.After(time.Second):
+				a.Error("timeout")
+			}
+		},
+	})
+
+	doneCh := make(chan struct{})
+	go func() {
+		Main([]string{"task"})
+		close(doneCh)
+	}()
+
+	<-hookCalled
+	p, _ := os.FindProcess(os.Getpid())
+	if err := p.Signal(os.Interrupt); err != nil {
+		t.Fatal(err)
+	}
+
+	<-doneCh
+	if exitCode != 1 {
+		t.Errorf("expected exit code 1, got %d", exitCode)
+	}
+}


### PR DESCRIPTION
Implemented support for SIGTERM as a termination signal in `Flow.Main` to improve robustness in containerized and CI/CD environments. Generalized the signal handling logic to be cross-platform, abstracted `os.Exit` for testability, and added comprehensive unit and integration tests. Updated documentation and the changelog accordingly.

---
*PR created automatically by Jules for task [11444714116069885555](https://jules.google.com/task/11444714116069885555) started by @pellared*