### PR TITLE
Migrate from client9/misspell to golangci/misspell

### DIFF
--- a/build/go.mod
+++ b/build/go.mod
@@ -3,8 +3,8 @@ module github.com/goyek/goyek/build
 go 1.25.0
 
 require (
-	github.com/client9/misspell v0.3.4
 	github.com/golangci/golangci-lint/v2 v2.12.2
+	github.com/golangci/misspell v0.8.0
 	github.com/goyek/goyek/v3 v3.0.1
 )
 
@@ -94,7 +94,6 @@ require (
 	github.com/golangci/go-printf-func-name v0.1.1 // indirect
 	github.com/golangci/gofmt v0.0.0-20250106114630-d62b90e6713d // indirect
 	github.com/golangci/golines v0.15.0 // indirect
-	github.com/golangci/misspell v0.8.0 // indirect
 	github.com/golangci/plugin-module-register v0.1.2 // indirect
 	github.com/golangci/revgrep v0.8.0 // indirect
 	github.com/golangci/rowserrcheck v0.0.0-20260419091836-c5f79b8a11ba // indirect

--- a/build/go.sum
+++ b/build/go.sum
@@ -148,7 +148,6 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/ckaznocha/intrange v0.3.1 h1:j1onQyXvHUsPWujDH6WIjhyH26gkRt/txNlV7LspvJs=
 github.com/ckaznocha/intrange v0.3.1/go.mod h1:QVepyz1AkUoFQkpEqksSYpNpUo3c5W7nWh/s6SHIJJk=
-github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/clipperhouse/displaywidth v0.11.0 h1:lBc6kY44VFw+TDx4I8opi/EtL9m20WSEFgwIwO+UVM8=
 github.com/clipperhouse/displaywidth v0.11.0/go.mod h1:bkrFNkf81G8HyVqmKGxsPufD3JhNl3dSqnGhOoSD/o0=

--- a/build/spell.go
+++ b/build/spell.go
@@ -8,7 +8,7 @@ var spell = goyek.Define(goyek.Task{
 	Name:  "spell",
 	Usage: "misspell",
 	Action: func(a *goyek.A) {
-		if !Exec(a, dirBuild, "go", "install", "github.com/client9/misspell/cmd/misspell") {
+		if !Exec(a, dirBuild, "go", "install", "github.com/golangci/misspell/cmd/misspell") {
 			return
 		}
 		mdFiles := find(a, ".md")

--- a/build/tools.go
+++ b/build/tools.go
@@ -7,6 +7,6 @@ package main
 // https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
 // https://github.com/golang/go/issues/25922
 import (
-	_ "github.com/client9/misspell/cmd/misspell"
+	_ "github.com/golangci/misspell/cmd/misspell"
 	_ "github.com/golangci/golangci-lint/v2/cmd/golangci-lint"
 )


### PR DESCRIPTION
Migrated the task automation project's spelling tool from the unmaintained github.com/client9/misspell to the maintained github.com/golangci/misspell fork. This change replaces references in build/tools.go, build/spell.go, and build/go.mod, running go mod tidy to update dependencies successfully.

---
*PR created automatically by Jules for task [3350092980119268640](https://jules.google.com/task/3350092980119268640) started by @pellared*