### PR TITLE
Add SIGTERM support to Main for graceful shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 
 ### Added
 
+- Add `SIGTERM` support to `Main` for graceful shutdown in containerized environments.
 - Add safety checks to `A.Setenv` and `A.Chdir` to prevent their usage
   in parallel tasks.
 

--- a/flow.go
+++ b/flow.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"os/signal"
 	"sort"
+
+	"github.com/goyek/goyek/v3/internal"
 	"strings"
 	"text/tabwriter"
 )
@@ -31,6 +33,12 @@ type Flow struct {
 // DefaultFlow is the default flow.
 // The top-level functions such as Define, Main, and so on are wrappers for the methods of Flow.
 var DefaultFlow = &Flow{}
+
+var (
+	osExit                = os.Exit
+	trapSignalsHook       = func() {}
+	trapSignalsSecondHook = func() {}
+)
 
 // Tasks returns all tasks sorted in lexicographical order.
 func Tasks() []*DefinedTask {
@@ -377,8 +385,8 @@ const (
 // Main runs provided tasks and all their dependencies.
 // Each task is executed at most once.
 // It exits the current program when after the run is finished
-// or SIGINT interrupted the execution.
-//   - 0 exit code means that non of the tasks failed.
+// or a termination signal interrupted the execution.
+//   - 0 exit code means that none of the tasks failed.
 //   - 1 exit code means that a task has failed or the execution was interrupted.
 //   - 2 exit code means that the input was invalid.
 //
@@ -390,40 +398,68 @@ func Main(args []string, opts ...Option) {
 // Main runs provided tasks and all their dependencies.
 // Each task is executed at most once.
 // It exits the current program when after the run is finished
-// or SIGINT interrupted the execution.
-//   - 0 exit code means that non of the tasks failed.
+// or a termination signal interrupted the execution.
+//   - 0 exit code means that none of the tasks failed.
 //   - 1 exit code means that a task has failed or the execution was interrupted.
 //   - 2 exit code means that the input was invalid.
 //
 // Calls [Usage] when invalid args are provided.
 func (f *Flow) Main(args []string, opts ...Option) {
-	out := f.Output()
+	out := internal.SyncWriter(f.Output())
 
-	// trap Ctrl+C and call cancel on the context
+	// trap termination signals and call cancel on the context
 	ctx, cancel := context.WithCancel(context.Background())
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
+	signal.Notify(c, internal.TerminationSignals()...)
+	handlerDone := make(chan struct{})
+	handlerFinished := make(chan struct{})
 	go func() {
-		<-c // first signal, cancel context
-		fmt.Fprintln(out, "first interrupt, graceful stop")
-		cancel()
+		defer close(handlerFinished)
+		defer signal.Stop(c)
+		trapSignalsHook()
+		select {
+		case <-c:
+			// first signal, cancel context
+			fmt.Fprintln(out, "first interrupt, graceful stop")
+			cancel()
+		case <-handlerDone:
+			return
+		}
 
-		<-c // second signal, hard exit
-		fmt.Fprintln(out, "second interrupt, exit")
-		os.Exit(exitCodeFail)
+		// consume potential remaining first signals
+		// this is needed if os.Interrupt and syscall.SIGTERM were both sent
+		for len(c) > 0 {
+			<-c
+		}
+
+		trapSignalsSecondHook()
+		select {
+		case <-c:
+			// second signal, hard exit
+			fmt.Fprintln(out, "second interrupt, exit")
+			osExit(exitCodeFail)
+		case <-handlerDone:
+			return
+		}
+
+		// Consume all other signals if osExit was mocked and did not exit.
+		for range c {
+		}
 	}()
 
 	exitCode := f.main(ctx, args, opts...)
-	os.Exit(exitCode)
+	close(handlerDone)
+	<-handlerFinished
+	osExit(exitCode)
 }
 
 func (f *Flow) main(ctx context.Context, args []string, opts ...Option) int {
 	err := f.Execute(ctx, args, opts...)
-	var ferr *FailError
-	if errors.As(err, &ferr) {
+	if ctx.Err() != nil {
 		return exitCodeFail
 	}
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+	var ferr *FailError
+	if errors.As(err, &ferr) {
 		return exitCodeFail
 	}
 	if err != nil {

--- a/flow.go
+++ b/flow.go
@@ -8,10 +8,10 @@ import (
 	"os"
 	"os/signal"
 	"sort"
-	"strings"
-	"text/tabwriter"
 
 	"github.com/goyek/goyek/v3/internal"
+	"strings"
+	"text/tabwriter"
 )
 
 // Flow is the root type of the package.
@@ -428,9 +428,14 @@ func (f *Flow) Main(args []string, opts ...Option) {
 
 		// consume potential remaining first signals
 		// this is needed if os.Interrupt and syscall.SIGTERM were both sent
-		for len(c) > 0 {
-			<-c
+		for {
+			select {
+			case <-c:
+			default:
+				goto next
+			}
 		}
+	next:
 
 		trapSignalsSecondHook()
 		select {
@@ -443,8 +448,13 @@ func (f *Flow) Main(args []string, opts ...Option) {
 		}
 
 		// Consume all other signals if osExit was mocked and did not exit.
-		for range c {
-			fmt.Fprintln(out, "extra interrupt ignored")
+		for {
+			select {
+			case <-c:
+				fmt.Fprintln(out, "extra interrupt ignored")
+			case <-handlerDone:
+				return
+			}
 		}
 	}()
 

--- a/flow.go
+++ b/flow.go
@@ -8,10 +8,10 @@ import (
 	"os"
 	"os/signal"
 	"sort"
-
-	"github.com/goyek/goyek/v3/internal"
 	"strings"
 	"text/tabwriter"
+
+	"github.com/goyek/goyek/v3/internal"
 )
 
 // Flow is the root type of the package.

--- a/flow.go
+++ b/flow.go
@@ -8,10 +8,10 @@ import (
 	"os"
 	"os/signal"
 	"sort"
-
-	"github.com/goyek/goyek/v3/internal"
 	"strings"
 	"text/tabwriter"
+
+	"github.com/goyek/goyek/v3/internal"
 )
 
 // Flow is the root type of the package.
@@ -444,6 +444,7 @@ func (f *Flow) Main(args []string, opts ...Option) {
 
 		// Consume all other signals if osExit was mocked and did not exit.
 		for range c {
+			fmt.Fprintln(out, "extra interrupt ignored")
 		}
 	}()
 

--- a/flow_main_test.go
+++ b/flow_main_test.go
@@ -2,9 +2,11 @@ package goyek
 
 import (
 	"context"
+	"errors"
 	"io"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestFlow_main(t *testing.T) {
@@ -42,6 +44,15 @@ func TestFlow_main(t *testing.T) {
 				return flow.main(ctx, []string{"task"})
 			},
 		},
+		{
+			desc: "deadline exceeded",
+			want: 1,
+			act: func() int {
+				ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+				defer cancel()
+				return flow.main(ctx, []string{"task"})
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -62,5 +73,23 @@ func Test_main_usage(t *testing.T) {
 
 	if !called {
 		t.Error("usage should be called for invalid input")
+	}
+}
+
+func TestFailError_Error(t *testing.T) {
+	err := &FailError{Task: "test"}
+	want := "task failed: test"
+	if got := err.Error(); got != want {
+		t.Errorf("got: %q; want: %q", got, want)
+	}
+}
+
+func TestExecute_error(t *testing.T) {
+	Define(Task{Name: "task"})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := Execute(ctx, []string{"task"})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("got: %v; want: %v", err, context.Canceled)
 	}
 }

--- a/internal/signals_default.go
+++ b/internal/signals_default.go
@@ -1,0 +1,11 @@
+//go:build !aix && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris
+// +build !aix,!darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd,!solaris
+
+package internal
+
+import "os"
+
+// TerminationSignals returns the signals that should cause a graceful shutdown.
+func TerminationSignals() []os.Signal {
+	return []os.Signal{os.Interrupt}
+}

--- a/internal/signals_test.go
+++ b/internal/signals_test.go
@@ -1,0 +1,24 @@
+package internal
+
+import (
+	"os"
+	"testing"
+)
+
+func TestTerminationSignals(t *testing.T) {
+	sigs := TerminationSignals()
+	if len(sigs) == 0 {
+		t.Fatal("TerminationSignals() returned no signals")
+	}
+
+	foundInterrupt := false
+	for _, sig := range sigs {
+		if sig == os.Interrupt {
+			foundInterrupt = true
+			break
+		}
+	}
+	if !foundInterrupt {
+		t.Error("os.Interrupt not found in termination signals")
+	}
+}

--- a/internal/signals_unix.go
+++ b/internal/signals_unix.go
@@ -1,0 +1,14 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
+
+package internal
+
+import (
+	"os"
+	"syscall"
+)
+
+// TerminationSignals returns the signals that should cause a graceful shutdown.
+func TerminationSignals() []os.Signal {
+	return []os.Signal{os.Interrupt, syscall.SIGTERM}
+}

--- a/trap_signals_test.go
+++ b/trap_signals_test.go
@@ -49,9 +49,7 @@ func TestFlow_Main_signal_graceful(t *testing.T) {
 	if err := p.Signal(os.Interrupt); err != nil {
 		t.Fatal(err)
 	}
-	// Give the signal handler some time to process the signal
-	// and for the task to finish.
-	// Wait for Main to exit
+
 	<-done
 
 	if exitCode != exitCodeFail {
@@ -121,7 +119,6 @@ func TestFlow_Main_signal_hard(t *testing.T) {
 	}
 
 	<-done
-	close(taskCanFinish)
 
 	mu.Lock()
 	code := exitCode
@@ -129,6 +126,99 @@ func TestFlow_Main_signal_hard(t *testing.T) {
 	if code != exitCodeFail {
 		t.Errorf("got exit code %d, want %d", code, exitCodeFail)
 	}
+
+	close(taskCanFinish)
+}
+
+func TestFlow_Main_signal_hard_timeout(t *testing.T) {
+	t.Skip("skipping flaky test in this environment")
+	if runtime.GOOS == windows {
+		t.Skip("skipping signal test on windows")
+	}
+
+	restoreOsExit := osExit
+	defer func() { osExit = restoreOsExit }()
+	var exitCode int
+	var mu sync.Mutex
+	osExit = func(code int) {
+		mu.Lock()
+		exitCode = code
+		mu.Unlock()
+	}
+
+	restoreTrapSignalsHook := trapSignalsHook
+	defer func() { trapSignalsHook = restoreTrapSignalsHook }()
+	hookCalled := make(chan struct{})
+	trapSignalsHook = func() {
+		close(hookCalled)
+	}
+
+	restoreTrapSignalsSecondHook := trapSignalsSecondHook
+	defer func() { trapSignalsSecondHook = restoreTrapSignalsSecondHook }()
+	secondHookCalled := make(chan struct{})
+	trapSignalsSecondHook = func() {
+		close(secondHookCalled)
+	}
+
+	f := &Flow{}
+	f.SetOutput(io.Discard)
+	taskCanFinish := make(chan struct{})
+	f.Define(Task{
+		Name: "task",
+		Action: func(_ *A) {
+			<-taskCanFinish
+		},
+	})
+
+	done := make(chan struct{})
+	go func() {
+		f.Main([]string{"task"})
+		close(done)
+	}()
+
+	<-hookCalled
+	p, _ := os.FindProcess(os.Getpid())
+	if err := p.Signal(os.Interrupt); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 100; i++ {
+		runtime.Gosched()
+	}
+
+	<-secondHookCalled
+	if err := p.Signal(os.Interrupt); err != nil {
+		t.Fatal(err)
+	}
+
+	// Send more signals to exercise the consumer loop
+	if err := p.Signal(os.Interrupt); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Signal(os.Interrupt); err != nil {
+		t.Fatal(err)
+	}
+
+	close(taskCanFinish)
+	<-done
+
+	mu.Lock()
+	code := exitCode
+	mu.Unlock()
+	if code != exitCodeFail {
+		t.Errorf("got exit code %d, want %d", code, exitCodeFail)
+	}
+}
+
+func TestFlow_Main_default_hooks(t *testing.T) {
+	restoreOsExit := osExit
+	defer func() { osExit = restoreOsExit }()
+	osExit = func(int) {}
+
+	f := &Flow{}
+	f.SetOutput(io.Discard)
+	f.Define(Task{Name: "task"})
+	f.Main([]string{"task"})
 }
 
 func TestMain_signal_graceful(t *testing.T) {

--- a/trap_signals_test.go
+++ b/trap_signals_test.go
@@ -14,7 +14,6 @@ func TestFlow_Main_signal_graceful(t *testing.T) {
 	if runtime.GOOS == windows {
 		t.Skip("skipping signal test on windows")
 	}
-
 	restoreOsExit := osExit
 	defer func() { osExit = restoreOsExit }()
 	var exitCode int
@@ -72,61 +71,38 @@ func TestFlow_Main_signal_hard(t *testing.T) {
 		exitCode = code
 		mu.Unlock()
 	}
-
 	restoreTrapSignalsHook := trapSignalsHook
 	defer func() { trapSignalsHook = restoreTrapSignalsHook }()
 	hookCalled := make(chan struct{})
-	trapSignalsHook = func() {
-		close(hookCalled)
-	}
-
+	trapSignalsHook = func() { close(hookCalled) }
 	restoreTrapSignalsSecondHook := trapSignalsSecondHook
 	defer func() { trapSignalsSecondHook = restoreTrapSignalsSecondHook }()
 	secondHookCalled := make(chan struct{})
-	trapSignalsSecondHook = func() {
-		close(secondHookCalled)
-	}
-
+	trapSignalsSecondHook = func() { close(secondHookCalled) }
 	f := &Flow{}
 	f.SetOutput(io.Discard)
 	taskCanFinish := make(chan struct{})
-	f.Define(Task{
-		Name: "task",
-		Action: func(_ *A) {
-			<-taskCanFinish
-		},
-	})
-
+	f.Define(Task{Name: "task", Action: func(_ *A) { <-taskCanFinish }})
 	done := make(chan struct{})
 	go func() {
 		f.Main([]string{"task"})
 		close(done)
 	}()
-
 	<-hookCalled
 	p, _ := os.FindProcess(os.Getpid())
-	if err := p.Signal(os.Interrupt); err != nil {
-		t.Fatal(err)
-	}
-
+	_ = p.Signal(os.Interrupt)
 	for i := 0; i < 100; i++ {
 		runtime.Gosched()
 	}
-
 	<-secondHookCalled
-	if err := p.Signal(os.Interrupt); err != nil {
-		t.Fatal(err)
-	}
-
+	_ = p.Signal(os.Interrupt)
 	<-done
-
 	mu.Lock()
 	code := exitCode
 	mu.Unlock()
 	if code != exitCodeFail {
 		t.Errorf("got exit code %d, want %d", code, exitCodeFail)
 	}
-
 	close(taskCanFinish)
 }
 
@@ -135,7 +111,6 @@ func TestFlow_Main_signal_hard_timeout(t *testing.T) {
 	if runtime.GOOS == windows {
 		t.Skip("skipping signal test on windows")
 	}
-
 	restoreOsExit := osExit
 	defer func() { osExit = restoreOsExit }()
 	var exitCode int
@@ -145,63 +120,35 @@ func TestFlow_Main_signal_hard_timeout(t *testing.T) {
 		exitCode = code
 		mu.Unlock()
 	}
-
 	restoreTrapSignalsHook := trapSignalsHook
 	defer func() { trapSignalsHook = restoreTrapSignalsHook }()
 	hookCalled := make(chan struct{})
-	trapSignalsHook = func() {
-		close(hookCalled)
-	}
-
+	trapSignalsHook = func() { close(hookCalled) }
 	restoreTrapSignalsSecondHook := trapSignalsSecondHook
 	defer func() { trapSignalsSecondHook = restoreTrapSignalsSecondHook }()
 	secondHookCalled := make(chan struct{})
-	trapSignalsSecondHook = func() {
-		close(secondHookCalled)
-	}
-
+	trapSignalsSecondHook = func() { close(secondHookCalled) }
 	f := &Flow{}
 	f.SetOutput(io.Discard)
 	taskCanFinish := make(chan struct{})
-	f.Define(Task{
-		Name: "task",
-		Action: func(_ *A) {
-			<-taskCanFinish
-		},
-	})
-
+	f.Define(Task{Name: "task", Action: func(_ *A) { <-taskCanFinish }})
 	done := make(chan struct{})
 	go func() {
 		f.Main([]string{"task"})
 		close(done)
 	}()
-
 	<-hookCalled
 	p, _ := os.FindProcess(os.Getpid())
-	if err := p.Signal(os.Interrupt); err != nil {
-		t.Fatal(err)
-	}
-
+	_ = p.Signal(os.Interrupt)
 	for i := 0; i < 100; i++ {
 		runtime.Gosched()
 	}
-
 	<-secondHookCalled
-	if err := p.Signal(os.Interrupt); err != nil {
-		t.Fatal(err)
-	}
-
-	// Send more signals to exercise the consumer loop
-	if err := p.Signal(os.Interrupt); err != nil {
-		t.Fatal(err)
-	}
-	if err := p.Signal(os.Interrupt); err != nil {
-		t.Fatal(err)
-	}
-
+	_ = p.Signal(os.Interrupt)
+	_ = p.Signal(os.Interrupt)
+	_ = p.Signal(os.Interrupt)
 	close(taskCanFinish)
 	<-done
-
 	mu.Lock()
 	code := exitCode
 	mu.Unlock()
@@ -210,7 +157,7 @@ func TestFlow_Main_signal_hard_timeout(t *testing.T) {
 	}
 }
 
-func TestFlow_Main_default_hooks(t *testing.T) {
+func TestFlow_Main_default_hooks(_ *testing.T) {
 	restoreOsExit := osExit
 	defer func() { osExit = restoreOsExit }()
 	osExit = func(int) {}
@@ -225,7 +172,6 @@ func TestMain_signal_graceful(t *testing.T) {
 	if runtime.GOOS == windows {
 		t.Skip("skipping signal test on windows")
 	}
-
 	restoreOsExit := osExit
 	defer func() { osExit = restoreOsExit }()
 	var exitCode int

--- a/trap_signals_test.go
+++ b/trap_signals_test.go
@@ -57,11 +57,9 @@ func TestFlow_Main_signal_graceful(t *testing.T) {
 }
 
 func TestFlow_Main_signal_hard(t *testing.T) {
-	t.Skip("skipping flaky test in this environment")
 	if runtime.GOOS == windows {
 		t.Skip("skipping signal test on windows")
 	}
-
 	restoreOsExit := osExit
 	defer func() { osExit = restoreOsExit }()
 	var exitCode int
@@ -90,12 +88,17 @@ func TestFlow_Main_signal_hard(t *testing.T) {
 	}()
 	<-hookCalled
 	p, _ := os.FindProcess(os.Getpid())
-	_ = p.Signal(os.Interrupt)
+	if err := p.Signal(os.Interrupt); err != nil {
+		t.Fatal(err)
+	}
 	for i := 0; i < 100; i++ {
 		runtime.Gosched()
 	}
 	<-secondHookCalled
-	_ = p.Signal(os.Interrupt)
+	if err := p.Signal(os.Interrupt); err != nil {
+		t.Fatal(err)
+	}
+	close(taskCanFinish)
 	<-done
 	mu.Lock()
 	code := exitCode
@@ -103,11 +106,9 @@ func TestFlow_Main_signal_hard(t *testing.T) {
 	if code != exitCodeFail {
 		t.Errorf("got exit code %d, want %d", code, exitCodeFail)
 	}
-	close(taskCanFinish)
 }
 
 func TestFlow_Main_signal_hard_timeout(t *testing.T) {
-	t.Skip("skipping flaky test in this environment")
 	if runtime.GOOS == windows {
 		t.Skip("skipping signal test on windows")
 	}
@@ -139,7 +140,9 @@ func TestFlow_Main_signal_hard_timeout(t *testing.T) {
 	}()
 	<-hookCalled
 	p, _ := os.FindProcess(os.Getpid())
-	_ = p.Signal(os.Interrupt)
+	if err := p.Signal(os.Interrupt); err != nil {
+		t.Fatal(err)
+	}
 	for i := 0; i < 100; i++ {
 		runtime.Gosched()
 	}

--- a/trap_signals_test.go
+++ b/trap_signals_test.go
@@ -8,8 +8,10 @@ import (
 	"testing"
 )
 
+const windows = "windows"
+
 func TestFlow_Main_signal_graceful(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == windows {
 		t.Skip("skipping signal test on windows")
 	}
 
@@ -59,7 +61,7 @@ func TestFlow_Main_signal_graceful(t *testing.T) {
 
 func TestFlow_Main_signal_hard(t *testing.T) {
 	t.Skip("skipping flaky test in this environment")
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == windows {
 		t.Skip("skipping signal test on windows")
 	}
 
@@ -92,7 +94,7 @@ func TestFlow_Main_signal_hard(t *testing.T) {
 	taskCanFinish := make(chan struct{})
 	f.Define(Task{
 		Name: "task",
-		Action: func(a *A) {
+		Action: func(_ *A) {
 			<-taskCanFinish
 		},
 	})
@@ -130,7 +132,7 @@ func TestFlow_Main_signal_hard(t *testing.T) {
 }
 
 func TestMain_signal_graceful(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == windows {
 		t.Skip("skipping signal test on windows")
 	}
 

--- a/trap_signals_test.go
+++ b/trap_signals_test.go
@@ -1,0 +1,199 @@
+package goyek
+
+import (
+	"io"
+	"os"
+	"runtime"
+	"sync"
+	"testing"
+)
+
+func TestFlow_Main_signal_graceful(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping signal test on windows")
+	}
+
+	restoreOsExit := osExit
+	defer func() { osExit = restoreOsExit }()
+	var exitCode int
+	osExit = func(code int) {
+		exitCode = code
+	}
+
+	restoreTrapSignalsHook := trapSignalsHook
+	defer func() { trapSignalsHook = restoreTrapSignalsHook }()
+	hookCalled := make(chan struct{})
+	trapSignalsHook = func() {
+		close(hookCalled)
+	}
+
+	f := &Flow{}
+	f.SetOutput(io.Discard)
+	f.Define(Task{
+		Name: "task",
+		Action: func(a *A) {
+			<-a.Context().Done()
+		},
+	})
+
+	done := make(chan struct{})
+	go func() {
+		f.Main([]string{"task"})
+		close(done)
+	}()
+
+	<-hookCalled
+	p, _ := os.FindProcess(os.Getpid())
+	if err := p.Signal(os.Interrupt); err != nil {
+		t.Fatal(err)
+	}
+	// Give the signal handler some time to process the signal
+	// and for the task to finish.
+	// Wait for Main to exit
+	<-done
+
+	if exitCode != exitCodeFail {
+		t.Errorf("got exit code %d, want %d", exitCode, exitCodeFail)
+	}
+}
+
+func TestFlow_Main_signal_hard(t *testing.T) {
+	t.Skip("skipping flaky test in this environment")
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping signal test on windows")
+	}
+
+	restoreOsExit := osExit
+	defer func() { osExit = restoreOsExit }()
+	var exitCode int
+	var mu sync.Mutex
+	osExit = func(code int) {
+		mu.Lock()
+		exitCode = code
+		mu.Unlock()
+	}
+
+	restoreTrapSignalsHook := trapSignalsHook
+	defer func() { trapSignalsHook = restoreTrapSignalsHook }()
+	hookCalled := make(chan struct{})
+	trapSignalsHook = func() {
+		close(hookCalled)
+	}
+
+	restoreTrapSignalsSecondHook := trapSignalsSecondHook
+	defer func() { trapSignalsSecondHook = restoreTrapSignalsSecondHook }()
+	secondHookCalled := make(chan struct{})
+	trapSignalsSecondHook = func() {
+		close(secondHookCalled)
+	}
+
+	f := &Flow{}
+	f.SetOutput(io.Discard)
+	taskCanFinish := make(chan struct{})
+	f.Define(Task{
+		Name: "task",
+		Action: func(a *A) {
+			<-taskCanFinish
+		},
+	})
+
+	done := make(chan struct{})
+	go func() {
+		f.Main([]string{"task"})
+		close(done)
+	}()
+
+	<-hookCalled
+	p, _ := os.FindProcess(os.Getpid())
+	if err := p.Signal(os.Interrupt); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 100; i++ {
+		runtime.Gosched()
+	}
+
+	<-secondHookCalled
+	if err := p.Signal(os.Interrupt); err != nil {
+		t.Fatal(err)
+	}
+
+	<-done
+	close(taskCanFinish)
+
+	mu.Lock()
+	code := exitCode
+	mu.Unlock()
+	if code != exitCodeFail {
+		t.Errorf("got exit code %d, want %d", code, exitCodeFail)
+	}
+}
+
+func TestMain_signal_graceful(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping signal test on windows")
+	}
+
+	restoreOsExit := osExit
+	defer func() { osExit = restoreOsExit }()
+	var exitCode int
+	osExit = func(code int) {
+		exitCode = code
+	}
+
+	restoreTrapSignalsHook := trapSignalsHook
+	defer func() { trapSignalsHook = restoreTrapSignalsHook }()
+	hookCalled := make(chan struct{})
+	trapSignalsHook = func() {
+		close(hookCalled)
+	}
+
+	f := DefaultFlow
+	oldTasks := f.tasks
+	f.tasks = make(map[string]*DefinedTask)
+	defer func() { f.tasks = oldTasks }()
+
+	Define(Task{
+		Name: "task",
+		Action: func(a *A) {
+			<-a.Context().Done()
+		},
+	})
+
+	done := make(chan struct{})
+	go func() {
+		Main([]string{"task"})
+		close(done)
+	}()
+
+	<-hookCalled
+	p, _ := os.FindProcess(os.Getpid())
+	if err := p.Signal(os.Interrupt); err != nil {
+		t.Fatal(err)
+	}
+
+	<-done
+
+	if exitCode != exitCodeFail {
+		t.Errorf("got exit code %d, want %d", exitCode, exitCodeFail)
+	}
+}
+
+func TestFlow_Main_pass(t *testing.T) {
+	restoreOsExit := osExit
+	defer func() { osExit = restoreOsExit }()
+	var exitCode int
+	osExit = func(code int) {
+		exitCode = code
+	}
+
+	f := &Flow{}
+	f.SetOutput(io.Discard)
+	f.Define(Task{Name: "task"})
+
+	f.Main([]string{"task"})
+
+	if exitCode != exitCodePass {
+		t.Errorf("got exit code %d, want %d", exitCode, exitCodePass)
+	}
+}


### PR DESCRIPTION
I have added `SIGTERM` support to the `Main` function to improve the reliability and security of graceful shutdowns, particularly in containerized environments like Kubernetes.

Key changes:
- Introduced a portable way to retrieve termination signals in the `internal` package, adding `SIGTERM` support on Unix-like systems.
- Refactored `Flow.Main` to use these signals and improved its testability by abstracting `os.Exit` and adding synchronization hooks.
- Ensured that the first termination signal triggers a graceful stop (via context cancellation) while a second signal triggers a hard exit.
- Added a comprehensive test suite in `trap_signals_test.go` to verify these behaviors.
- Updated `CHANGELOG.md` to reflect the new feature.

These changes ensure that cleanup functions registered with `A.Cleanup` (e.g., removing temporary sensitive files or releasing resources) are correctly executed when the process is terminated by standard system signals.

---
*PR created automatically by Jules for task [3140101258487647488](https://jules.google.com/task/3140101258487647488) started by @pellared*