### PR TITLE
Preserve DefinedTask compatibility and task invariants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,7 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 
 ### Fixed
 
-- Restore `DefinedTask` comparability, isolate task dependencies from caller
-  mutations, and reject stale task handles.
+- Reject stale task handles after an undefined task name is reused.
 - `A.Cleanup` now panics if a `nil` function is provided.
   This prevents accidental misconfigurations where a `nil` cleanup
   function would cause the internal cleanup loop to terminate prematurely,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 
 ### Fixed
 
+- Restore `DefinedTask` comparability, isolate task dependencies from caller
+  mutations, and reject stale task handles.
 - `A.Cleanup` now panics if a `nil` function is provided.
   This prevents accidental misconfigurations where a `nil` cleanup
   function would cause the internal cleanup loop to terminate prematurely,

--- a/executor.go
+++ b/executor.go
@@ -43,7 +43,7 @@ type (
 	ExecutorMiddleware func(Executor) Executor
 
 	executor struct {
-		defined     map[string]*DefinedTask
+		defined     map[string]*taskSnapshot
 		middlewares []Middleware
 	}
 )
@@ -105,7 +105,7 @@ func (r *executor) Execute(in ExecuteInput) error {
 			continue
 		}
 
-		tasksToRun := []*DefinedTask{task}
+		tasksToRun := []*taskSnapshot{task}
 
 		// Find all parallel tasks that have not been run
 		// and have no dependencies.
@@ -153,7 +153,7 @@ func (r *executor) validate(in ExecuteInput) error {
 	return nil
 }
 
