### PR TITLE
fix: report A.Chdir failures at the caller's code line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 
 ### Fixed
 
+- `A.Chdir` now reports failures with the caller's file and line,
+  like `A.Setenv` and `A.TempDir`.
 - Reject stale task handles after an undefined task name is reused.
 - `A.Cleanup` now panics if a `nil` function is provided.
   This prevents accidental misconfigurations where a `nil` cleanup

--- a/a.go
+++ b/a.go
@@ -306,6 +306,7 @@ func (a *A) TempDir() string {
 // Because Chdir affects the whole process, it should not be used
 // in parallel tasks.
 func (a *A) Chdir(dir string) {
+	a.Helper()
 	if a.parallel {
 		a.Fatalf("Chdir called in a parallel task")
 	}

--- a/a_test.go
+++ b/a_test.go
@@ -665,9 +665,11 @@ func TestA_Setenv_error(t *testing.T) {
 }
 
 func TestA_Chdir_error(t *testing.T) {
+	out := &strings.Builder{}
 	got := goyek.NewRunner(func(a *goyek.A) {
 		a.Chdir("non-existent-directory-@!#$")
-	})(goyek.Input{})
+	})(goyek.Input{Output: goyek.SyncWriter(out), Logger: &goyek.CodeLineLogger{}})
 
 	assertEqual(t, got.Status, goyek.StatusFailed, "should return proper status")
+	assertContains(t, out, "a_test.go:", "should report the caller's code line")
 }


### PR DESCRIPTION
## Why

Give `a.Chdir` a path that isnt there and the failure gets blamed on goyek itself:

```
a.go:305: chdir /nope: no such file or directory
```

That's v3.0.1, and it's `a.go:327` on main. `A.Setenv` and `A.TempDir` sit right above it in the same file and both open with `a.Helper()`, so a bad argument to either gets reported against the build file that passed it. `Chdir` doesnt, so a path typo in your own build file points at the library.

## What

`a.Helper()` as the first statement of `Chdir`. It covers the four `Fatal`/`Fatalf` sites in there plus the nested `a.Setenv("PWD", ...)` at the end, which reports the `Chdir` caller now rather than a line inside `a.go`.

`TestA_Chdir_error` was only checking the status, so it asserts the reported file as well. Filename and not the line number, thats going to move.

## Checklist

- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated.
- [x] The code changes follow [Effective Go](https://golang.org/doc/effective_go).
- [x] The code changes follow [CodeReviewComments](https://github.com/golang/go/wiki/CodeReviewComments).
- [x] The code changes are covered by tests.
