### PR TITLE
fix: bound buffered middleware output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 - Fix signal handling in `Flow.Main` to support `SIGTERM` on Unix and
   synchronize output during shutdown.
 - Document that `Flow` and `DefinedTask` are not safe for concurrent use.
+- Stream task-attributed output from `middleware.BufferParallel`, truncating
+  individual lines larger than 1 MiB, and spill `middleware.SilentNonFailed`
+  output larger than 1 MiB to temporary files. Extend `SyncWriter` with atomic
+  `io.ReaderFrom` calls so failed-output replay stays serialized.
 
 ## [3.0.1](https://github.com/goyek/goyek/releases/tag/v3.0.1) - 2025-12-09
 

--- a/README.md
+++ b/README.md
@@ -171,8 +171,9 @@ The following repositories demonstrate real-world usage of goyek:
   concurrently shared with another flow or external code. Create one wrapper
   and share it so every participant uses the same lock.
 - **Be deliberate with parallelism**: set `Task.Parallel` only when actions are
-  safe to run concurrently and rely on `middleware.BufferParallel` to keep
-  output readable.
+  safe to run concurrently and use `middleware.BufferParallel` to stream
+  task-attributed output without retaining complete task logs in memory.
+  Individual lines larger than 1 MiB are emitted with a truncation marker.
 - **Treat context and cleanup carefully**: start long-running resources using
   `a.Context()` and release them in `a.Cleanup` callbacks, keeping in mind that
   the task context is canceled before cleanups run.