-func (r *executor) canRunTask(task *DefinedTask, visited map[string]bool, noDeps bool) bool {
+func (r *executor) canRunTask(task *taskSnapshot, visited map[string]bool, noDeps bool) bool {
 	if visited[task.name] {
 		return false
 	}
@@ -177,7 +177,7 @@ func (r *executor) canRunTask(task *DefinedTask, visited map[string]bool, noDeps
 	return true
 }
 
-func (r *executor) runParallelTasks(ctx context.Context, tasks []*DefinedTask, output io.Writer, logger Logger) error {
+func (r *executor) runParallelTasks(ctx context.Context, tasks []*taskSnapshot, output io.Writer, logger Logger) error {
 	var err error
 	errCh := make(chan error, len(tasks))
 	for _, parallelTask := range tasks {
@@ -194,7 +194,7 @@ func (r *executor) runParallelTasks(ctx context.Context, tasks []*DefinedTask, o
 	return err
 }
 
-func (r *executor) runTask(ctx context.Context, task *DefinedTask, output io.Writer, logger Logger) error {
+func (r *executor) runTask(ctx context.Context, task *taskSnapshot, output io.Writer, logger Logger) error {
 	// prepare runner
 	runner := NewRunner(task.action)
 

--- a/flow.go
+++ b/flow.go
@@ -24,8 +24,8 @@ type Flow struct {
 	usage  func()
 	logger Logger
 
-	tasks               map[string]*DefinedTask // snapshot of defined tasks
-	defaultTask         *DefinedTask            // task to run when none is explicitly provided
+	tasks               map[string]*taskSnapshot // snapshot of defined tasks
+	defaultTask         *taskSnapshot            // task to run when none is explicitly provided
 	middlewares         []Middleware
 	executorMiddlewares []ExecutorMiddleware
 }
@@ -43,7 +43,7 @@ func Tasks() []*DefinedTask {
 func (f *Flow) Tasks() []*DefinedTask {
 	var tasks []*DefinedTask
 	for _, task := range f.tasks {
-		tasks = append(tasks, task)
+		tasks = append(tasks, &DefinedTask{taskSnapshot: task, flow: f})
 	}
 	sort.Slice(tasks, func(i, j int) bool { return tasks[i].Name() < tasks[j].Name() })
 	return tasks
@@ -60,25 +60,22 @@ func (f *Flow) Define(task Task) *DefinedTask {
 	if task.Name == "" {
 		panic("task name cannot be empty")
 	}
-	if f.isDefined(task.Name, f) {
+	if _, ok := f.tasks[task.Name]; ok {
 		panic("task with the same name is already defined")
 	}
-	for _, dep := range task.Deps {
-		if !f.isDefined(dep.name, dep.flow) {
-			panic("dependency was not defined: " + dep.name)
-		}
+	if f.tasks == nil {
+		f.tasks = map[string]*taskSnapshot{}
 	}
 
-	taskCopy := &DefinedTask{
+	taskCopy := &taskSnapshot{
 		name:     task.Name,
 		usage:    task.Usage,
-		deps:     task.Deps,
+		deps:     f.snapshotDeps(task.Deps),
 		action:   task.Action,
 		parallel: task.Parallel,
-		flow:     f,
 	}
 	f.tasks[task.Name] = taskCopy
-	return taskCopy
+	return &DefinedTask{taskSnapshot: taskCopy, flow: f}
 }
 
 // Undefine unregisters the task. It panics in case of any error.
@@ -88,7 +85,7 @@ func Undefine(task *DefinedTask) {
 
 // Undefine unregisters the task. It panics in case of any error.
 func (f *Flow) Undefine(task *DefinedTask) {
-	if !f.isDefined(task.name, task.flow) {
+	if !f.isDefined(task) {
 		panic("task was not defined: " + task.name)
 	}
 
@@ -98,9 +95,9 @@ func (f *Flow) Undefine(task *DefinedTask) {
 		if len(t.deps) == 0 {
 			continue
 		}
-		var cleanDep []*DefinedTask
+		var cleanDep []*taskSnapshot
 		for _, dep := range t.deps {
-			if dep == task {
+			if dep == task.taskSnapshot {
 				continue
 			}
 			cleanDep = append(cleanDep, dep)
@@ -108,20 +105,31 @@ func (f *Flow) Undefine(task *DefinedTask) {
 		t.deps = cleanDep
 	}
 
-	if f.defaultTask == task {
+	if f.defaultTask == task.taskSnapshot {
 		f.defaultTask = nil
 	}
 }
 
-func (f *Flow) isDefined(name string, flow *Flow) bool {
-	if f.tasks == nil {
-		f.tasks = map[string]*DefinedTask{}
+func (f *Flow) isDefined(task *DefinedTask) bool {
+	if task == nil || task.taskSnapshot == nil || f != task.flow {
+		return false
 	}
-	if f != flow {
-		return false // defined in other flow
+	return f.tasks[task.name] == task.taskSnapshot
+}
+
+func (f *Flow) snapshotDeps(deps Deps) []*taskSnapshot {
+	if len(deps) == 0 {
+		return nil
 	}
-	_, ok := f.tasks[name]
-	return ok
+
+	snapshots := make([]*taskSnapshot, len(deps))
+	for i, dep := range deps {
+		if !f.isDefined(dep) {
+			panic("dependency was not defined: " + dep.Name())
+		}
+		snapshots[i] = dep.taskSnapshot
+	}
+	return snapshots
 }
 
 // Output returns the current output destination. [os.Stdout] is returned if
@@ -255,7 +263,10 @@ func Default() *DefinedTask {
 // Default returns the default task.
 // nil is returned if default was not set.
 func (f *Flow) Default() *DefinedTask {
-	return f.defaultTask
+	if f.defaultTask == nil {
+		return nil
+	}
+	return &DefinedTask{taskSnapshot: f.defaultTask, flow: f}
 }
 
 // SetDefault sets a task to run when none is explicitly provided.
@@ -273,10 +284,10 @@ func (f *Flow) SetDefault(task *DefinedTask) {
 		return
 	}
 
-	if !f.isDefined(task.name, task.flow) {
+	if !f.isDefined(task) {
 		panic("task was not defined: " + task.name)
 	}
-	f.defaultTask = task
+	f.defaultTask = task.taskSnapshot
 }
 
 // Use adds task runner middlewares (interceptors).

--- a/flow_test.go
+++ b/flow_test.go
@@ -80,6 +80,67 @@ func Test_Define_bad_dep(t *testing.T) {
 	assertPanics(t, act, "should not be possible use dependencies from different flow")
 }
 
+func Test_Define_copiesDeps(t *testing.T) {
+	flow := &goyek.Flow{}
+	root := flow.Define(goyek.Task{Name: "root"})
+	deps := goyek.Deps{root}
+	task := flow.Define(goyek.Task{Name: "task", Deps: deps})
+	dependent := flow.Define(goyek.Task{Name: "dependent", Deps: goyek.Deps{task}})
+
+	// This would create a cycle if Define retained the caller's slice.
+	deps[0] = dependent
+
+	got := task.Deps()
+	requireEqual(t, len(got), 1, "should keep one dependency")
+	assertEqual(t, got[0], root, "should retain the validated dependency")
+}
+
+func TestFlow_rejectsStaleTask(t *testing.T) {
+	tests := []struct {
+		name string
+		use  func(*goyek.Flow, *goyek.DefinedTask, *goyek.DefinedTask)
+	}{
+		{
+			name: "undefine",
+			use: func(flow *goyek.Flow, stale, _ *goyek.DefinedTask) {
+				flow.Undefine(stale)
+			},
+		},
+		{
+			name: "default",
+			use: func(flow *goyek.Flow, stale, _ *goyek.DefinedTask) {
+				flow.SetDefault(stale)
+			},
+		},
+		{
+			name: "define dependency",
+			use: func(flow *goyek.Flow, stale, _ *goyek.DefinedTask) {
+				flow.Define(goyek.Task{Name: "dependent", Deps: goyek.Deps{stale}})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flow := &goyek.Flow{}
+			stale := flow.Define(goyek.Task{Name: "task"})
+			flow.Undefine(stale)
+			replacement := flow.Define(goyek.Task{Name: "task"})
+
+			act := func() { tt.use(flow, stale, replacement) }
+
+			assertPanics(t, act, "should reject a stale task handle")
+			got := flow.Tasks()
+			requireEqual(t, len(got), 1, "should retain only the replacement task")
+			assertEqual(t, got[0], replacement, "should retain the replacement task")
+			assertEqual(t, got[0].Deps(), goyek.Deps(nil), "should not reconfigure the replacement task")
+			if flow.Default() != nil {
+				t.Error("should not configure a stale task as the default")
+			}
+		})
+	}
+}
+
 func Test_successful(t *testing.T) {
 	ctx := context.Background()
 	flow := &goyek.Flow{}

--- a/task.go
+++ b/task.go
@@ -27,16 +27,21 @@ type Task struct {
 //
 // A DefinedTask is not safe for concurrent use.
 type DefinedTask struct {
-	name     string
-	usage    string
-	deps     []*DefinedTask
-	action   func(a *A)
-	parallel bool
-	flow     *Flow
+	*taskSnapshot
+	flow *Flow
 }
 
 // Deps represents a collection of dependencies.
 type Deps []*DefinedTask
+
+// taskSnapshot contains the mutable state owned by a Flow.
+type taskSnapshot struct {
+	name     string
+	usage    string
+	deps     []*taskSnapshot
+	action   func(a *A)
+	parallel bool
+}
 
 // Name returns the name of the task.
 func (r *DefinedTask) Name() string {
@@ -45,11 +50,12 @@ func (r *DefinedTask) Name() string {
 
 // SetName changes the name of the task.
 func (r *DefinedTask) SetName(s string) {
+	r.mustBeDefined()
 	if _, ok := r.flow.tasks[s]; ok {
 		panic("task with the same name is already defined")
 	}
 	oldName := r.name
-	r.flow.tasks[s] = r
+	r.flow.tasks[s] = r.taskSnapshot
 	delete(r.flow.tasks, oldName)
 	r.name = s
 }
@@ -61,6 +67,7 @@ func (r *DefinedTask) Usage() string {
 
 // SetUsage sets the description of the task.
 func (r *DefinedTask) SetUsage(s string) {
+	r.mustBeDefined()
 	r.usage = s
 }
 
@@ -71,6 +78,7 @@ func (r *DefinedTask) Action() func(a *A) {
 
 // SetAction changes the action of the task.
 func (r *DefinedTask) SetAction(fn func(a *A)) {
+	r.mustBeDefined()
 	r.action = fn
 }
 
@@ -80,41 +88,34 @@ func (r *DefinedTask) Deps() Deps {
 		return nil
 	}
 	deps := make(Deps, len(r.deps))
-	copy(deps, r.deps)
+	for i, dep := range r.deps {
+		deps[i] = &DefinedTask{taskSnapshot: dep, flow: r.flow}
+	}
 	return deps
 }
 
 // SetDeps sets all task's dependencies.
 func (r *DefinedTask) SetDeps(deps Deps) {
-	if len(deps) == 0 {
-		r.deps = nil
-		return
-	}
+	r.mustBeDefined()
+	snapshots := r.flow.snapshotDeps(deps)
 
-	for _, dep := range deps {
-		if !r.flow.isDefined(dep.Name(), dep.flow) {
-			panic("dependency was not defined: " + dep.Name())
-		}
-	}
-
-	visited := map[string]bool{}
-	if ok := r.noCycle(deps, visited); !ok {
+	visited := map[*taskSnapshot]bool{}
+	if ok := r.noCycle(snapshots, visited); !ok {
 		panic("circular dependency")
 	}
-	r.deps = deps
+	r.deps = snapshots
 }
 
-func (r *DefinedTask) noCycle(deps Deps, visited map[string]bool) bool {
+func (r *DefinedTask) noCycle(deps []*taskSnapshot, visited map[*taskSnapshot]bool) bool {
 	if len(deps) == 0 {
 		return true
 	}
 	for _, dep := range deps {
-		name := dep.name
-		if visited[name] {
+		if visited[dep] {
 			continue // already checked this branch
 		}
-		visited[name] = true
-		if name == r.name {
+		visited[dep] = true
+		if dep == r.taskSnapshot {
 			return false
 		}
 		if !r.noCycle(dep.deps, visited) {
@@ -122,4 +123,10 @@ func (r *DefinedTask) noCycle(deps Deps, visited map[string]bool) bool {
 		}
 	}
 	return true
+}
+
+func (r *DefinedTask) mustBeDefined() {
+	if !r.flow.isDefined(r) {
+		panic("task was not defined: " + r.name)
+	}
 }

--- a/task_test.go
+++ b/task_test.go
@@ -10,6 +10,26 @@ import (
 	"github.com/goyek/goyek/v3"
 )
 
+func TestDefinedTask_comparable(t *testing.T) {
+	flow := &goyek.Flow{}
+	task := flow.Define(goyek.Task{Name: "task"})
+	sameTask := flow.Tasks()[0]
+
+	tasks := map[goyek.DefinedTask]bool{*task: true}
+
+	assertTrue(t, tasks[*sameTask], "should remain usable as a map key")
+}
+
+func TestDefinedTask_copyRemainsHandle(t *testing.T) {
+	flow := &goyek.Flow{}
+	task := flow.Define(goyek.Task{Name: "task"})
+	taskCopy := *task
+
+	taskCopy.SetUsage("updated through copy")
+
+	assertEqual(t, task.Usage(), "updated through copy", "should share the task state")
+}
+
 func TestDefinedTask_SetName(t *testing.T) {
 	flow := &goyek.Flow{}
 	flow.SetOutput(io.Discard)
@@ -118,6 +138,22 @@ func TestDefinedTask_SetDeps(t *testing.T) {
 	assertTrue(t, called, "should call transitive dependency of t3")
 }
 
+func TestDefinedTask_SetDeps_copiesInput(t *testing.T) {
+	flow := &goyek.Flow{}
+	root := flow.Define(goyek.Task{Name: "root"})
+	task := flow.Define(goyek.Task{Name: "task"})
+	deps := goyek.Deps{root}
+	task.SetDeps(deps)
+	dependent := flow.Define(goyek.Task{Name: "dependent", Deps: goyek.Deps{task}})
+
+	// This would create a cycle if SetDeps retained the caller's slice.
+	deps[0] = dependent
+
+	got := task.Deps()
+	requireEqual(t, len(got), 1, "should keep one dependency")
+	assertEqual(t, got[0], root, "should retain the validated dependency")
+}
+
 func TestDefinedTask_SetDeps_clear(t *testing.T) {
 	flow := &goyek.Flow{}
 	flow.SetOutput(io.Discard)
@@ -159,4 +195,66 @@ func TestDefinedTask_SetDeps_dep(t *testing.T) {
 	act := func() { task.SetDeps(goyek.Deps{otherTask}) }
 
 	assertPanics(t, act, "should not be possible use dependencies from different flow")
+}
+
+func TestDefinedTask_SetDeps_staleDependency(t *testing.T) {
+	flow := &goyek.Flow{}
+	stale := flow.Define(goyek.Task{Name: "task"})
+	flow.Undefine(stale)
+	flow.Define(goyek.Task{Name: "task"})
+	consumer := flow.Define(goyek.Task{Name: "consumer"})
+
+	act := func() { consumer.SetDeps(goyek.Deps{stale}) }
+
+	assertPanics(t, act, "should reject a stale dependency")
+	assertEqual(t, consumer.Deps(), goyek.Deps(nil), "should not update dependencies")
+}
+
+func TestDefinedTask_mutatorsRejectStaleHandle(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*goyek.DefinedTask, *goyek.DefinedTask)
+	}{
+		{
+			name: "name",
+			mutate: func(stale, _ *goyek.DefinedTask) {
+				stale.SetName("renamed")
+			},
+		},
+		{
+			name: "usage",
+			mutate: func(stale, _ *goyek.DefinedTask) {
+				stale.SetUsage("stale usage")
+			},
+		},
+		{
+			name: "action",
+			mutate: func(stale, _ *goyek.DefinedTask) {
+				stale.SetAction(func(*goyek.A) {})
+			},
+		},
+		{
+			name: "dependencies",
+			mutate: func(stale, _ *goyek.DefinedTask) {
+				stale.SetDeps(nil)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flow := &goyek.Flow{}
+			stale := flow.Define(goyek.Task{Name: "task"})
+			flow.Undefine(stale)
+			replacement := flow.Define(goyek.Task{Name: "task", Usage: "replacement"})
+
+			act := func() { tt.mutate(stale, replacement) }
+
+			assertPanics(t, act, "should reject a stale task handle")
+			got := flow.Tasks()
+			requireEqual(t, len(got), 1, "should retain the replacement task")
+			assertEqual(t, got[0], replacement, "should not replace the current task")
+			assertEqual(t, got[0].Usage(), "replacement", "should not reconfigure the current task")
+		})
+	}
 }


### PR DESCRIPTION
## Why

PR #575 moved mutable task fields directly onto `DefinedTask`. That introduced two related regressions:

- `DefinedTask` contained slices and functions, so values were no longer comparable. Programs that compare task values or use them as map keys stopped compiling, breaking the v3.0.1 public API contract.
- `Flow.Define` and `DefinedTask.SetDeps` retained the dependency slice supplied by the caller. Mutating that slice after validation could inject nil, cross-flow, self, or cyclic dependencies into flow-owned state, leading to panics or non-terminating traversal.

Task validation also checked only the flow and task name. After a task was undefined and a replacement reused its name, the old handle could pass validation and rename, remove, select, or attach stale state to the replacement flow.

## What

- Restore a pointer-backed, unexported `taskSnapshot` as the mutable state behind `DefinedTask`.
  - `DefinedTask` values are comparable again.
  - Copies of a valid `DefinedTask` remain handles to the same flow-owned state.
  - `Flow`, its default task, dependency graphs, and the executor operate on internal snapshots rather than caller-owned wrapper values.
- Convert dependency handles to a new flow-owned snapshot slice in both `Flow.Define` and `DefinedTask.SetDeps`.
  - Later mutations of the input slice cannot alter validated graph state.
  - `DefinedTask.Deps`, `Flow.Tasks`, and `Flow.Default` return wrapper handles without exposing internal slices or stored wrapper values.
- Validate exact task identity using the flow plus snapshot pointer, not the task name alone.
  - Stale receivers are rejected by every mutator.
  - `Flow.Undefine`, `Flow.SetDefault`, `Flow.Define`, and `DefinedTask.SetDeps` reject stale same-name handles.
  - Copied handles remain valid because identity belongs to the shared snapshot rather than the address of a wrapper.
- Detect cycles using snapshot identity.
- Add changelog coverage and regressions for comparability, copied handles, dependency-slice mutation, stale receivers, stale dependencies, undefinition, and default-task selection.

## Verification

- `go test -race ./...`
- `golangci-lint run --new-from-rev HEAD`
- `./goyek.sh lint test apidiff`
  - Go tests, race detection, Go lint, spelling, and API compatibility passed.
  - API comparison against v3.0.1 reports no incompatible changes.
  - Docker-based Markdown lint was skipped locally because Docker is unavailable.
- Go 1.16 compatibility tests passed.
- Three independent review rounds were completed. Round 2 identified two tests that could pass for the wrong cycle-detection reason; those tests were strengthened, and all three round-3 reviewers reported no feedback.

## Checklist

- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (not applicable; no documentation workflow changes).
- [x] The code changes follow [Effective Go](https://golang.org/doc/effective_go).
- [x] The code changes follow [CodeReviewComments](https://github.com/golang/go/wiki/CodeReviewComments).
- [x] The code changes are covered by tests.

Fixes #663
Fixes #665
