### PR TITLE
fix: expose default task to executor middleware (#666)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
   to resource leaks.
 - Fix races in `middleware.BufferParallel` and `middleware.SilentNonFailed`
   when task output is written from multiple goroutines.
+- Resolve the default task before executor middleware so authorization and audit
+  middleware observe the task that will actually run.
 - Treat nil output as `io.Discard` in bundled output-writing middleware.
 - Emit each `middleware.ReportStatus` panic report with one write so concurrent
   records cannot split its header from its stack.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,8 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
   to resource leaks.
 - Fix races in `middleware.BufferParallel` and `middleware.SilentNonFailed`
   when task output is written from multiple goroutines.
-- Resolve the default task before executor middleware so authorization and audit
-  middleware observe the task that will actually run.
+- Resolve the default task before executor middleware so middlewares
+  can observe the task that will actually run.
 - Treat nil output as `io.Discard` in bundled output-writing middleware.
 - Emit each `middleware.ReportStatus` panic report with one write so concurrent
   records cannot split its header from its stack.

--- a/executor.go
+++ b/executor.go
@@ -15,7 +15,9 @@ type (
 
 	// ExecuteInput received by the flow executor.
 	ExecuteInput struct {
-		Context   context.Context
+		Context context.Context
+		// Tasks contains the effective task names. [Flow.Execute] resolves a
+		// configured default task before invoking executor middleware.
 		Tasks     []string
 		SkipTasks []string
 		NoDeps    bool
@@ -43,7 +45,6 @@ type (
 	executor struct {
 		defined     map[string]*DefinedTask
 		middlewares []Middleware
-		defaultTask *DefinedTask
 	}
 )
 
@@ -52,11 +53,6 @@ type (
 //
 //nolint:gocyclo // Contains graph traversal logic.
 func (r *executor) Execute(in ExecuteInput) error {
-	// Handle default task.
-	if len(in.Tasks) == 0 && r.defaultTask != nil {
-		in.Tasks = append(in.Tasks, r.defaultTask.name)
-	}
-
 	if err := r.validate(in); err != nil {
 		return err
 	}

--- a/flow.go
+++ b/flow.go
@@ -373,6 +373,9 @@ func Execute(ctx context.Context, tasks []string, opts ...Option) error {
 func (f *Flow) Execute(ctx context.Context, tasks []string, opts ...Option) error {
 	var middlewares []Middleware
 	middlewares = append(middlewares, f.middlewares...)
+	if len(tasks) == 0 && f.defaultTask != nil {
+		tasks = []string{f.defaultTask.name}
+	}
 
 	cfg := &config{}
 	for _, opt := range opts {
@@ -383,7 +386,6 @@ func (f *Flow) Execute(ctx context.Context, tasks []string, opts ...Option) erro
 	r := &executor{
 		defined:     f.tasks,
 		middlewares: middlewares,
-		defaultTask: f.defaultTask,
 	}
 	runner := r.Execute
 

--- a/flow.go
+++ b/flow.go
@@ -373,6 +373,7 @@ func Execute(ctx context.Context, tasks []string, opts ...Option) error {
 func (f *Flow) Execute(ctx context.Context, tasks []string, opts ...Option) error {
 	var middlewares []Middleware
 	middlewares = append(middlewares, f.middlewares...)
+	// Handle default task.
 	if len(tasks) == 0 && f.defaultTask != nil {
 		tasks = []string{f.defaultTask.name}
 	}

--- a/flow_test.go
+++ b/flow_test.go
@@ -625,6 +625,25 @@ func TestFlow_UseExecutor(t *testing.T) {
 	assertContains(t, out, "message", "should call executor middleware")
 }
 
+func TestFlow_UseExecutor_observesDefaultTask(t *testing.T) {
+	flow := &goyek.Flow{}
+	task := flow.Define(goyek.Task{Name: "task"})
+	flow.SetDefault(task)
+
+	var gotTasks []string
+	flow.UseExecutor(func(next goyek.Executor) goyek.Executor {
+		return func(in goyek.ExecuteInput) error {
+			gotTasks = append(gotTasks, in.Tasks...)
+			return next(in)
+		}
+	})
+
+	err := flow.Execute(context.Background(), nil)
+
+	assertPass(t, err, "should pass")
+	requireEqual(t, gotTasks, []string{"task"}, "executor middleware should observe the effective task")
+}
+
 func TestFlow_UseExecutor_nil_middleware(t *testing.T) {
 	flow := &goyek.Flow{}
 


### PR DESCRIPTION
## Why

When `Flow.Execute` receives no explicit task names, default-task expansion currently happens inside the executor, after executor middleware has already been invoked. Authorization and audit middleware therefore observe an empty task list even though the configured default task runs.

## What

- resolve the configured default task at the `Flow.Execute` boundary before applying executor middleware
- document that `ExecuteInput.Tasks` contains the effective task names
- add a regression proving middleware observes the default task
- record the fix in the unreleased changelog

Fixes #666