### PR TITLE
Add SIGTERM support for graceful shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 
 ### Added
 
+- Add `SIGTERM` support for graceful shutdown in `Flow.Main`. This ensures that
+  when the application is terminated by the system (e.g., in a containerized
+  environment like Kubernetes), it has a chance to execute cleanup functions.
 - Add safety checks to `A.Setenv` and `A.Chdir` to prevent their usage
   in parallel tasks.
 

--- a/flow.go
+++ b/flow.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 	"strings"
 	"text/tabwriter"
+
+	"github.com/goyek/goyek/v3/internal"
 )
 
 // Flow is the root type of the package.
@@ -31,6 +33,10 @@ type Flow struct {
 // DefaultFlow is the default flow.
 // The top-level functions such as Define, Main, and so on are wrappers for the methods of Flow.
 var DefaultFlow = &Flow{}
+
+var osExit = os.Exit
+
+var trapSignalsHook func(chan<- os.Signal)
 
 // Tasks returns all tasks sorted in lexicographical order.
 func Tasks() []*DefinedTask {
@@ -397,12 +403,16 @@ func Main(args []string, opts ...Option) {
 //
 // Calls [Usage] when invalid args are provided.
 func (f *Flow) Main(args []string, opts ...Option) {
-	out := f.Output()
+	out := internal.SyncWriter(f.Output())
 
-	// trap Ctrl+C and call cancel on the context
+	// trap signals and call cancel on the context
 	ctx, cancel := context.WithCancel(context.Background())
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
+	signal.Notify(c, internal.TerminationSignals...)
+	defer signal.Stop(c)
+	if trapSignalsHook != nil {
+		trapSignalsHook(c)
+	}
 	go func() {
 		<-c // first signal, cancel context
 		fmt.Fprintln(out, "first interrupt, graceful stop")
@@ -410,11 +420,11 @@ func (f *Flow) Main(args []string, opts ...Option) {
 
 		<-c // second signal, hard exit
 		fmt.Fprintln(out, "second interrupt, exit")
-		os.Exit(exitCodeFail)
+		osExit(exitCodeFail)
 	}()
 
 	exitCode := f.main(ctx, args, opts...)
-	os.Exit(exitCode)
+	osExit(exitCode)
 }
 
 func (f *Flow) main(ctx context.Context, args []string, opts ...Option) int {

--- a/internal/signals.go
+++ b/internal/signals.go
@@ -1,0 +1,6 @@
+package internal
+
+import "os"
+
+// TerminationSignals are the signals that cause the program to terminate.
+var TerminationSignals []os.Signal

--- a/internal/signals_default.go
+++ b/internal/signals_default.go
@@ -1,0 +1,10 @@
+//go:build !aix && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris
+// +build !aix,!darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd,!solaris
+
+package internal
+
+import "os"
+
+func init() {
+	TerminationSignals = []os.Signal{os.Interrupt}
+}

--- a/internal/signals_unix.go
+++ b/internal/signals_unix.go
@@ -1,0 +1,13 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
+
+package internal
+
+import (
+	"os"
+	"syscall"
+)
+
+func init() {
+	TerminationSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}
+}

--- a/trap_signals_test.go
+++ b/trap_signals_test.go
@@ -1,0 +1,248 @@
+package goyek
+
+import (
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type safeBuffer struct {
+	mu sync.Mutex
+	sb strings.Builder
+}
+
+func (s *safeBuffer) Write(p []byte) (n int, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.sb.Write(p)
+}
+
+func (s *safeBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.sb.String()
+}
+
+func TestFlow_Main_signal_graceful(t *testing.T) {
+	origOsExit := osExit
+	origTrapSignalsHook := trapSignalsHook
+	defer func() {
+		osExit = origOsExit
+		trapSignalsHook = origTrapSignalsHook
+	}()
+
+	var exitCode int
+	var exitMu sync.Mutex
+	osExit = func(code int) {
+		exitMu.Lock()
+		exitCode = code
+		exitMu.Unlock()
+	}
+
+	var sigChan chan<- os.Signal
+	var sigMu sync.Mutex
+	trapSignalsHook = func(c chan<- os.Signal) {
+		sigMu.Lock()
+		sigChan = c
+		sigMu.Unlock()
+	}
+
+	out := &safeBuffer{}
+	flow := &Flow{}
+	flow.SetOutput(out)
+
+	taskCanFinish := make(chan struct{})
+	flow.Define(Task{
+		Name: "task",
+		Action: func(a *A) {
+			<-a.Context().Done()
+			<-taskCanFinish
+		},
+	})
+
+	done := make(chan struct{})
+	go func() {
+		flow.Main([]string{"task"})
+		close(done)
+	}()
+
+	// wait until sigChan is set
+	var sc chan<- os.Signal
+	for {
+		sigMu.Lock()
+		sc = sigChan
+		sigMu.Unlock()
+		if sc != nil {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	sc <- os.Interrupt
+
+	// check if "graceful stop" was printed
+	for !strings.Contains(out.String(), "first interrupt, graceful stop") {
+		time.Sleep(time.Millisecond)
+	}
+
+	close(taskCanFinish)
+	<-done
+
+	exitMu.Lock()
+	if exitCode != 0 {
+		t.Errorf("got exit code %d, want 0", exitCode)
+	}
+	exitMu.Unlock()
+}
+
+func TestFlow_Main_signal_hard(t *testing.T) {
+	origOsExit := osExit
+	origTrapSignalsHook := trapSignalsHook
+	defer func() {
+		osExit = origOsExit
+		trapSignalsHook = origTrapSignalsHook
+	}()
+
+	var exitCode int
+	var exitMu sync.Mutex
+	osExit = func(code int) {
+		exitMu.Lock()
+		exitCode = code
+		exitMu.Unlock()
+	}
+
+	var sigChan chan<- os.Signal
+	var sigMu sync.Mutex
+	trapSignalsHook = func(c chan<- os.Signal) {
+		sigMu.Lock()
+		sigChan = c
+		sigMu.Unlock()
+	}
+
+	out := &safeBuffer{}
+	flow := &Flow{}
+	flow.SetOutput(out)
+	flow.Define(Task{
+		Name: "task",
+		Action: func(a *A) {
+			<-a.Context().Done()
+			select {} // block forever
+		},
+	})
+
+	go flow.Main([]string{"task"})
+
+	// wait until sigChan is set and send first interrupt
+	var sc chan<- os.Signal
+	for {
+		sigMu.Lock()
+		sc = sigChan
+		sigMu.Unlock()
+		if sc != nil {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	sc <- os.Interrupt
+	for !strings.Contains(out.String(), "first interrupt, graceful stop") {
+		time.Sleep(time.Millisecond)
+	}
+
+	// send second interrupt
+	sc <- os.Interrupt
+
+	for !strings.Contains(out.String(), "second interrupt, exit") {
+		time.Sleep(time.Millisecond)
+	}
+
+	// Wait a bit for osExit to be called
+	for {
+		exitMu.Lock()
+		code := exitCode
+		exitMu.Unlock()
+		if code != 0 {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	exitMu.Lock()
+	if exitCode != 1 {
+		t.Errorf("got exit code %d, want 1", exitCode)
+	}
+	exitMu.Unlock()
+}
+
+func TestMain_signal_graceful(t *testing.T) {
+	origOsExit := osExit
+	origTrapSignalsHook := trapSignalsHook
+	origDefaultFlow := DefaultFlow
+	defer func() {
+		osExit = origOsExit
+		trapSignalsHook = origTrapSignalsHook
+		DefaultFlow = origDefaultFlow
+	}()
+
+	var exitCode int
+	var exitMu sync.Mutex
+	osExit = func(code int) {
+		exitMu.Lock()
+		exitCode = code
+		exitMu.Unlock()
+	}
+
+	var sigChan chan<- os.Signal
+	var sigMu sync.Mutex
+	trapSignalsHook = func(c chan<- os.Signal) {
+		sigMu.Lock()
+		sigChan = c
+		sigMu.Unlock()
+	}
+
+	out := &safeBuffer{}
+	DefaultFlow = &Flow{}
+	DefaultFlow.SetOutput(out)
+
+	taskCanFinish := make(chan struct{})
+	Define(Task{
+		Name: "task",
+		Action: func(a *A) {
+			<-a.Context().Done()
+			<-taskCanFinish
+		},
+	})
+
+	done := make(chan struct{})
+	go func() {
+		Main([]string{"task"})
+		close(done)
+	}()
+
+	// wait until sigChan is set
+	var sc chan<- os.Signal
+	for {
+		sigMu.Lock()
+		sc = sigChan
+		sigMu.Unlock()
+		if sc != nil {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	sc <- os.Interrupt
+
+	// check if "graceful stop" was printed
+	for !strings.Contains(out.String(), "first interrupt, graceful stop") {
+		time.Sleep(time.Millisecond)
+	}
+
+	close(taskCanFinish)
+	<-done
+
+	exitMu.Lock()
+	if exitCode != 0 {
+		t.Errorf("got exit code %d, want 0", exitCode)
+	}
+	exitMu.Unlock()
+}


### PR DESCRIPTION
Implemented graceful shutdown support for SIGTERM in `Flow.Main`. This allows systems like Kubernetes to signal the application to stop, ensuring that tasks can perform necessary cleanup operations (e.g., removing temporary files, closing connections).

Key changes:
- Introduced `internal.TerminationSignals` to handle cross-platform signals (`SIGINT` and `SIGTERM` on Unix).
- Updated `Flow.Main` to use `internal.SyncWriter` for thread-safe output during signal handling.
- Added `signal.Stop(c)` in `Flow.Main` to release signal resources.
- Refactored `Flow.Main` to use a mockable `osExit` variable for testability.
- Added comprehensive tests in `trap_signals_test.go` covering graceful shutdown and hard exit scenarios.
- Updated `CHANGELOG.md` to document the enhancement.

---
*PR created automatically by Jules for task [16789189050410166586](https://jules.google.com/task/16789189050410166586) started by @pellared*