--- a/flow_main_test.go
+++ b/flow_main_test.go
@@ -114,7 +114,7 @@ func TestFlow_runMain(t *testing.T) {
 
 func TestFlow_runMain_sharesSynchronizedOutput(t *testing.T) {
 	flow := &Flow{}
-	out := io.Discard
+	out := &strings.Builder{}
 	flow.SetOutput(out)
 	flow.Define(Task{Name: "task"})
 
@@ -148,7 +148,7 @@ func TestFlow_runMain_sharesSynchronizedOutput(t *testing.T) {
 
 func TestFlow_runMain_reusesSyncWriter(t *testing.T) {
 	flow := &Flow{}
-	out := SyncWriter(io.Discard)
+	out := SyncWriter(&strings.Builder{})
 	flow.SetOutput(out)
 	flow.Define(Task{Name: "task"})
 

--- a/flow_test.go
+++ b/flow_test.go
@@ -735,7 +735,7 @@ func TestFlow_UseExecutor_nil_middleware(t *testing.T) {
 }
 
 func TestFlow_Execute_synchronizesOutputOnce(t *testing.T) {
-	out := io.Discard
+	out := &strings.Builder{}
 	flow := &goyek.Flow{}
 	flow.SetOutput(out)
 
@@ -780,7 +780,7 @@ func TestFlow_Execute_synchronizesOutputOnce(t *testing.T) {
 }
 
 func TestFlow_Execute_reusesSyncWriter(t *testing.T) {
-	out := goyek.SyncWriter(io.Discard)
+	out := goyek.SyncWriter(&strings.Builder{})
 	flow := &goyek.Flow{}
 	flow.SetOutput(out)
 

--- a/middleware/bufferparallel.go
+++ b/middleware/bufferparallel.go
@@ -2,25 +2,32 @@ package middleware
 
 import (
 	"io"
-	"strings"
 
 	"github.com/goyek/goyek/v3"
 )
 
-// BufferParallel is a middleware which buffers the output from parallel tasks
-// to not have mixed output from parallel tasks execution.
+// BufferParallel is a middleware which streams line-buffered output from
+// parallel tasks and frames each line with its task name so interleaved output
+// can be attributed without retaining the entire task output in memory, like
+// the verbose Go test runner.
+// Lines longer than 1 MiB are truncated with a visible marker. A final
+// incomplete line is terminated with a newline when the task finishes.
 func BufferParallel(next goyek.Runner) goyek.Runner {
 	return func(in goyek.Input) goyek.Result {
 		if !in.Parallel {
 			return next(in)
 		}
+		if in.Output == nil || outputIsDiscard(in.Output) {
+			in.Output = io.Discard
+			return next(in)
+		}
 
 		originalOut := outputOrDiscard(in.Output)
-		streamWriter := &strings.Builder{}
-		in.Output = goyek.SyncWriter(streamWriter)
-
-		result := next(in)
-		io.WriteString(originalOut, streamWriter.String()) //nolint:errcheck // not checking errors when writing to output
-		return result
+		streamWriter := newParallelWriter(originalOut, in.TaskName)
+		defer func() {
+			_ = streamWriter.Close() // best-effort final partial-line flush
+		}()
+		in.Output = streamWriter
+		return next(in)
 	}
 }

--- a/middleware/bufferparallel_test.go
+++ b/middleware/bufferparallel_test.go
@@ -40,11 +40,15 @@ func TestBufferParallel(t *testing.T) {
 	_ = flow.Execute(context.Background(), []string{"task"})
 
 	got := out.String()
-	if !strings.Contains(got, "Hello\nFarewell") {
-		t.Fatalf("should have not mixed input from task-1\nGOT:\n%s", got)
-	}
-	if !strings.Contains(got, "Hi\nBye") {
-		t.Fatalf("should have not mixed input from task-2\nGOT:\n%s", got)
+	for _, want := range []string{
+		"=== NAME  task-1\nHello\n",
+		"=== NAME  task-1\nFarewell\n",
+		"=== NAME  task-2\nHi\n",
+		"=== NAME  task-2\nBye\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("output does not contain %q\nGOT:\n%s", want, got)
+		}
 	}
 }
 
@@ -78,7 +82,13 @@ func TestBufferParallel_concurrent_printing_standalone(t *testing.T) {
 
 func TestBufferParallel_nilOutput(t *testing.T) {
 	runner := middleware.BufferParallel(func(in goyek.Input) goyek.Result {
-		_, _ = io.WriteString(in.Output, "discarded")
+		if in.Output != io.Discard {
+			t.Fatalf("output = %T, want io.Discard", in.Output)
+		}
+		message := strings.Repeat("x", (1<<20)+1)
+		if n, err := io.WriteString(in.Output, message); err != nil || n != len(message) {
+			t.Fatalf("WriteString returned %d, %v; want %d, nil", n, err, len(message))
+		}
 		return goyek.Result{Status: goyek.StatusPassed}
 	})
 
@@ -87,4 +97,161 @@ func TestBufferParallel_nilOutput(t *testing.T) {
 	if result.Status != goyek.StatusPassed {
 		t.Fatalf("got status %v, want %v", result.Status, goyek.StatusPassed)
 	}
+}
+
+func TestBufferParallel_discardOutput(t *testing.T) {
+	runner := middleware.BufferParallel(func(in goyek.Input) goyek.Result {
+		if in.Output != io.Discard {
+			t.Fatalf("output = %T, want io.Discard", in.Output)
+		}
+		message := strings.Repeat("x", (1<<20)+1)
+		if n, err := io.WriteString(in.Output, message); err != nil || n != len(message) {
+			t.Fatalf("WriteString returned %d, %v; want %d, nil", n, err, len(message))
+		}
+		return goyek.Result{Status: goyek.StatusPassed}
+	})
+
+	result := runner(goyek.Input{Parallel: true, Output: goyek.SyncWriter(io.Discard)})
+
+	if result.Status != goyek.StatusPassed {
+		t.Fatalf("got status %v, want %v", result.Status, goyek.StatusPassed)
+	}
+}
+
+func TestBufferParallel_nonParallelPassThrough(t *testing.T) {
+	output := &strings.Builder{}
+	runner := middleware.BufferParallel(func(in goyek.Input) goyek.Result {
+		if in.Output != output {
+			t.Fatal("non-parallel output was replaced")
+		}
+		_, _ = io.WriteString(in.Output, "message")
+		return goyek.Result{Status: goyek.StatusPassed}
+	})
+
+	result := runner(goyek.Input{Output: output})
+
+	if result.Status != goyek.StatusPassed {
+		t.Fatalf("got status %v, want %v", result.Status, goyek.StatusPassed)
+	}
+	if got, want := output.String(), "message"; got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestBufferParallel_uncomparableOutput(t *testing.T) {
+	runner := middleware.BufferParallel(func(in goyek.Input) goyek.Result {
+		_, _ = io.WriteString(in.Output, "message\n")
+		return goyek.Result{Status: goyek.StatusPassed}
+	})
+
+	result := runner(goyek.Input{
+		TaskName: "task",
+		Parallel: true,
+		Output:   uncomparableWriter(make([]byte, 64)),
+	})
+
+	if result.Status != goyek.StatusPassed {
+		t.Fatalf("got status %v, want %v", result.Status, goyek.StatusPassed)
+	}
+}
+
+func TestBufferParallel_streamsBeforeTaskReturns(t *testing.T) {
+	const message = "message\n"
+	written := make(chan struct{})
+	release := make(chan struct{})
+	writeResult := make(chan struct {
+		n   int
+		err error
+	}, 1)
+	runner := middleware.BufferParallel(func(in goyek.Input) goyek.Result {
+		n, err := io.WriteString(in.Output, message)
+		writeResult <- struct {
+			n   int
+			err error
+		}{n: n, err: err}
+		close(written)
+		<-release
+		return goyek.Result{Status: goyek.StatusPassed}
+	})
+
+	out := &strings.Builder{}
+	done := make(chan goyek.Result)
+	go func() {
+		done <- runner(goyek.Input{
+			TaskName: "task",
+			Parallel: true,
+			Output:   goyek.SyncWriter(out),
+		})
+	}()
+	<-written
+	got := out.String()
+	result := <-writeResult
+	close(release)
+	taskResult := <-done
+
+	if result.err != nil {
+		t.Fatalf("writing output: %v", result.err)
+	}
+	if result.n != len(message) {
+		t.Fatalf("wrote %d bytes, want %d", result.n, len(message))
+	}
+	if want := "=== NAME  task\n" + message; got != want {
+		t.Fatalf("output before task return = %q, want %q", got, want)
+	}
+	if taskResult.Status != goyek.StatusPassed {
+		t.Fatalf("got status %v, want %v", taskResult.Status, goyek.StatusPassed)
+	}
+}
+
+func TestBufferParallel_composesWithSilentNonFailed(t *testing.T) {
+	message := strings.Repeat("x", (1<<20)+1) + "\n"
+	action := func(in goyek.Input) goyek.Result {
+		if n, err := io.WriteString(in.Output, message); err != nil || n != len(message) {
+			t.Fatalf("WriteString returned %d, %v; want %d, nil", n, err, len(message))
+		}
+		return goyek.Result{Status: goyek.StatusFailed}
+	}
+	tests := []struct {
+		name string
+		wrap func(goyek.Runner) goyek.Runner
+	}{
+		{
+			name: "buffer outside silent",
+			wrap: func(next goyek.Runner) goyek.Runner {
+				return middleware.BufferParallel(middleware.SilentNonFailed(next))
+			},
+		},
+		{
+			name: "silent outside buffer",
+			wrap: func(next goyek.Runner) goyek.Runner {
+				return middleware.SilentNonFailed(middleware.BufferParallel(next))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output := &strings.Builder{}
+			result := tt.wrap(action)(goyek.Input{
+				TaskName: "task",
+				Parallel: true,
+				Output:   goyek.SyncWriter(output),
+			})
+
+			if result.Status != goyek.StatusFailed {
+				t.Fatalf("got status %v, want %v", result.Status, goyek.StatusFailed)
+			}
+			want := "=== NAME  task\n" + strings.Repeat("x", 1<<20) + "\n\t... [output truncated]\n"
+			if got := output.String(); got != want {
+				t.Fatalf("output length = %d, want %d", len(got), len(want))
+			}
+		})
+	}
+}
+
+type uncomparableWriter []byte
+
+func (w uncomparableWriter) Write(p []byte) (int, error) {
+	copy(w, p)
+	return len(p), nil
 }

--- a/middleware/output.go
+++ b/middleware/output.go
@@ -1,10 +1,19 @@
 package middleware
 
-import "io"
+import (
+	"io"
+	"reflect"
+)
+
+var discardOutputType = reflect.TypeOf(io.Discard)
 
 func outputOrDiscard(out io.Writer) io.Writer {
 	if out == nil {
 		return io.Discard
 	}
 	return out
+}
+
+func outputIsDiscard(out io.Writer) bool {
+	return reflect.TypeOf(out) == discardOutputType
 }

--- a/middleware/parallelwriter.go
+++ b/middleware/parallelwriter.go
@@ -1,0 +1,288 @@
+package middleware
+
+import (
+	"bytes"
+	"io"
+	"strconv"
+	"strings"
+	"sync"
+	"unicode/utf8"
+)
+
+const (
+	parallelOutputFrame     = "=== NAME  "
+	parallelTruncatedMarker = "\n\t... [output truncated]\n"
+)
+
+// parallelWriter line-buffers output so the task frame is never inserted in
+// the middle of a logical line. Every framed record is sent to output with one
+// Write call so any concurrency-safe output keeps the frame and line together.
+type parallelWriter struct {
+	mu         sync.Mutex
+	output     io.Writer
+	record     []byte
+	prefixLen  int
+	discarding bool
+	closed     bool
+	writeErr   error
+}
+
+func newParallelWriter(output io.Writer, taskName string) *parallelWriter {
+	quotedTaskName := strconv.QuoteToGraphic(taskName)
+	taskName = quotedTaskName[1 : len(quotedTaskName)-1]
+	prefix := parallelOutputFrame + taskName + "\n"
+	return &parallelWriter{
+		output:    output,
+		record:    append([]byte(nil), prefix...),
+		prefixLen: len(prefix),
+	}
+}
+
+func (w *parallelWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return 0, io.ErrClosedPipe
+	}
+	if w.writeErr != nil {
+		return 0, w.writeErr
+	}
+	return w.writeBytes(p)
+}
+
+func (w *parallelWriter) WriteString(s string) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return 0, io.ErrClosedPipe
+	}
+	if w.writeErr != nil {
+		return 0, w.writeErr
+	}
+	return w.writeString(s)
+}
+
+// ReadFrom preserves line buffering when this writer is the destination of
+// io.Copy. Hiding r's WriterTo method keeps the copy buffer bounded even for a
+// reader whose WriterTo implementation performs one enormous Write.
+func (w *parallelWriter) ReadFrom(r io.Reader) (int64, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return 0, io.ErrClosedPipe
+	}
+	if w.writeErr != nil {
+		return 0, w.writeErr
+	}
+
+	destination := writerFunc(w.writeBytes)
+	return io.Copy(destination, struct{ io.Reader }{r})
+}
+
+func (w *parallelWriter) writeBytes(p []byte) (int, error) {
+	return w.writeInput(&parallelInput{bytes: p})
+}
+
+func (w *parallelWriter) writeString(s string) (int, error) {
+	return w.writeInput(&parallelInput{text: s, isString: true})
+}
+
+func (w *parallelWriter) writeInput(input *parallelInput) (int, error) {
+	written := 0
+	currentRecordBytes := 0
+	for input.length() > 0 {
+		if w.discarding {
+			newline := input.indexByte('\n')
+			if newline < 0 {
+				return written + input.length(), nil
+			}
+			consumed := newline + 1
+			written += consumed
+			input.consume(consumed)
+			w.discarding = false
+			continue
+		}
+
+		remaining := maxBufferedOutputBytes - w.payloadLen()
+		newline := input.indexByte('\n')
+		if newline >= 0 && newline <= remaining {
+			lineLen := newline + 1
+			w.record = input.appendTo(w.record, lineLen)
+			currentRecordBytes += lineLen
+			n, _, err := w.emit(currentRecordBytes, false)
+			written += n
+			if err != nil {
+				return written, err
+			}
+			currentRecordBytes = 0
+			input.consume(lineLen)
+			continue
+		}
+
+		if remaining > input.length() {
+			remaining = input.length()
+		}
+		w.record = input.appendTo(w.record, remaining)
+		currentRecordBytes += remaining
+		input.consume(remaining)
+		if w.payloadLen() < maxBufferedOutputBytes || input.length() == 0 {
+			return written + currentRecordBytes, nil
+		}
+
+		n, complete, err := w.emit(currentRecordBytes, true)
+		if complete {
+			w.discarding = true
+		}
+		written += n
+		if err != nil {
+			return written, err
+		}
+		currentRecordBytes = 0
+	}
+	return written + currentRecordBytes, nil
+}
+
+type parallelInput struct {
+	bytes    []byte
+	text     string
+	isString bool
+}
+
+func (in *parallelInput) length() int {
+	if in.isString {
+		return len(in.text)
+	}
+	return len(in.bytes)
+}
+
+func (in *parallelInput) indexByte(value byte) int {
+	if in.isString {
+		return strings.IndexByte(in.text, value)
+	}
+	return bytes.IndexByte(in.bytes, value)
+}
+
+func (in *parallelInput) appendTo(destination []byte, n int) []byte {
+	if in.isString {
+		return append(destination, in.text[:n]...)
+	}
+	return append(destination, in.bytes[:n]...)
+}
+
+func (in *parallelInput) consume(n int) {
+	if in.isString {
+		in.text = in.text[n:]
+		return
+	}
+	in.bytes = in.bytes[n:]
+}
+
+func (w *parallelWriter) emit(currentRecordBytes int, truncated bool) (int, bool, error) {
+	payloadLen := w.payloadLen()
+	previousRecordBytes := payloadLen - currentRecordBytes
+	if truncated {
+		payload := trimIncompleteUTF8(w.record[w.prefixLen:])
+		w.record = w.record[:w.prefixLen+len(payload)]
+		payloadLen = len(payload)
+		if previousRecordBytes > payloadLen {
+			previousRecordBytes = payloadLen
+		}
+		w.record = append(w.record, parallelTruncatedMarker...)
+	}
+
+	n, err := w.output.Write(w.record)
+	complete := n == len(w.record)
+	if !complete && err == nil {
+		err = io.ErrShortWrite
+	}
+	if n < 0 {
+		n = 0
+	}
+	if n > len(w.record) {
+		n = len(w.record)
+	}
+
+	currentWritten := n - w.prefixLen - previousRecordBytes
+	if currentWritten < 0 {
+		currentWritten = 0
+	}
+	retainedCurrentBytes := payloadLen - previousRecordBytes
+	if currentWritten > retainedCurrentBytes {
+		currentWritten = retainedCurrentBytes
+	}
+	if complete {
+		currentWritten = currentRecordBytes
+	} else {
+		w.writeErr = err
+	}
+	w.record = w.record[:w.prefixLen]
+	return currentWritten, complete, err
+}
+
+func (w *parallelWriter) payloadLen() int {
+	return len(w.record) - w.prefixLen
+}
+
+func trimIncompleteUTF8(p []byte) []byte {
+	start := len(p) - 1
+	min := len(p) - utf8.UTFMax
+	if min < 0 {
+		min = 0
+	}
+	for start >= min && !utf8.RuneStart(p[start]) {
+		start--
+	}
+	if start >= min && !utf8.FullRune(p[start:]) {
+		return p[:start]
+	}
+	return p
+}
+
+func (w *parallelWriter) Flush() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return io.ErrClosedPipe
+	}
+	if w.writeErr != nil {
+		return w.writeErr
+	}
+	return w.flush()
+}
+
+func (w *parallelWriter) flush() error {
+	if w.discarding || w.payloadLen() == 0 {
+		return nil
+	}
+	w.record = append(w.record, '\n')
+	_, _, err := w.emit(0, false)
+	return err
+}
+
+func (w *parallelWriter) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return nil
+	}
+
+	err := w.writeErr
+	if err == nil {
+		err = w.flush()
+	}
+	w.closed = true
+	return err
+}
+
+type writerFunc func([]byte) (int, error)
+
+func (f writerFunc) Write(p []byte) (int, error) {
+	return f(p)
+}
+
+var (
+	_ io.Writer       = (*parallelWriter)(nil)
+	_ io.StringWriter = (*parallelWriter)(nil)
+	_ io.ReaderFrom   = (*parallelWriter)(nil)
+	_ io.Closer       = (*parallelWriter)(nil)
+)

--- a/middleware/parallelwriter_test.go
+++ b/middleware/parallelwriter_test.go
@@ -1,0 +1,433 @@
+package middleware
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestParallelWriter(t *testing.T) {
+	tests := []struct {
+		name  string
+		write func(io.Writer) (int, error)
+	}{
+		{
+			name: "Write",
+			write: func(w io.Writer) (int, error) {
+				return w.Write([]byte("message\n"))
+			},
+		},
+		{
+			name: "WriteString",
+			write: func(w io.Writer) (int, error) {
+				return io.WriteString(w, "message\n")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var output bytes.Buffer
+			writer := newParallelWriter(&output, "task")
+			t.Cleanup(func() { _ = writer.Close() })
+
+			n, err := tt.write(writer)
+			if err != nil {
+				t.Fatalf("write returned error: %v", err)
+			}
+			if n != len("message\n") {
+				t.Fatalf("write returned %d, want %d", n, len("message\n"))
+			}
+			if got, want := output.String(), "=== NAME  task\nmessage\n"; got != want {
+				t.Fatalf("output = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestParallelWriter_shortWrite(t *testing.T) {
+	writer := newParallelWriter(&shortWriter{remaining: len("=== NAME  task\n") + 2}, "task")
+	t.Cleanup(func() { _ = writer.Close() })
+
+	n, err := writer.Write([]byte("message\n"))
+
+	if n != 2 {
+		t.Fatalf("Write returned %d, want 2", n)
+	}
+	if !errors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("Write returned error %v, want %v", err, io.ErrShortWrite)
+	}
+}
+
+func TestParallelWriter_multilineWrite(t *testing.T) {
+	var output bytes.Buffer
+	writer := newParallelWriter(&output, "task")
+	t.Cleanup(func() { _ = writer.Close() })
+
+	n, err := io.WriteString(writer, "first\nsecond\n")
+	if err != nil {
+		t.Fatalf("WriteString returned error: %v", err)
+	}
+	if n != len("first\nsecond\n") {
+		t.Fatalf("WriteString returned %d, want %d", n, len("first\nsecond\n"))
+	}
+	want := "=== NAME  task\nfirst\n=== NAME  task\nsecond\n"
+	if got := output.String(); got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestParallelWriter_splitLine(t *testing.T) {
+	var output bytes.Buffer
+	writer := newParallelWriter(&output, "task")
+	t.Cleanup(func() { _ = writer.Close() })
+
+	if n, err := writer.Write([]byte("hel")); err != nil || n != 3 {
+		t.Fatalf("first Write returned %d, %v; want 3, nil", n, err)
+	}
+	if output.Len() != 0 {
+		t.Fatalf("partial line was streamed early: %q", output.String())
+	}
+	if n, err := writer.WriteString("lo\n"); err != nil || n != 3 {
+		t.Fatalf("second WriteString returned %d, %v; want 3, nil", n, err)
+	}
+
+	if got, want := output.String(), "=== NAME  task\nhello\n"; got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestParallelWriter_splitUTF8Rune(t *testing.T) {
+	var output bytes.Buffer
+	writer := newParallelWriter(&output, "task")
+	t.Cleanup(func() { _ = writer.Close() })
+	message := []byte("€\n")
+
+	if n, err := writer.Write(message[:1]); err != nil || n != 1 {
+		t.Fatalf("first Write returned %d, %v; want 1, nil", n, err)
+	}
+	if n, err := writer.Write(message[1:]); err != nil || n != len(message)-1 {
+		t.Fatalf("second Write returned %d, %v; want %d, nil", n, err, len(message)-1)
+	}
+
+	if got, want := output.String(), "=== NAME  task\n€\n"; got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestParallelWriter_flushesPartialLine(t *testing.T) {
+	var output bytes.Buffer
+	writer := newParallelWriter(&output, "task")
+
+	if n, err := writer.WriteString("message"); err != nil || n != len("message") {
+		t.Fatalf("WriteString returned %d, %v; want %d, nil", n, err, len("message"))
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	if got, want := output.String(), "=== NAME  task\nmessage\n"; got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestParallelWriter_truncatesLongLine(t *testing.T) {
+	tests := []struct {
+		name  string
+		write func(io.Writer, string) (int, error)
+	}{
+		{
+			name: "Write",
+			write: func(w io.Writer, s string) (int, error) {
+				return w.Write([]byte(s))
+			},
+		},
+		{name: "WriteString", write: io.WriteString},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var output bytes.Buffer
+			writer := newParallelWriter(&output, "task")
+			t.Cleanup(func() { _ = writer.Close() })
+			message := strings.Repeat("x", maxBufferedOutputBytes+1) + "ignored\nnext\n"
+
+			n, err := tt.write(writer, message)
+			if err != nil {
+				t.Fatalf("write returned error: %v", err)
+			}
+			if n != len(message) {
+				t.Fatalf("write returned %d, want %d", n, len(message))
+			}
+
+			want := "=== NAME  task\n" + strings.Repeat("x", maxBufferedOutputBytes) +
+				parallelTruncatedMarker + "=== NAME  task\nnext\n"
+			if got := output.String(); got != want {
+				t.Fatalf("output length = %d, want %d", len(got), len(want))
+			}
+		})
+	}
+}
+
+func TestParallelWriter_ReadFrom(t *testing.T) {
+	var output bytes.Buffer
+	writer := newParallelWriter(&output, "task")
+	t.Cleanup(func() { _ = writer.Close() })
+	message := "first\nsecond\n"
+
+	n, err := writer.ReadFrom(strings.NewReader(message))
+	if err != nil {
+		t.Fatalf("ReadFrom returned error: %v", err)
+	}
+	if n != int64(len(message)) {
+		t.Fatalf("ReadFrom returned %d, want %d", n, len(message))
+	}
+	want := "=== NAME  task\nfirst\n=== NAME  task\nsecond\n"
+	if got := output.String(); got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestParallelWriter_truncationPreservesUTF8(t *testing.T) {
+	var output bytes.Buffer
+	writer := newParallelWriter(&output, "task")
+	t.Cleanup(func() { _ = writer.Close() })
+	message := strings.Repeat("x", maxBufferedOutputBytes-1) + "€more\n"
+
+	if n, err := writer.WriteString(message); err != nil || n != len(message) {
+		t.Fatalf("WriteString returned %d, %v; want %d, nil", n, err, len(message))
+	}
+
+	want := "=== NAME  task\n" + strings.Repeat("x", maxBufferedOutputBytes-1) + parallelTruncatedMarker
+	if got := output.String(); got != want {
+		t.Fatalf("output length = %d, want %d", len(got), len(want))
+	}
+	if !utf8.ValidString(output.String()) {
+		t.Fatal("truncated output is not valid UTF-8")
+	}
+}
+
+func TestParallelWriter_truncationStateSurvivesWriteError(t *testing.T) {
+	tests := []struct {
+		name  string
+		write func(io.Writer, string) (int, error)
+	}{
+		{
+			name: "Write",
+			write: func(w io.Writer, s string) (int, error) {
+				return w.Write([]byte(s))
+			},
+		},
+		{name: "WriteString", write: io.WriteString},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output := &fullWriteErrorWriter{err: errors.New("write failed")}
+			writer := newParallelWriter(output, "task")
+			t.Cleanup(func() { _ = writer.Close() })
+			message := strings.Repeat("x", maxBufferedOutputBytes+1) + "\nnext\n"
+
+			n, err := tt.write(writer, message)
+			if n != maxBufferedOutputBytes {
+				t.Fatalf("first write returned %d, want %d", n, maxBufferedOutputBytes)
+			}
+			if !errors.Is(err, output.err) {
+				t.Fatalf("first write returned error %v, want %v", err, output.err)
+			}
+			if retryN, retryErr := tt.write(writer, message[n:]); retryErr != nil || retryN != len(message)-n {
+				t.Fatalf("retry returned %d, %v; want %d, nil", retryN, retryErr, len(message)-n)
+			}
+
+			want := "=== NAME  task\n" + strings.Repeat("x", maxBufferedOutputBytes) +
+				parallelTruncatedMarker + "=== NAME  task\nnext\n"
+			if got := output.String(); got != want {
+				t.Fatalf("output length = %d, want %d", len(got), len(want))
+			}
+		})
+	}
+}
+
+func TestParallelWriter_partialTruncationWriteErrorIsSticky(t *testing.T) {
+	writes := []struct {
+		name  string
+		write func(io.Writer, string) (int, error)
+	}{
+		{
+			name: "Write",
+			write: func(w io.Writer, s string) (int, error) {
+				return w.Write([]byte(s))
+			},
+		},
+		{name: "WriteString", write: io.WriteString},
+	}
+	partialWrites := []struct {
+		name           string
+		outputBytes    int
+		wantInputBytes int
+	}{
+		{name: "zero", outputBytes: 0, wantInputBytes: 0},
+		{name: "short", outputBytes: len("=== NAME  task\n") + 2, wantInputBytes: 2},
+	}
+
+	for _, write := range writes {
+		for _, partial := range partialWrites {
+			t.Run(write.name+"/"+partial.name, func(t *testing.T) {
+				writeErr := errors.New("write failed")
+				output := &partialWriteErrorWriter{n: partial.outputBytes, err: writeErr}
+				writer := newParallelWriter(output, "task")
+				t.Cleanup(func() { _ = writer.Close() })
+				message := strings.Repeat("x", maxBufferedOutputBytes+1) + "\n"
+
+				n, err := write.write(writer, message)
+				if n != partial.wantInputBytes {
+					t.Fatalf("first write returned %d, want %d", n, partial.wantInputBytes)
+				}
+				if !errors.Is(err, writeErr) {
+					t.Fatalf("first write returned error %v, want %v", err, writeErr)
+				}
+				retryN, retryErr := write.write(writer, message[n:])
+				if retryN != 0 || !errors.Is(retryErr, writeErr) {
+					t.Fatalf("retry returned %d, %v; want 0, %v", retryN, retryErr, writeErr)
+				}
+				if output.calls != 1 {
+					t.Fatalf("underlying Write calls = %d, want 1", output.calls)
+				}
+			})
+		}
+	}
+}
+
+func TestParallelWriter_sanitizesTaskName(t *testing.T) {
+	tests := []struct {
+		name     string
+		taskName string
+		wantName string
+	}{
+		{name: "line breaks", taskName: "line\r\nbreak", wantName: `line\r\nbreak`},
+		{name: "literal escapes", taskName: `line\r\nbreak`, wantName: `line\\r\\nbreak`},
+		{name: "other controls", taskName: "tab\tzero\x00", wantName: `tab\tzero\x00`},
+		{name: "graphic Unicode", taskName: "ą😊", wantName: "ą😊"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var output bytes.Buffer
+			writer := newParallelWriter(&output, tt.taskName)
+			t.Cleanup(func() { _ = writer.Close() })
+
+			if _, err := writer.WriteString("message\n"); err != nil {
+				t.Fatalf("WriteString returned error: %v", err)
+			}
+
+			want := "=== NAME  " + tt.wantName + "\nmessage\n"
+			if got := output.String(); got != want {
+				t.Fatalf("output = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestParallelWriter_recordsUseOneWrite(t *testing.T) {
+	output := &recordingWriter{}
+	first := newParallelWriter(output, "first")
+	second := newParallelWriter(output, "second")
+	start := make(chan struct{})
+	var wait sync.WaitGroup
+	for _, writer := range []*parallelWriter{first, second} {
+		writer := writer
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			<-start
+			_, _ = writer.WriteString("message\n")
+		}()
+	}
+	close(start)
+	wait.Wait()
+
+	if len(output.records) != 2 {
+		t.Fatalf("underlying Write calls = %d, want 2: %q", len(output.records), output.records)
+	}
+	for _, record := range output.records {
+		if record != "=== NAME  first\nmessage\n" && record != "=== NAME  second\nmessage\n" {
+			t.Fatalf("split or malformed record: %q", record)
+		}
+	}
+}
+
+func TestParallelWriter_manyLinesHasBoundedAllocations(t *testing.T) {
+	message := strings.Repeat("x\n", 4096)
+	allocations := testing.AllocsPerRun(5, func() {
+		output := &countWriter{}
+		writer := newParallelWriter(output, "task")
+		if n, err := writer.WriteString(message); err != nil || n != len(message) {
+			t.Fatalf("WriteString returned %d, %v; want %d, nil", n, err, len(message))
+		}
+		if err := writer.Close(); err != nil {
+			t.Fatalf("Close returned error: %v", err)
+		}
+	})
+	if allocations > 20 {
+		t.Fatalf("allocations per run = %.0f, want at most 20", allocations)
+	}
+}
+
+type recordingWriter struct {
+	mu      sync.Mutex
+	records []string
+}
+
+type fullWriteErrorWriter struct {
+	bytes.Buffer
+	err   error
+	calls int
+}
+
+type partialWriteErrorWriter struct {
+	n     int
+	err   error
+	calls int
+}
+
+func (w *partialWriteErrorWriter) Write(p []byte) (int, error) {
+	w.calls++
+	if w.n > len(p) {
+		return len(p), w.err
+	}
+	return w.n, w.err
+}
+
+func (w *fullWriteErrorWriter) Write(p []byte) (int, error) {
+	w.calls++
+	_, _ = w.Buffer.Write(p)
+	if w.calls == 1 {
+		return len(p), w.err
+	}
+	return len(p), nil
+}
+
+func (w *recordingWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.records = append(w.records, string(p))
+	return len(p), nil
+}
+
+type shortWriter struct {
+	remaining int
+}
+
+func (w *shortWriter) Write(p []byte) (int, error) {
+	if w.remaining >= len(p) {
+		w.remaining -= len(p)
+		return len(p), nil
+	}
+	n := w.remaining
+	w.remaining = 0
+	return n, nil
+}

--- a/middleware/parallelwriter_test.go
+++ b/middleware/parallelwriter_test.go
@@ -135,6 +135,47 @@ func TestParallelWriter_flushesPartialLine(t *testing.T) {
 	}
 }
 
+func TestParallelWriter_Flush(t *testing.T) {
+	var output bytes.Buffer
+	writer := newParallelWriter(&output, "task")
+
+	if n, err := writer.WriteString("first"); err != nil || n != len("first") {
+		t.Fatalf("WriteString returned %d, %v; want %d, nil", n, err, len("first"))
+	}
+	if err := writer.Flush(); err != nil {
+		t.Fatalf("Flush returned error: %v", err)
+	}
+	if n, err := writer.WriteString("second\n"); err != nil || n != len("second\n") {
+		t.Fatalf("WriteString returned %d, %v; want %d, nil", n, err, len("second\n"))
+	}
+	if got, want := output.String(), "=== NAME  task\nfirst\n=== NAME  task\nsecond\n"; got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestParallelWriter_afterClose(t *testing.T) {
+	writer := newParallelWriter(io.Discard, "task")
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	if n, err := writer.Write([]byte("message")); n != 0 || !errors.Is(err, io.ErrClosedPipe) {
+		t.Fatalf("Write returned %d, %v; want 0, %v", n, err, io.ErrClosedPipe)
+	}
+	if n, err := writer.WriteString("message"); n != 0 || !errors.Is(err, io.ErrClosedPipe) {
+		t.Fatalf("WriteString returned %d, %v; want 0, %v", n, err, io.ErrClosedPipe)
+	}
+	if n, err := writer.ReadFrom(strings.NewReader("message")); n != 0 || !errors.Is(err, io.ErrClosedPipe) {
+		t.Fatalf("ReadFrom returned %d, %v; want 0, %v", n, err, io.ErrClosedPipe)
+	}
+	if err := writer.Flush(); !errors.Is(err, io.ErrClosedPipe) {
+		t.Fatalf("Flush returned %v, want %v", err, io.ErrClosedPipe)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("second Close returned error: %v", err)
+	}
+}
+
 func TestParallelWriter_truncatesLongLine(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -208,6 +249,68 @@ func TestParallelWriter_truncationPreservesUTF8(t *testing.T) {
 	}
 	if !utf8.ValidString(output.String()) {
 		t.Fatal("truncated output is not valid UTF-8")
+	}
+}
+
+func TestParallelWriter_truncationAcrossWritesPreservesUTF8(t *testing.T) {
+	var output bytes.Buffer
+	writer := newParallelWriter(&output, "task")
+	t.Cleanup(func() { _ = writer.Close() })
+	runeBytes := []byte("€")
+	first := append([]byte(strings.Repeat("x", maxBufferedOutputBytes-2)), runeBytes[:2]...)
+
+	if n, err := writer.Write(first); err != nil || n != len(first) {
+		t.Fatalf("first Write returned %d, %v; want %d, nil", n, err, len(first))
+	}
+	if n, err := writer.Write(append(runeBytes[2:], []byte("discarded")...)); err != nil || n != len("€")-2+len("discarded") {
+		t.Fatalf("second Write returned %d, %v; want %d, nil", n, err, len("€")-2+len("discarded"))
+	}
+
+	want := "=== NAME  task\n" + strings.Repeat("x", maxBufferedOutputBytes-2) + parallelTruncatedMarker
+	if got := output.String(); got != want {
+		t.Fatalf("output length = %d, want %d", len(got), len(want))
+	}
+	if !utf8.ValidString(output.String()) {
+		t.Fatal("truncated output is not valid UTF-8")
+	}
+}
+
+func TestTrimIncompleteUTF8_shortInput(t *testing.T) {
+	input := []byte{0xe2}
+	if got := trimIncompleteUTF8(input); len(got) != 0 {
+		t.Fatalf("trimIncompleteUTF8 returned %x, want empty output", got)
+	}
+}
+
+func TestParallelWriter_invalidOutputCount(t *testing.T) {
+	tests := []struct {
+		name   string
+		output io.Writer
+		wantN  int
+	}{
+		{
+			name: "negative",
+			output: writerFunc(func([]byte) (int, error) {
+				return -1, nil
+			}),
+		},
+		{
+			name: "too large",
+			output: writerFunc(func(p []byte) (int, error) {
+				return len(p) + 1, nil
+			}),
+			wantN: len("message\n"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			writer := newParallelWriter(tt.output, "task")
+			n, err := writer.WriteString("message\n")
+			if n != tt.wantN || !errors.Is(err, io.ErrShortWrite) {
+				t.Fatalf("WriteString returned %d, %v; want %d, %v", n, err, tt.wantN, io.ErrShortWrite)
+			}
+		})
 	}
 }
 
@@ -296,6 +399,12 @@ func TestParallelWriter_partialTruncationWriteErrorIsSticky(t *testing.T) {
 				}
 				if output.calls != 1 {
 					t.Fatalf("underlying Write calls = %d, want 1", output.calls)
+				}
+				if readN, readErr := writer.ReadFrom(strings.NewReader("ignored")); readN != 0 || !errors.Is(readErr, writeErr) {
+					t.Fatalf("ReadFrom after write error returned %d, %v; want 0, %v", readN, readErr, writeErr)
+				}
+				if flushErr := writer.Flush(); !errors.Is(flushErr, writeErr) {
+					t.Fatalf("Flush after write error returned %v, want %v", flushErr, writeErr)
 				}
 			})
 		}

--- a/middleware/spoolbuffer.go
+++ b/middleware/spoolbuffer.go
@@ -38,9 +38,6 @@ func (b *spoolBuffer) Write(p []byte) (int, error) {
 	}
 	n, err := b.file.Write(p)
 	b.size += int64(n)
-	if n < len(p) && err == nil {
-		err = io.ErrShortWrite
-	}
 	return n, err
 }
 
@@ -57,9 +54,6 @@ func (b *spoolBuffer) WriteString(s string) (int, error) {
 	}
 	n, err := io.WriteString(b.file, s)
 	b.size += int64(n)
-	if n < len(s) && err == nil {
-		err = io.ErrShortWrite
-	}
 	return n, err
 }
 
@@ -68,6 +62,10 @@ func (b *spoolBuffer) spill() error {
 	if err != nil {
 		return err
 	}
+	return b.spillTo(file)
+}
+
+func (b *spoolBuffer) spillTo(file *os.File) error {
 	if _, err := io.WriteString(file, b.buffer.String()); err != nil {
 		_ = file.Close()
 		_ = os.Remove(file.Name())

--- a/middleware/spoolbuffer.go
+++ b/middleware/spoolbuffer.go
@@ -1,0 +1,129 @@
+package middleware
+
+import (
+	"io"
+	"os"
+	"strings"
+)
+
+const (
+	maxBufferedOutputBytes = 1 << 20
+	outputSpillPattern     = "goyek-output-*"
+)
+
+// spoolBuffer retains small output in memory and spills larger output to a
+// temporary file. It is not safe for concurrent use; middleware wraps it with
+// goyek.SyncWriter before exposing it to a runner.
+type spoolBuffer struct {
+	buffer strings.Builder
+	file   *os.File
+	limit  int
+	size   int64
+}
+
+func newSpoolBuffer(limit int) *spoolBuffer {
+	return &spoolBuffer{limit: limit}
+}
+
+func (b *spoolBuffer) Write(p []byte) (int, error) {
+	if b.file == nil && len(p) <= b.limit-b.buffer.Len() {
+		n, err := b.buffer.Write(p)
+		b.size += int64(n)
+		return n, err
+	}
+	if b.file == nil {
+		if err := b.spill(); err != nil {
+			return 0, err
+		}
+	}
+	n, err := b.file.Write(p)
+	b.size += int64(n)
+	if n < len(p) && err == nil {
+		err = io.ErrShortWrite
+	}
+	return n, err
+}
+
+func (b *spoolBuffer) WriteString(s string) (int, error) {
+	if b.file == nil && len(s) <= b.limit-b.buffer.Len() {
+		n, err := b.buffer.WriteString(s)
+		b.size += int64(n)
+		return n, err
+	}
+	if b.file == nil {
+		if err := b.spill(); err != nil {
+			return 0, err
+		}
+	}
+	n, err := io.WriteString(b.file, s)
+	b.size += int64(n)
+	if n < len(s) && err == nil {
+		err = io.ErrShortWrite
+	}
+	return n, err
+}
+
+func (b *spoolBuffer) spill() error {
+	file, err := os.CreateTemp("", outputSpillPattern)
+	if err != nil {
+		return err
+	}
+	if _, err := io.WriteString(file, b.buffer.String()); err != nil {
+		_ = file.Close()
+		_ = os.Remove(file.Name())
+		return err
+	}
+	b.buffer.Reset()
+	b.file = file
+	return nil
+}
+
+func (b *spoolBuffer) Len() int64 {
+	return b.size
+}
+
+// reader returns a reader starting at the beginning of the retained output.
+// Its concrete WriterTo method is hidden so a destination ReaderFrom method
+// (notably goyek.SyncWriter's) controls the copy and its synchronization unit.
+func (b *spoolBuffer) reader() (io.Reader, error) {
+	if b.file == nil {
+		return struct{ io.Reader }{strings.NewReader(b.buffer.String())}, nil
+	}
+	if _, err := b.file.Seek(0, io.SeekStart); err != nil {
+		return nil, err
+	}
+	return struct{ io.Reader }{b.file}, nil
+}
+
+func (b *spoolBuffer) WriteTo(output io.Writer) (int64, error) {
+	reader, err := b.reader()
+	if err != nil {
+		return 0, err
+	}
+	return io.Copy(output, reader)
+}
+
+func (b *spoolBuffer) Reset() error {
+	b.buffer.Reset()
+	b.size = 0
+	return b.closeFile()
+}
+
+func (b *spoolBuffer) Close() error {
+	return b.Reset()
+}
+
+func (b *spoolBuffer) closeFile() error {
+	if b.file == nil {
+		return nil
+	}
+
+	name := b.file.Name()
+	closeErr := b.file.Close()
+	removeErr := os.Remove(name)
+	b.file = nil
+	if closeErr != nil {
+		return closeErr
+	}
+	return removeErr
+}

--- a/middleware/spoolbuffer_test.go
+++ b/middleware/spoolbuffer_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -150,5 +151,96 @@ func TestSpoolBuffer_Reset(t *testing.T) {
 	}
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Fatalf("spill file still exists after Reset: %v", err)
+	}
+}
+
+func TestSpoolBuffer_spillCreateError(t *testing.T) {
+	missingTempDir := filepath.Join(t.TempDir(), "missing")
+	setProcessTempDir(t, missingTempDir)
+
+	tests := []struct {
+		name  string
+		write func(*spoolBuffer) (int, error)
+	}{
+		{
+			name: "Write",
+			write: func(buffer *spoolBuffer) (int, error) {
+				return buffer.Write([]byte("d"))
+			},
+		},
+		{
+			name: "WriteString",
+			write: func(buffer *spoolBuffer) (int, error) {
+				return buffer.WriteString("d")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buffer := newSpoolBuffer(3)
+			if n, err := buffer.WriteString("abc"); err != nil || n != 3 {
+				t.Fatalf("prefix write returned %d, %v; want 3, nil", n, err)
+			}
+
+			n, err := tt.write(buffer)
+
+			if n != 0 {
+				t.Fatalf("write returned %d, want 0", n)
+			}
+			if err == nil {
+				t.Fatal("write returned nil error for an unavailable temporary directory")
+			}
+			if buffer.file != nil {
+				t.Fatal("failed spill retained a file")
+			}
+			if got := buffer.buffer.String(); got != "abc" {
+				t.Fatalf("buffered output = %q, want %q", got, "abc")
+			}
+			if got := buffer.Len(); got != 3 {
+				t.Fatalf("length = %d, want 3", got)
+			}
+		})
+	}
+}
+
+func TestSpoolBuffer_WriteToClosedFile(t *testing.T) {
+	buffer := newSpoolBuffer(0)
+	t.Cleanup(func() { _ = buffer.Close() })
+	if n, err := buffer.WriteString("message"); err != nil || n != len("message") {
+		t.Fatalf("WriteString returned %d, %v; want %d, nil", n, err, len("message"))
+	}
+	if err := buffer.file.Close(); err != nil {
+		t.Fatalf("closing spill file: %v", err)
+	}
+
+	n, err := buffer.WriteTo(io.Discard)
+
+	if n != 0 {
+		t.Fatalf("WriteTo returned %d, want 0", n)
+	}
+	if err == nil {
+		t.Fatal("WriteTo returned nil error for a closed spill file")
+	}
+}
+
+func TestSpoolBuffer_CloseClosedFile(t *testing.T) {
+	buffer := newSpoolBuffer(0)
+	t.Cleanup(func() { _ = buffer.Close() })
+	if n, err := buffer.WriteString("message"); err != nil || n != len("message") {
+		t.Fatalf("WriteString returned %d, %v; want %d, nil", n, err, len("message"))
+	}
+	path := buffer.file.Name()
+	if err := buffer.file.Close(); err != nil {
+		t.Fatalf("closing spill file: %v", err)
+	}
+
+	err := buffer.Close()
+
+	if err == nil {
+		t.Fatal("Close returned nil error for an already closed spill file")
+	}
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Fatalf("spill file still exists after Close: %v", statErr)
 	}
 }

--- a/middleware/spoolbuffer_test.go
+++ b/middleware/spoolbuffer_test.go
@@ -204,6 +204,53 @@ func TestSpoolBuffer_spillCreateError(t *testing.T) {
 	}
 }
 
+func TestSpoolBuffer_spillWriteError(t *testing.T) {
+	buffer := newSpoolBuffer(3)
+	t.Cleanup(func() { _ = buffer.Close() })
+	if n, err := buffer.WriteString("abc"); err != nil || n != 3 {
+		t.Fatalf("prefix write returned %d, %v; want 3, nil", n, err)
+	}
+
+	file, err := os.CreateTemp(t.TempDir(), outputSpillPattern)
+	if err != nil {
+		t.Fatalf("create spill file: %v", err)
+	}
+	path := file.Name()
+	t.Cleanup(func() { _ = os.Remove(path) })
+	if closeErr := file.Close(); closeErr != nil {
+		t.Fatalf("close spill file: %v", closeErr)
+	}
+
+	err = buffer.spillTo(file)
+
+	if err == nil {
+		t.Fatal("spillTo returned nil error for a closed spill file")
+	}
+	if buffer.file != nil {
+		t.Fatal("failed spill retained a file")
+	}
+	if got := buffer.buffer.String(); got != "abc" {
+		t.Fatalf("buffered output = %q, want %q", got, "abc")
+	}
+	if got := buffer.Len(); got != 3 {
+		t.Fatalf("length = %d, want 3", got)
+	}
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Fatalf("spill file still exists after failed write: %v", statErr)
+	}
+
+	if n, err := buffer.WriteString("d"); err != nil || n != 1 {
+		t.Fatalf("retry returned %d, %v; want 1, nil", n, err)
+	}
+	var output bytes.Buffer
+	if n, err := buffer.WriteTo(&output); err != nil || n != 4 {
+		t.Fatalf("WriteTo after retry returned %d, %v; want 4, nil", n, err)
+	}
+	if got, want := output.String(), "abcd"; got != want {
+		t.Fatalf("output after retry = %q, want %q", got, want)
+	}
+}
+
 func TestSpoolBuffer_WriteToClosedFile(t *testing.T) {
 	buffer := newSpoolBuffer(0)
 	t.Cleanup(func() { _ = buffer.Close() })

--- a/middleware/spoolbuffer_test.go
+++ b/middleware/spoolbuffer_test.go
@@ -1,0 +1,154 @@
+package middleware
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestSpoolBuffer_inMemory(t *testing.T) {
+	buffer := newSpoolBuffer(5)
+	t.Cleanup(func() { _ = buffer.Close() })
+
+	if n, err := buffer.Write([]byte("ab")); err != nil || n != 2 {
+		t.Fatalf("Write returned %d, %v; want 2, nil", n, err)
+	}
+	if n, err := buffer.WriteString("cde"); err != nil || n != 3 {
+		t.Fatalf("WriteString returned %d, %v; want 3, nil", n, err)
+	}
+	if buffer.file != nil {
+		t.Fatal("output at the memory limit spilled to a file")
+	}
+
+	var output bytes.Buffer
+	if n, err := buffer.WriteTo(&output); err != nil || n != 5 {
+		t.Fatalf("WriteTo returned %d, %v; want 5, nil", n, err)
+	}
+	if got, want := output.String(), "abcde"; got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestSpoolBuffer_spillsAndRemovesFile(t *testing.T) {
+	tests := []struct {
+		name  string
+		write func(io.Writer, string) (int, error)
+	}{
+		{
+			name: "Write",
+			write: func(w io.Writer, s string) (int, error) {
+				return w.Write([]byte(s))
+			},
+		},
+		{
+			name:  "WriteString",
+			write: io.WriteString,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const (
+				limit  = 8
+				prefix = "prefix"
+			)
+			input := strings.Repeat("x", 1<<20)
+			buffer := newSpoolBuffer(limit)
+			t.Cleanup(func() { _ = buffer.Close() })
+			if n, err := buffer.WriteString(prefix); err != nil || n != len(prefix) {
+				t.Fatalf("prefix write returned %d, %v; want %d, nil", n, err, len(prefix))
+			}
+
+			n, err := tt.write(buffer, input)
+			if err != nil {
+				t.Fatalf("write returned error: %v", err)
+			}
+			if n != len(input) {
+				t.Fatalf("write returned %d, want %d", n, len(input))
+			}
+			if buffer.file == nil {
+				t.Fatal("large output did not spill to a file")
+			}
+			path := buffer.file.Name()
+			info, err := buffer.file.Stat()
+			if err != nil {
+				t.Fatalf("stat spill file: %v", err)
+			}
+			if runtime.GOOS != "windows" && info.Mode().Perm()&0o077 != 0 {
+				t.Fatalf("spill file permissions = %v; group or other access is set", info.Mode().Perm())
+			}
+
+			var output bytes.Buffer
+			want := prefix + input
+			if written, err := buffer.WriteTo(&output); err != nil || written != int64(len(want)) {
+				t.Fatalf("WriteTo returned %d, %v; want %d, nil", written, err, len(want))
+			}
+			if got := output.String(); got != want {
+				t.Fatalf("replayed output length = %d, want %d", len(got), len(want))
+			}
+
+			if err := buffer.Close(); err != nil {
+				t.Fatalf("Close returned error: %v", err)
+			}
+			if _, err := os.Stat(path); !os.IsNotExist(err) {
+				t.Fatalf("spill file still exists after Close: %v", err)
+			}
+		})
+	}
+}
+
+func TestSpoolBuffer_WriteToShortWriter(t *testing.T) {
+	tests := []struct {
+		name  string
+		limit int
+	}{
+		{name: "in memory", limit: 16},
+		{name: "spilled", limit: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buffer := newSpoolBuffer(tt.limit)
+			t.Cleanup(func() { _ = buffer.Close() })
+			if n, err := buffer.WriteString("message"); err != nil || n != len("message") {
+				t.Fatalf("WriteString returned %d, %v; want %d, nil", n, err, len("message"))
+			}
+
+			n, err := buffer.WriteTo(&shortWriter{remaining: 2})
+
+			if n != 2 {
+				t.Fatalf("WriteTo returned %d, want 2", n)
+			}
+			if !errors.Is(err, io.ErrShortWrite) {
+				t.Fatalf("WriteTo returned error %v, want %v", err, io.ErrShortWrite)
+			}
+		})
+	}
+}
+
+func TestSpoolBuffer_Reset(t *testing.T) {
+	buffer := newSpoolBuffer(2)
+	t.Cleanup(func() { _ = buffer.Close() })
+	if _, err := buffer.WriteString("message"); err != nil {
+		t.Fatalf("WriteString returned error: %v", err)
+	}
+	if buffer.file == nil {
+		t.Fatal("output did not spill to disk")
+	}
+	path := buffer.file.Name()
+
+	if err := buffer.Reset(); err != nil {
+		t.Fatalf("Reset returned error: %v", err)
+	}
+
+	if buffer.Len() != 0 {
+		t.Fatalf("length after Reset = %d, want 0", buffer.Len())
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("spill file still exists after Reset: %v", err)
+	}
+}

--- a/middleware/verbose.go
+++ b/middleware/verbose.go
@@ -2,24 +2,35 @@ package middleware
 
 import (
 	"io"
-	"strings"
 
 	"github.com/goyek/goyek/v3"
 )
 
 // SilentNonFailed is a middleware which makes sure that only output from failed tasks is printed.
 //
-// The behavior is based on the Go test runner when it is executed without the -v flag.
+// Like the Go test runner without -v, it defers output until the result is known.
+// It retains up to 1 MiB of output per task in memory, then spills additional
+// output to a temporary file. It makes a best-effort attempt to remove the file
+// when the task finishes. Writes may return temporary-file I/O errors after the
+// in-memory limit is reached.
 func SilentNonFailed(next goyek.Runner) goyek.Runner {
 	return func(in goyek.Input) goyek.Result {
+		if in.Output == nil || outputIsDiscard(in.Output) {
+			in.Output = io.Discard
+			return next(in)
+		}
+
 		originalOut := outputOrDiscard(in.Output)
-		streamWriter := &strings.Builder{}
+		streamWriter := newSpoolBuffer(maxBufferedOutputBytes)
+		defer func() {
+			_ = streamWriter.Close() // best-effort temporary file cleanup
+		}()
 		in.Output = goyek.SyncWriter(streamWriter)
 
 		result := next(in)
 
 		if result.Status == goyek.StatusFailed {
-			io.WriteString(originalOut, streamWriter.String()) //nolint:errcheck // not checking errors when writing to output
+			streamWriter.WriteTo(originalOut) //nolint:errcheck // not checking errors when writing to output
 		}
 
 		return result

--- a/middleware/verbose_internal_test.go
+++ b/middleware/verbose_internal_test.go
@@ -1,0 +1,102 @@
+package middleware
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/goyek/goyek/v3"
+)
+
+func TestSilentNonFailed_removesSpillFile(t *testing.T) {
+	tempDir := t.TempDir()
+	setProcessTempDir(t, tempDir)
+	message := strings.Repeat("x", maxBufferedOutputBytes+1)
+
+	tests := []struct {
+		name      string
+		status    goyek.Status
+		panic     bool
+		wantBytes int64
+	}{
+		{name: "passed", status: goyek.StatusPassed},
+		{name: "failed", status: goyek.StatusFailed, wantBytes: int64(len(message))},
+		{name: "panic", panic: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output := &countWriter{}
+			runner := SilentNonFailed(func(in goyek.Input) goyek.Result {
+				if _, err := io.WriteString(in.Output, message); err != nil {
+					t.Fatalf("writing output: %v", err)
+				}
+				if tt.panic {
+					panic("boom")
+				}
+				return goyek.Result{Status: tt.status}
+			})
+
+			var recovered interface{}
+			func() {
+				defer func() { recovered = recover() }()
+				runner(goyek.Input{Output: goyek.SyncWriter(output)})
+			}()
+
+			if tt.panic && recovered == nil {
+				t.Fatal("runner did not propagate panic")
+			}
+			if !tt.panic && recovered != nil {
+				t.Fatalf("runner unexpectedly panicked: %v", recovered)
+			}
+			if output.n != tt.wantBytes {
+				t.Fatalf("replayed %d bytes, want %d", output.n, tt.wantBytes)
+			}
+			matches, err := filepath.Glob(filepath.Join(tempDir, outputSpillPattern))
+			if err != nil {
+				t.Fatalf("glob spill files: %v", err)
+			}
+			if len(matches) != 0 {
+				t.Fatalf("spill files remain after runner exit: %v", matches)
+			}
+		})
+	}
+}
+
+type countWriter struct {
+	n int64
+}
+
+func (w *countWriter) Write(p []byte) (int, error) {
+	w.n += int64(len(p))
+	return len(p), nil
+}
+
+func setProcessTempDir(t *testing.T, dir string) {
+	t.Helper()
+	if runtime.GOOS == "plan9" {
+		t.Skip("Plan 9 does not select the temporary directory from the environment")
+	}
+
+	names := []string{"TMPDIR"}
+	if runtime.GOOS == "windows" {
+		names = []string{"TMP", "TEMP"}
+	}
+	for _, name := range names {
+		name := name
+		old, existed := os.LookupEnv(name)
+		if err := os.Setenv(name, dir); err != nil {
+			t.Fatalf("set %s: %v", name, err)
+		}
+		t.Cleanup(func() {
+			if existed {
+				_ = os.Setenv(name, old)
+			} else {
+				_ = os.Unsetenv(name)
+			}
+		})
+	}
+}

--- a/middleware/verbose_test.go
+++ b/middleware/verbose_test.go
@@ -91,11 +91,79 @@ func TestSilentNonFailed_concurrent_printing(t *testing.T) {
 
 func TestSilentNonFailed_nilOutput(t *testing.T) {
 	runner := middleware.SilentNonFailed(func(in goyek.Input) goyek.Result {
-		_, _ = io.WriteString(in.Output, "discarded")
+		message := strings.Repeat("x", (1<<20)+1)
+		n, err := io.WriteString(in.Output, message)
+		if err != nil {
+			t.Fatalf("writing output: %v", err)
+		}
+		if n != len(message) {
+			t.Fatalf("wrote %d bytes, want %d", n, len(message))
+		}
 		return goyek.Result{Status: goyek.StatusFailed}
 	})
 
 	result := runner(goyek.Input{})
+
+	if result.Status != goyek.StatusFailed {
+		t.Fatalf("got status %v, want %v", result.Status, goyek.StatusFailed)
+	}
+}
+
+func TestSilentNonFailed_discardOutput(t *testing.T) {
+	runner := middleware.SilentNonFailed(func(in goyek.Input) goyek.Result {
+		if in.Output != io.Discard {
+			t.Fatalf("output = %T, want io.Discard", in.Output)
+		}
+		message := strings.Repeat("x", (1<<20)+1)
+		n, err := io.WriteString(in.Output, message)
+		if err != nil {
+			t.Fatalf("writing output: %v", err)
+		}
+		if n != len(message) {
+			t.Fatalf("wrote %d bytes, want %d", n, len(message))
+		}
+		return goyek.Result{Status: goyek.StatusFailed}
+	})
+
+	result := runner(goyek.Input{Output: goyek.SyncWriter(io.Discard)})
+
+	if result.Status != goyek.StatusFailed {
+		t.Fatalf("got status %v, want %v", result.Status, goyek.StatusFailed)
+	}
+}
+
+func TestSilentNonFailed_preservesLargeFailedOutput(t *testing.T) {
+	const outputLimit = 1 << 20
+	message := strings.Repeat("x", outputLimit+1)
+	runner := middleware.SilentNonFailed(func(in goyek.Input) goyek.Result {
+		n, err := io.WriteString(in.Output, message)
+		if err != nil {
+			t.Fatalf("writing output: %v", err)
+		}
+		if n != len(message) {
+			t.Fatalf("wrote %d bytes, want %d", n, len(message))
+		}
+		return goyek.Result{Status: goyek.StatusFailed}
+	})
+
+	out := &strings.Builder{}
+	result := runner(goyek.Input{Output: goyek.SyncWriter(out)})
+
+	if result.Status != goyek.StatusFailed {
+		t.Fatalf("got status %v, want %v", result.Status, goyek.StatusFailed)
+	}
+	if got := out.String(); got != message {
+		t.Fatalf("output length = %d, want %d", len(got), len(message))
+	}
+}
+
+func TestSilentNonFailed_uncomparableOutput(t *testing.T) {
+	runner := middleware.SilentNonFailed(func(in goyek.Input) goyek.Result {
+		_, _ = io.WriteString(in.Output, "message")
+		return goyek.Result{Status: goyek.StatusFailed}
+	})
+
+	result := runner(goyek.Input{Output: uncomparableWriter(make([]byte, 64))})
 
 	if result.Status != goyek.StatusFailed {
 		t.Fatalf("got status %v, want %v", result.Status, goyek.StatusFailed)

--- a/syncwriter.go
+++ b/syncwriter.go
@@ -2,8 +2,11 @@ package goyek
 
 import (
 	"io"
+	"reflect"
 	"sync"
 )
+
+var discardWriterType = reflect.TypeOf(io.Discard)
 
 type syncWriter struct {
 	writer io.Writer
@@ -22,14 +25,25 @@ func (w *syncWriter) WriteString(s string) (int, error) {
 	return io.WriteString(w.writer, s)
 }
 
-var _ io.StringWriter = (*syncWriter)(nil)
+func (w *syncWriter) ReadFrom(r io.Reader) (int64, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return io.Copy(w.writer, r)
+}
+
+var (
+	_ io.StringWriter = (*syncWriter)(nil)
+	_ io.ReaderFrom   = (*syncWriter)(nil)
+)
 
 // SyncWriter returns a writer safe for concurrent use by serializing calls to
-// Write and WriteString. Each call is a synchronization unit; a logical record
-// split across multiple calls may be interleaved with other writes. The returned
-// writer implements [io.StringWriter], but does not preserve other optional
-// interfaces implemented by w.
+// Write, WriteString, and ReadFrom. Each call is a synchronization unit; a
+// logical record split across multiple calls may be interleaved with other
+// writes. The returned writer implements [io.StringWriter] and [io.ReaderFrom],
+// but does not preserve other optional interfaces implemented by w.
 // It returns nil if w is nil.
+// It returns [io.Discard] unchanged because that writer is already safe for
+// concurrent use and implements both optional interfaces.
 //
 // Calling SyncWriter with a writer previously returned by SyncWriter returns
 // that writer unchanged. Call SyncWriter once and share its result: separately
@@ -49,6 +63,9 @@ var _ io.StringWriter = (*syncWriter)(nil)
 func SyncWriter(w io.Writer) io.Writer {
 	if w == nil {
 		return nil
+	}
+	if reflect.TypeOf(w) == discardWriterType {
+		return w
 	}
 	if sw, ok := w.(*syncWriter); ok {
 		return sw

--- a/syncwriter_test.go
+++ b/syncwriter_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/goyek/goyek/v3"
 )
@@ -65,6 +66,91 @@ func TestSyncWriter_WriteStringFallback(t *testing.T) {
 	}
 }
 
+func TestSyncWriter_ReadFrom(t *testing.T) {
+	buf := &strings.Builder{}
+	w := goyek.SyncWriter(buf)
+	readerFrom, ok := w.(io.ReaderFrom)
+	if !ok {
+		t.Fatal("SyncWriter result does not implement io.ReaderFrom")
+	}
+
+	n, err := readerFrom.ReadFrom(strings.NewReader("hello"))
+	if err != nil {
+		t.Fatalf("ReadFrom error: %v", err)
+	}
+	if n != int64(len("hello")) {
+		t.Fatalf("ReadFrom returned %d, want %d", n, len("hello"))
+	}
+	if got := buf.String(); got != "hello" {
+		t.Fatalf("output = %q, want %q", got, "hello")
+	}
+}
+
+func TestSyncWriter_ReadFromIsAtomic(t *testing.T) {
+	buf := &strings.Builder{}
+	w := goyek.SyncWriter(buf)
+	readerFrom := w.(io.ReaderFrom)
+	reader := &blockingReader{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+
+	readDone := make(chan error, 1)
+	go func() {
+		_, err := readerFrom.ReadFrom(reader)
+		readDone <- err
+	}()
+	<-reader.started
+
+	writeStarted := make(chan struct{})
+	writeDone := make(chan error, 1)
+	go func() {
+		close(writeStarted)
+		_, err := io.WriteString(w, "other")
+		writeDone <- err
+	}()
+	<-writeStarted
+	select {
+	case err := <-writeDone:
+		close(reader.release)
+		<-readDone
+		t.Fatalf("concurrent WriteString completed during ReadFrom: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(reader.release)
+	if err := <-readDone; err != nil {
+		t.Fatalf("ReadFrom returned error: %v", err)
+	}
+	if err := <-writeDone; err != nil {
+		t.Fatalf("WriteString returned error: %v", err)
+	}
+	if got, want := buf.String(), "firstsecondother"; got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+type blockingReader struct {
+	started chan struct{}
+	release chan struct{}
+	reads   int
+}
+
+func (r *blockingReader) Read(p []byte) (int, error) {
+	switch r.reads {
+	case 0:
+		r.reads++
+		close(r.started)
+		return copy(p, "first"), nil
+	case 1:
+		r.reads++
+		<-r.release
+		return copy(p, "second"), nil
+	default:
+		return 0, io.EOF
+	}
+}
+
 type writeOnly struct {
 	io.Writer
 }
@@ -112,6 +198,28 @@ func TestSyncWriter_nil(t *testing.T) {
 	if got := goyek.SyncWriter(nil); got != nil {
 		t.Fatalf("SyncWriter(nil) = %T, want nil", got)
 	}
+}
+
+func TestSyncWriter_discard(t *testing.T) {
+	if got := goyek.SyncWriter(io.Discard); got != io.Discard {
+		t.Fatalf("SyncWriter(io.Discard) = %T, want io.Discard", got)
+	}
+}
+
+func TestSyncWriter_uncomparableWriter(t *testing.T) {
+	output := uncomparableWriter(make([]byte, len("message")))
+	w := goyek.SyncWriter(output)
+
+	if n, err := w.Write([]byte("message")); err != nil || n != len("message") {
+		t.Fatalf("Write returned %d, %v; want %d, nil", n, err, len("message"))
+	}
+}
+
+type uncomparableWriter []byte
+
+func (w uncomparableWriter) Write(p []byte) (int, error) {
+	copy(w, p)
+	return len(p), nil
 }
 
 func ExampleSyncWriter() {


### PR DESCRIPTION
## Why

`BufferParallel` and `SilentNonFailed` retain complete task output in a
`strings.Builder`. A noisy task can therefore exhaust the process heap before
the middleware gets a chance to flush or discard that output.

This follows the approach introduced for verbose `go test` output in
[Go 1.14](https://go.dev/doc/go1.14#testing): stream line-buffered records as
they become available and keep each record attributable to its task. Output
that must remain silent until the result is known uses a bounded-memory spool
instead.

Fixes #669.

## What

- Change `BufferParallel` to stream complete lines immediately with
  testing-style `=== NAME` task frames.
  - Each frame and line is one downstream `Write`, preserving record atomicity.
  - The reusable line buffer is capped at 1 MiB; longer lines get the familiar
    `... [output truncated]` marker.
  - Split writes, UTF-8 boundaries, final partial lines, quoted task names, and
    downstream write errors are handled explicitly.
- Change `SilentNonFailed` to retain 1 MiB in memory and then spill to a secure
  temporary file.
  - Failed output is replayed in full.
  - Passed and skipped output is discarded.
  - Spill files are removed on pass, failure, and panic paths on a best-effort
    basis.
- Add atomic `io.ReaderFrom` support to `SyncWriter` so a spooled replay remains
  one synchronization unit, and preserve the already-concurrency-safe
  `io.Discard` writer.
- Bypass buffering and spooling when output is discarded.
- Document the new bounds and observable truncation behavior.

Unlike verbose streaming, suppression inherently requires deferred storage.
The Go test runner's non-verbose path still buffers output in memory, so the
temporary-file spill is Goyek-specific and preserves the existing full failed
output behavior.

### Review and validation

The change went through nine iterative review passes covering Go API
compatibility, writer contracts, allocation bounds, concurrency, middleware
composition, portability, cleanup, documentation, and error retries. All final
reviewers reported no remaining findings.

- `./goyek.sh all -v` (markdownlint skipped because Docker is unavailable)
- `go test -race ./... -count=10`
- CI-style coverage run: 98.3% overall; `parallelwriter.go` and `spoolbuffer.go` at 100%
- `GOTOOLCHAIN=go1.16.15 go test ./...`
- `GOARCH=386 go test ./...`
- Windows cross-compilation via `GOOS=windows GOARCH=amd64 go test -exec=/bin/true ./...`
- `go vet ./...`
- `golangci-lint run --new-from-rev=origin/main`
- `./goyek.sh diff -v`

## Checklist

- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated.
- [x] The code changes follow [Effective Go](https://golang.org/doc/effective_go).
- [x] The code changes follow [CodeReviewComments](https://github.com/golang/go/wiki/CodeReviewComments).
- [x] The code changes are covered by tests.

<!-- markdownlint-disable-file MD041 -->