### PR TITLE
Enhance Signal Handling and Fix Output Data Race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 
 ### Added
 
+- Add support for `SIGTERM` signal to `Flow.Main` for graceful shutdown
+  in container environments.
 - Add safety checks to `A.Setenv` and `A.Chdir` to prevent their usage
   in parallel tasks.
 
@@ -28,6 +30,9 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
   not canceled when the task finished.
 - `A.TempDir` now truncates the sanitized task name to prevent
   "file name too long" errors.
+- Fix races in `Flow.Main` when signal handler and task output
+  are written simultaneously by ensuring the same synchronized
+  writer is used.
 - Fix races when task output is written from multiple goroutines
   by automatically wrapping the output in a synchronized writer.
 - Document that `Flow` and `DefinedTask` are not safe for concurrent use.

--- a/flow.go
+++ b/flow.go
@@ -10,6 +10,14 @@ import (
 	"sort"
 	"strings"
 	"text/tabwriter"
+
+	"github.com/goyek/goyek/v3/internal"
+)
+
+var (
+	signalNotify = signal.Notify
+	signalStop   = signal.Stop
+	osExit       = os.Exit
 )
 
 // Flow is the root type of the package.
@@ -377,7 +385,7 @@ const (
 // Main runs provided tasks and all their dependencies.
 // Each task is executed at most once.
 // It exits the current program when after the run is finished
-// or SIGINT interrupted the execution.
+// or a termination signal interrupted the execution.
 //   - 0 exit code means that non of the tasks failed.
 //   - 1 exit code means that a task has failed or the execution was interrupted.
 //   - 2 exit code means that the input was invalid.
@@ -390,31 +398,53 @@ func Main(args []string, opts ...Option) {
 // Main runs provided tasks and all their dependencies.
 // Each task is executed at most once.
 // It exits the current program when after the run is finished
-// or SIGINT interrupted the execution.
+// or a termination signal interrupted the execution.
 //   - 0 exit code means that non of the tasks failed.
 //   - 1 exit code means that a task has failed or the execution was interrupted.
 //   - 2 exit code means that the input was invalid.
 //
 // Calls [Usage] when invalid args are provided.
 func (f *Flow) Main(args []string, opts ...Option) {
-	out := f.Output()
+	osExit(f.runMain(args, opts...))
+}
 
-	// trap Ctrl+C and call cancel on the context
+func (f *Flow) runMain(args []string, opts ...Option) int {
+	// Ensure we use the same syncWriter in the signal handler and the executor.
+	out := internal.SyncWriter(f.Output())
+	oldOut := f.output
+	f.output = out
+	defer func() { f.output = oldOut }()
+
+	// trap signals and call cancel on the context
 	ctx, cancel := context.WithCancel(context.Background())
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
-	go func() {
-		<-c // first signal, cancel context
-		fmt.Fprintln(out, "first interrupt, graceful stop")
-		cancel()
+	defer cancel()
 
-		<-c // second signal, hard exit
-		fmt.Fprintln(out, "second interrupt, exit")
-		os.Exit(exitCodeFail)
+	sigChan := make(chan os.Signal, 1)
+	signalNotify(sigChan, internal.TerminationSignals...)
+	defer signalStop(sigChan)
+
+	handlerDone := make(chan struct{})
+	defer close(handlerDone)
+
+	go func() {
+		select {
+		case <-sigChan: // first signal, cancel context
+			fmt.Fprintln(out, "first interrupt, graceful stop")
+			cancel()
+		case <-handlerDone:
+			return
+		}
+
+		select {
+		case <-sigChan: // second signal, hard exit
+			fmt.Fprintln(out, "second interrupt, exit")
+			osExit(exitCodeFail)
+		case <-handlerDone:
+			return
+		}
 	}()
 
-	exitCode := f.main(ctx, args, opts...)
-	os.Exit(exitCode)
+	return f.main(ctx, args, opts...)
 }
 
 func (f *Flow) main(ctx context.Context, args []string, opts ...Option) int {

--- a/flow_main_test.go
+++ b/flow_main_test.go
@@ -64,3 +64,11 @@ func Test_main_usage(t *testing.T) {
 		t.Error("usage should be called for invalid input")
 	}
 }
+
+func TestFailError_Error(t *testing.T) {
+	err := &FailError{Task: "test-task"}
+	want := "task failed: test-task"
+	if got := err.Error(); got != want {
+		t.Errorf("got: %q; want: %q", got, want)
+	}
+}

--- a/internal/signals.go
+++ b/internal/signals.go
@@ -1,0 +1,6 @@
+package internal
+
+import "os"
+
+// TerminationSignals are the signals that should cause a graceful shutdown.
+var TerminationSignals = []os.Signal{os.Interrupt}

--- a/internal/signals_default.go
+++ b/internal/signals_default.go
@@ -1,0 +1,4 @@
+//go:build !aix && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris
+// +build !aix,!darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd,!solaris
+
+package internal

--- a/internal/signals_unix.go
+++ b/internal/signals_unix.go
@@ -1,0 +1,12 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
+
+package internal
+
+import (
+	"syscall"
+)
+
+func init() {
+	TerminationSignals = append(TerminationSignals, syscall.SIGTERM)
+}

--- a/trap_signals_test.go
+++ b/trap_signals_test.go
@@ -135,3 +135,87 @@ func TestFlow_Main_signal_hard(t *testing.T) {
 		t.Errorf("got exit code %d, want %d", exitCode, exitCodeFail)
 	}
 }
+
+func TestMain_signal_graceful(t *testing.T) {
+	// Backup and restore
+	oldSignalNotify := signalNotify
+	oldSignalStop := signalStop
+	oldOsExit := osExit
+	defer func() {
+		signalNotify = oldSignalNotify
+		signalStop = oldSignalStop
+		osExit = oldOsExit
+	}()
+
+	var mu sync.Mutex
+	var sigChan chan<- os.Signal
+	signalNotify = func(c chan<- os.Signal, _ ...os.Signal) {
+		mu.Lock()
+		sigChan = c
+		mu.Unlock()
+	}
+	signalStop = func(_ chan<- os.Signal) {}
+
+	osExit = func(_ int) {
+		// do nothing
+	}
+
+	f := DefaultFlow
+	taskRan := false
+	task := f.Define(Task{
+		Name: "task-pkg-main",
+		Action: func(a *A) {
+			taskRan = true
+			<-a.Context().Done()
+		},
+	})
+	defer f.Undefine(task)
+
+	done := make(chan struct{})
+	go func() {
+		Main([]string{"task-pkg-main"})
+		close(done)
+	}()
+
+	// Wait for sigChan to be set
+	var sc chan<- os.Signal
+	for {
+		mu.Lock()
+		sc = sigChan
+		mu.Unlock()
+		if sc != nil {
+			break
+		}
+	}
+
+	// Send first signal
+	sc <- os.Interrupt
+
+	<-done
+
+	if !taskRan {
+		t.Error("task did not run")
+	}
+}
+
+func TestFlow_Main_pass(t *testing.T) {
+	// Backup and restore
+	oldOsExit := osExit
+	defer func() {
+		osExit = oldOsExit
+	}()
+
+	exitCode := -1
+	osExit = func(code int) {
+		exitCode = code
+	}
+
+	f := &Flow{}
+	f.Define(Task{Name: "task"})
+
+	f.Main([]string{"task"})
+
+	if exitCode != 0 {
+		t.Errorf("got exit code %d, want 0", exitCode)
+	}
+}

--- a/trap_signals_test.go
+++ b/trap_signals_test.go
@@ -1,0 +1,137 @@
+package goyek
+
+import (
+	"os"
+	"sync"
+	"testing"
+)
+
+func TestFlow_Main_signal_graceful(t *testing.T) {
+	// Backup and restore
+	oldSignalNotify := signalNotify
+	oldSignalStop := signalStop
+	oldOsExit := osExit
+	defer func() {
+		signalNotify = oldSignalNotify
+		signalStop = oldSignalStop
+		osExit = oldOsExit
+	}()
+
+	var mu sync.Mutex
+	var sigChan chan<- os.Signal
+	signalNotify = func(c chan<- os.Signal, _ ...os.Signal) {
+		mu.Lock()
+		sigChan = c
+		mu.Unlock()
+	}
+	signalStop = func(_ chan<- os.Signal) {}
+
+	osExit = func(_ int) {
+		// do nothing
+	}
+
+	f := &Flow{}
+	taskRan := false
+	f.Define(Task{
+		Name: "task",
+		Action: func(a *A) {
+			taskRan = true
+			// Wait for signal to be processed
+			<-a.Context().Done()
+		},
+	})
+
+	done := make(chan struct{})
+	go func() {
+		f.Main([]string{"task"})
+		close(done)
+	}()
+
+	// Wait for sigChan to be set
+	var sc chan<- os.Signal
+	for {
+		mu.Lock()
+		sc = sigChan
+		mu.Unlock()
+		if sc != nil {
+			break
+		}
+	}
+
+	// Send first signal
+	sc <- os.Interrupt
+
+	<-done
+
+	if !taskRan {
+		t.Error("task did not run")
+	}
+}
+
+func TestFlow_Main_signal_hard(t *testing.T) {
+	// Backup and restore
+	oldSignalNotify := signalNotify
+	oldSignalStop := signalStop
+	oldOsExit := osExit
+	defer func() {
+		signalNotify = oldSignalNotify
+		signalStop = oldSignalStop
+		osExit = oldOsExit
+	}()
+
+	var mu sync.Mutex
+	var sigChan chan<- os.Signal
+	signalNotify = func(c chan<- os.Signal, _ ...os.Signal) {
+		mu.Lock()
+		sigChan = c
+		mu.Unlock()
+	}
+	signalStop = func(_ chan<- os.Signal) {}
+
+	exitCode := -1
+	osExit = func(code int) {
+		mu.Lock()
+		exitCode = code
+		mu.Unlock()
+	}
+
+	f := &Flow{}
+	f.Define(Task{
+		Name: "task",
+		Action: func(_ *A) {
+			select {} // block forever
+		},
+	})
+
+	go f.Main([]string{"task"})
+
+	// Wait for sigChan to be set
+	var sc chan<- os.Signal
+	for {
+		mu.Lock()
+		sc = sigChan
+		mu.Unlock()
+		if sc != nil {
+			break
+		}
+	}
+
+	// Send first signal
+	sc <- os.Interrupt
+	// Send second signal
+	sc <- os.Interrupt
+
+	// Wait for osExit to be called
+	for {
+		mu.Lock()
+		code := exitCode
+		mu.Unlock()
+		if code != -1 {
+			break
+		}
+	}
+
+	if exitCode != exitCodeFail {
+		t.Errorf("got exit code %d, want %d", exitCode, exitCodeFail)
+	}
+}


### PR DESCRIPTION
This submission enhances the `goyek` task runner's reliability and security by improving its signal handling capabilities. 

Key changes include:
- **SIGTERM Support:** `Flow.Main` now listens for `SIGTERM` in addition to `SIGINT`. This is crucial for applications running in containerized environments like Kubernetes, where `SIGTERM` is the standard signal for graceful termination.
- **Race Condition Fix:** A potential data race between the signal handler's log messages and task output has been resolved. Both now share a synchronized writer, ensuring thread-safe output.
- **Improved Testability:** `Flow.Main` was refactored to use package-level hooks for `signal.Notify`, `signal.Stop`, and `os.Exit`, allowing for robust automated testing of signal handling logic without affecting the parent process.
- **Comprehensive Testing:** New tests in `trap_signals_test.go` verify both graceful shutdown (on the first signal) and immediate exit (on the second signal).

These changes ensure that `goyek` can be safely used in modern cloud-native environments and provide a more robust experience for CLI users.

---
*PR created automatically by Jules for task [2595819831061664980](https://jules.google.com/task/2595819831061664980) started by @pellared*