### PR TITLE
Enhance signal handling for graceful shutdown and robust exit codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 - Fix races when task output is written from multiple goroutines
   by automatically wrapping the output in a synchronized writer.
 - Document that `Flow` and `DefinedTask` are not safe for concurrent use.
+- Add `SIGTERM` support for graceful shutdown on Unix-like systems.
+- Ensure `Flow.Main` returns failure exit code (1) when interrupted,
+  even if the current task finishes successfully.
 
 ## [3.0.1](https://github.com/goyek/goyek/releases/tag/v3.0.1) - 2025-12-09
 

--- a/flow.go
+++ b/flow.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 	"strings"
 	"text/tabwriter"
+
+	"github.com/goyek/goyek/v3/internal"
 )
 
 // Flow is the root type of the package.
@@ -399,10 +401,10 @@ func Main(args []string, opts ...Option) {
 func (f *Flow) Main(args []string, opts ...Option) {
 	out := f.Output()
 
-	// trap Ctrl+C and call cancel on the context
+	// trap signals and call cancel on the context
 	ctx, cancel := context.WithCancel(context.Background())
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
+	signal.Notify(c, internal.TerminationSignals...)
 	go func() {
 		<-c // first signal, cancel context
 		fmt.Fprintln(out, "first interrupt, graceful stop")
@@ -424,6 +426,9 @@ func (f *Flow) main(ctx context.Context, args []string, opts ...Option) int {
 		return exitCodeFail
 	}
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return exitCodeFail
+	}
+	if ctx.Err() != nil {
 		return exitCodeFail
 	}
 	if err != nil {

--- a/flow_main_test.go
+++ b/flow_main_test.go
@@ -49,7 +49,7 @@ func TestFlow_main(t *testing.T) {
 				ctx, cancel := context.WithCancel(context.Background())
 				flow.Define(Task{
 					Name: "interrupted",
-					Action: func(a *A) {
+					Action: func(_ *A) {
 						cancel() // simulate interrupt during execution
 					},
 				})

--- a/flow_main_test.go
+++ b/flow_main_test.go
@@ -42,6 +42,20 @@ func TestFlow_main(t *testing.T) {
 				return flow.main(ctx, []string{"task"})
 			},
 		},
+		{
+			desc: "interrupted after successful execution",
+			want: 1,
+			act: func() int {
+				ctx, cancel := context.WithCancel(context.Background())
+				flow.Define(Task{
+					Name: "interrupted",
+					Action: func(a *A) {
+						cancel() // simulate interrupt during execution
+					},
+				})
+				return flow.main(ctx, []string{"interrupted"})
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/internal/signals.go
+++ b/internal/signals.go
@@ -1,0 +1,6 @@
+package internal
+
+import "os"
+
+// TerminationSignals are the signals that cause the flow to stop.
+var TerminationSignals []os.Signal

--- a/internal/signals_default.go
+++ b/internal/signals_default.go
@@ -1,0 +1,10 @@
+//go:build !aix && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris
+// +build !aix,!darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd,!solaris
+
+package internal
+
+import "os"
+
+func init() {
+	TerminationSignals = []os.Signal{os.Interrupt}
+}

--- a/internal/signals_unix.go
+++ b/internal/signals_unix.go
@@ -1,0 +1,13 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
+
+package internal
+
+import (
+	"os"
+	"syscall"
+)
+
+func init() {
+	TerminationSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}
+}


### PR DESCRIPTION
I have implemented a security enhancement to improve the robustness of the `goyek` task runner during process termination.

### Changes:
- **SIGTERM Support**: On Unix-like systems (Linux, macOS, etc.), `goyek` now listens for `SIGTERM` in addition to `SIGINT`. This is critical for graceful shutdowns in containerized environments (Kubernetes, Docker), allowing tasks to complete their cleanups before the process is killed.
- **Improved Exit Logic**: Updated `f.main` to always return a failure exit code (`1`) if the execution context was canceled, regardless of whether the final task returned an error. This prevents a race condition where a task finishing exactly when a signal is received could lead to an incorrect success exit code.
- **Cross-Platform Compatibility**: Used an internal package with build tags (`//go:build`) to manage termination signals, ensuring the code remains compatible with Windows and Plan 9 (where `SIGTERM` is not available).
- **Testing**: Added a new test case in `flow_main_test.go` to verify the fixed exit code logic when an interruption occurs.

These changes ensure that `goyek` behaves predictably and safely when it receives termination signals from the operating system or orchestrator.

---
*PR created automatically by Jules for task [4528096707617615151](https://jules.google.com/task/4528096707617615151) started by @pellared*