### PR TITLE
Improve Flow.Main termination signal handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
   "file name too long" errors.
 - Fix races when task output is written from multiple goroutines
   by automatically wrapping the output in a synchronized writer.
+- Fix signal handling in `Flow.Main` to support `SIGTERM` on Unix and
+  synchronize output during shutdown.
 - Document that `Flow` and `DefinedTask` are not safe for concurrent use.
 
 ## [3.0.1](https://github.com/goyek/goyek/releases/tag/v3.0.1) - 2025-12-09

--- a/flow.go
+++ b/flow.go
@@ -414,7 +414,12 @@ func (f *Flow) runMain(args []string, exit func(int), opts ...Option) int {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	signals := make(chan os.Signal, 2)
+	// os/signal can drop signals when the channel buffer is full.
+	// With a buffer of 1, a quick second termination signal may be dropped
+	// before the handler reads the first one, preventing the intended
+	// hard-exit behavior on the second signal.
+	const terminationSignalBuffer = 2
+	signals := make(chan os.Signal, terminationSignalBuffer)
 	signal.Notify(signals, internal.TerminationSignals()...)
 
 	done := make(chan struct{})

--- a/flow.go
+++ b/flow.go
@@ -378,9 +378,9 @@ const (
 
 // Main runs provided tasks and all their dependencies.
 // Each task is executed at most once.
-// It exits the current program when after the run is finished
+// It exits the current program after the run is finished
 // or a termination signal interrupted the execution.
-//   - 0 exit code means that non of the tasks failed.
+//   - 0 exit code means that none of the tasks failed.
 //   - 1 exit code means that a task has failed or the execution was interrupted.
 //   - 2 exit code means that the input was invalid.
 //
@@ -391,9 +391,9 @@ func Main(args []string, opts ...Option) {
 
 // Main runs provided tasks and all their dependencies.
 // Each task is executed at most once.
-// It exits the current program when after the run is finished
+// It exits the current program after the run is finished
 // or a termination signal interrupted the execution.
-//   - 0 exit code means that non of the tasks failed.
+//   - 0 exit code means that none of the tasks failed.
 //   - 1 exit code means that a task has failed or the execution was interrupted.
 //   - 2 exit code means that the input was invalid.
 //

--- a/flow.go
+++ b/flow.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 	"strings"
 	"text/tabwriter"
+
+	"github.com/goyek/goyek/v3/internal"
 )
 
 // Flow is the root type of the package.
@@ -377,7 +379,7 @@ const (
 // Main runs provided tasks and all their dependencies.
 // Each task is executed at most once.
 // It exits the current program when after the run is finished
-// or SIGINT interrupted the execution.
+// or a termination signal interrupted the execution.
 //   - 0 exit code means that non of the tasks failed.
 //   - 1 exit code means that a task has failed or the execution was interrupted.
 //   - 2 exit code means that the input was invalid.
@@ -390,31 +392,69 @@ func Main(args []string, opts ...Option) {
 // Main runs provided tasks and all their dependencies.
 // Each task is executed at most once.
 // It exits the current program when after the run is finished
-// or SIGINT interrupted the execution.
+// or a termination signal interrupted the execution.
 //   - 0 exit code means that non of the tasks failed.
 //   - 1 exit code means that a task has failed or the execution was interrupted.
 //   - 2 exit code means that the input was invalid.
 //
 // Calls [Usage] when invalid args are provided.
 func (f *Flow) Main(args []string, opts ...Option) {
-	out := f.Output()
+	os.Exit(f.runMain(args, os.Exit, opts...))
+}
 
-	// trap Ctrl+C and call cancel on the context
-	ctx, cancel := context.WithCancel(context.Background())
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
-	go func() {
-		<-c // first signal, cancel context
-		fmt.Fprintln(out, "first interrupt, graceful stop")
-		cancel()
-
-		<-c // second signal, hard exit
-		fmt.Fprintln(out, "second interrupt, exit")
-		os.Exit(exitCodeFail)
+func (f *Flow) runMain(args []string, exit func(int), opts ...Option) int {
+	out := internal.SyncWriter(f.Output())
+	originalOutput := f.output
+	f.output = out
+	defer func() {
+		f.output = originalOutput
 	}()
 
-	exitCode := f.main(ctx, args, opts...)
-	os.Exit(exitCode)
+	// trap termination signals and call cancel on the context
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, internal.TerminationSignals()...)
+	defer signal.Stop(signals)
+
+	done := make(chan struct{})
+	handlerDone := trapTerminationSignals(out, signals, done, cancel, exit)
+	defer func() {
+		close(done)
+		<-handlerDone
+	}()
+
+	return f.main(ctx, args, opts...)
+}
+
+func trapTerminationSignals(out io.Writer, signals <-chan os.Signal, done <-chan struct{}, cancel context.CancelFunc, exit func(int)) <-chan struct{} {
+	handlerDone := make(chan struct{})
+	go func() {
+		defer close(handlerDone)
+
+		select {
+		case <-signals: // first signal, cancel context
+			fmt.Fprintln(out, "first interrupt, graceful stop")
+			cancel()
+		case <-done:
+			return
+		}
+
+		select {
+		case <-done:
+			return
+		default:
+		}
+
+		select {
+		case <-signals: // second signal, hard exit
+			fmt.Fprintln(out, "second interrupt, exit")
+			exit(exitCodeFail)
+		case <-done:
+		}
+	}()
+	return handlerDone
 }
 
 func (f *Flow) main(ctx context.Context, args []string, opts ...Option) int {

--- a/flow.go
+++ b/flow.go
@@ -447,12 +447,6 @@ func trapTerminationSignals(out io.Writer, signals <-chan os.Signal, done <-chan
 		}
 
 		select {
-		case <-done:
-			return
-		default:
-		}
-
-		select {
 		case <-signals: // second signal, hard exit
 			fmt.Fprintln(out, "second termination signal, exit")
 			exit(exitCodeFail)

--- a/flow.go
+++ b/flow.go
@@ -414,13 +414,13 @@ func (f *Flow) runMain(args []string, exit func(int), opts ...Option) int {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	signals := make(chan os.Signal, 1)
+	signals := make(chan os.Signal, 2)
 	signal.Notify(signals, internal.TerminationSignals()...)
-	defer signal.Stop(signals)
 
 	done := make(chan struct{})
 	handlerDone := trapTerminationSignals(out, signals, done, cancel, exit)
 	defer func() {
+		signal.Stop(signals)
 		close(done)
 		<-handlerDone
 	}()
@@ -435,7 +435,7 @@ func trapTerminationSignals(out io.Writer, signals <-chan os.Signal, done <-chan
 
 		select {
 		case <-signals: // first signal, cancel context
-			fmt.Fprintln(out, "first interrupt, graceful stop")
+			fmt.Fprintln(out, "first termination signal, graceful stop")
 			cancel()
 		case <-done:
 			return
@@ -449,7 +449,7 @@ func trapTerminationSignals(out io.Writer, signals <-chan os.Signal, done <-chan
 
 		select {
 		case <-signals: // second signal, hard exit
-			fmt.Fprintln(out, "second interrupt, exit")
+			fmt.Fprintln(out, "second termination signal, exit")
 			exit(exitCodeFail)
 		case <-done:
 		}

--- a/flow_main_test.go
+++ b/flow_main_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestFlow_main(t *testing.T) {
@@ -42,6 +43,23 @@ func TestFlow_main(t *testing.T) {
 				return flow.main(ctx, []string{"task"})
 			},
 		},
+		{
+			desc: "interrupted success",
+			want: 0,
+			act: func() int {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				flow := &Flow{}
+				flow.SetOutput(&strings.Builder{})
+				flow.Define(Task{
+					Name: "task",
+					Action: func(*A) {
+						cancel()
+					},
+				})
+				return flow.main(ctx, []string{"task"})
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -62,5 +80,34 @@ func Test_main_usage(t *testing.T) {
 
 	if !called {
 		t.Error("usage should be called for invalid input")
+	}
+}
+
+func TestFlow_runMain(t *testing.T) {
+	flow := &Flow{}
+	flow.SetOutput(io.Discard)
+	flow.Define(Task{Name: "task"})
+
+	exited := make(chan int, 1)
+	done := make(chan int, 1)
+	go func() {
+		done <- flow.runMain([]string{"task"}, func(code int) {
+			exited <- code
+		})
+	}()
+
+	select {
+	case got := <-done:
+		if got != exitCodePass {
+			t.Fatalf("got exit code %d, want %d", got, exitCodePass)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("runMain did not finish")
+	}
+
+	select {
+	case code := <-exited:
+		t.Fatalf("exit called with code %d", code)
+	default:
 	}
 }

--- a/internal/signals_default.go
+++ b/internal/signals_default.go
@@ -1,0 +1,11 @@
+//go:build !aix && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris
+// +build !aix,!darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd,!solaris
+
+package internal
+
+import "os"
+
+// TerminationSignals returns signals that should cause a graceful shutdown.
+func TerminationSignals() []os.Signal {
+	return []os.Signal{os.Interrupt}
+}

--- a/internal/signals_default.go
+++ b/internal/signals_default.go
@@ -1,5 +1,5 @@
-//go:build !aix && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris
-// +build !aix,!darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd,!solaris
+//go:build !aix && !android && !darwin && !dragonfly && !freebsd && !hurd && !illumos && !ios && !linux && !netbsd && !openbsd && !solaris
+// +build !aix,!android,!darwin,!dragonfly,!freebsd,!hurd,!illumos,!ios,!linux,!netbsd,!openbsd,!solaris
 
 package internal
 

--- a/internal/signals_default_test.go
+++ b/internal/signals_default_test.go
@@ -1,0 +1,20 @@
+//go:build !aix && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris
+// +build !aix,!darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd,!solaris
+
+package internal_test
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/goyek/goyek/v3/internal"
+)
+
+func TestTerminationSignals(t *testing.T) {
+	got := internal.TerminationSignals()
+	want := []os.Signal{os.Interrupt}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}

--- a/internal/signals_default_test.go
+++ b/internal/signals_default_test.go
@@ -1,5 +1,5 @@
-//go:build !aix && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris
-// +build !aix,!darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd,!solaris
+//go:build !aix && !android && !darwin && !dragonfly && !freebsd && !hurd && !illumos && !ios && !linux && !netbsd && !openbsd && !solaris
+// +build !aix,!android,!darwin,!dragonfly,!freebsd,!hurd,!illumos,!ios,!linux,!netbsd,!openbsd,!solaris
 
 package internal_test
 

--- a/internal/signals_unix.go
+++ b/internal/signals_unix.go
@@ -1,5 +1,5 @@
-//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
-// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
+//go:build aix || android || darwin || dragonfly || freebsd || hurd || illumos || ios || linux || netbsd || openbsd || solaris
+// +build aix android darwin dragonfly freebsd hurd illumos ios linux netbsd openbsd solaris
 
 package internal
 

--- a/internal/signals_unix.go
+++ b/internal/signals_unix.go
@@ -1,0 +1,14 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
+
+package internal
+
+import (
+	"os"
+	"syscall"
+)
+
+// TerminationSignals returns signals that should cause a graceful shutdown.
+func TerminationSignals() []os.Signal {
+	return []os.Signal{os.Interrupt, syscall.SIGTERM}
+}

--- a/internal/signals_unix_test.go
+++ b/internal/signals_unix_test.go
@@ -1,5 +1,5 @@
-//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
-// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
+//go:build aix || android || darwin || dragonfly || freebsd || hurd || illumos || ios || linux || netbsd || openbsd || solaris
+// +build aix android darwin dragonfly freebsd hurd illumos ios linux netbsd openbsd solaris
 
 package internal_test
 

--- a/internal/signals_unix_test.go
+++ b/internal/signals_unix_test.go
@@ -1,0 +1,21 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
+
+package internal_test
+
+import (
+	"os"
+	"reflect"
+	"syscall"
+	"testing"
+
+	"github.com/goyek/goyek/v3/internal"
+)
+
+func TestTerminationSignals(t *testing.T) {
+	got := internal.TerminationSignals()
+	want := []os.Signal{os.Interrupt, syscall.SIGTERM}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}

--- a/trap_signals_test.go
+++ b/trap_signals_test.go
@@ -50,7 +50,7 @@ func TestTrapTerminationSignalsGraceful(t *testing.T) {
 	waitForDone(t, handlerDone)
 	assertNoExit(t, exited)
 
-	if got, want := out.String(), "first interrupt, graceful stop\n"; got != want {
+	if got, want := out.String(), "first termination signal, graceful stop\n"; got != want {
 		t.Fatalf("got output %q, want %q", got, want)
 	}
 }
@@ -76,7 +76,7 @@ func TestTrapTerminationSignalsHardExit(t *testing.T) {
 	if exitCode != exitCodeFail {
 		t.Fatalf("got exit code %d, want %d", exitCode, exitCodeFail)
 	}
-	want := "first interrupt, graceful stop\nsecond interrupt, exit\n"
+	want := "first termination signal, graceful stop\nsecond termination signal, exit\n"
 	if got := out.String(); got != want {
 		t.Fatalf("got output %q, want %q", got, want)
 	}

--- a/trap_signals_test.go
+++ b/trap_signals_test.go
@@ -1,0 +1,110 @@
+package goyek
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTrapTerminationSignalsDone(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	signals := make(chan os.Signal)
+	exited := make(chan int, 1)
+	var out strings.Builder
+	handlerDone := trapTerminationSignals(&out, signals, done, cancel, func(code int) {
+		exited <- code
+	})
+
+	close(done)
+	waitForDone(t, handlerDone)
+	assertNoExit(t, exited)
+
+	if err := ctx.Err(); err != nil {
+		t.Fatalf("context error: %v", err)
+	}
+	if got := out.String(); got != "" {
+		t.Fatalf("got output %q, want empty", got)
+	}
+}
+
+func TestTrapTerminationSignalsGraceful(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	signals := make(chan os.Signal, 1)
+	exited := make(chan int, 1)
+	var out strings.Builder
+	handlerDone := trapTerminationSignals(&out, signals, done, cancel, func(code int) {
+		exited <- code
+	})
+
+	signals <- os.Interrupt
+	waitForContext(t, ctx)
+	close(done)
+	waitForDone(t, handlerDone)
+	assertNoExit(t, exited)
+
+	if got, want := out.String(), "first interrupt, graceful stop\n"; got != want {
+		t.Fatalf("got output %q, want %q", got, want)
+	}
+}
+
+func TestTrapTerminationSignalsHardExit(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	signals := make(chan os.Signal, 1)
+	var out strings.Builder
+	exitCode := -1
+	handlerDone := trapTerminationSignals(&out, signals, done, cancel, func(code int) {
+		exitCode = code
+	})
+
+	signals <- os.Interrupt
+	waitForContext(t, ctx)
+	signals <- os.Interrupt
+	waitForDone(t, handlerDone)
+	close(done)
+
+	if exitCode != exitCodeFail {
+		t.Fatalf("got exit code %d, want %d", exitCode, exitCodeFail)
+	}
+	want := "first interrupt, graceful stop\nsecond interrupt, exit\n"
+	if got := out.String(); got != want {
+		t.Fatalf("got output %q, want %q", got, want)
+	}
+}
+
+func waitForContext(t *testing.T, ctx context.Context) {
+	t.Helper()
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("context should have been canceled")
+	}
+}
+
+func waitForDone(t *testing.T, done <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for goroutine")
+	}
+}
+
+func assertNoExit(t *testing.T, exited <-chan int) {
+	t.Helper()
+	select {
+	case code := <-exited:
+		t.Fatalf("exit called with code %d", code)
+	default:
+	}
+}

--- a/trap_signals_test.go
+++ b/trap_signals_test.go
@@ -82,6 +82,7 @@ func TestTrapTerminationSignalsHardExit(t *testing.T) {
 	}
 }
 
+//nolint:revive // testing.T should be the first parameter, not context.Context.
 func waitForContext(t *testing.T, ctx context.Context) {
 	t.Helper()
 	select {


### PR DESCRIPTION
## Why

`Flow.Main` only handled `SIGINT`, which meant Unix `SIGTERM` requests from Docker, Kubernetes, and similar process managers were not treated as graceful shutdown signals.

The previous signal handler also stayed alive after `Main` completed, wrote to the same output as running tasks without sharing the synchronized writer.

## What

- Handle `SIGTERM` on Unix in addition to `SIGINT` everywhere.
- Share one synchronized output writer between task execution, usage output, and signal-handler messages.

## Checklist

- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated.
- [x] The code changes follow [Effective Go](https://golang.org/doc/effective_go).
- [x] The code changes follow [CodeReviewComments](https://github.com/golang/go/wiki/CodeReviewComments).
- [x] The code changes are covered by tests.
